### PR TITLE
Adds extension module to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,5 +38,7 @@ setup(name='ptvsd',
         'License :: OSI Approved :: MIT License'],
       packages=['ptvsd'],
       package_data={'ptvsd': list(get_pydevd_package_data())},
-      ext_modules=[Extension('ptvsd.pydevd._pydevd_bundle.pydevd_cython', ['ptvsd/pydevd/_pydevd_bundle/pydevd_cython.c'])],
+      ext_modules=[Extension('ptvsd.pydevd._pydevd_bundle.pydevd_cython',
+                             ['ptvsd/pydevd/_pydevd_bundle/pydevd_cython.c'],
+                             optional=True)],
       )


### PR DESCRIPTION
This is the simplest way to build the pydevd extension when creating wheels.

However, I think we'd probably be better off using a more custom script for generating a single wheel with ABI tagged extension modules in it, as this will better suit us being able to embed a copy of the package in our tools with prebuilt extensions. We also need to code sign it, which is currently easier to do by building separately rather than integrating into the distutils flow (though this is possible).

But at least with this change anyone who installs ptvsd manually can have the extension module.