### PR TITLE
Fix file path case on windows

### DIFF
--- a/ptvsd/pathutils.py
+++ b/ptvsd/pathutils.py
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
+from __future__ import print_function, with_statement, absolute_import
+
+import sys
+import os.path
+import platform
+from glob import glob
+
+
+__author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
+__version__ = "4.0.0a1"
+
+MAX_FILES_TO_CACHE = 1000
+
+class PathUnNormcase(object):
+    """Ensures path names of files are returned as they exist on the fs."""
+
+    def __init__(self):
+        self._dict = {}
+        self._enabled = False
+
+    def enable(self):
+        self._enabled = platform.system() == 'Windows'
+
+    def un_normcase(self, file_path):
+        if not self._enabled or len(file_path) == 0:
+            return file_path
+        if file_path in self._dict:
+            return self._dict[file_path]
+        file_path_to_return = self._get_actual_filename(file_path)
+        self.track_file_path_case(file_path_to_return)
+        return file_path_to_return
+
+    def track_file_path_case(self, file_path):
+        if not self._enabled:
+            return
+        if len(self._dict) > MAX_FILES_TO_CACHE:
+            self._dict.clear()
+        self._dict[file_path] = file_path
+
+    def _get_actual_filename(self, name):
+        """
+        Use glob to search for a file by building a regex.
+        Original source from https://stackoverflow.com/a/30374360/4443457
+        (Modified to match file name as well).
+        """
+
+        sep = os.path.sep
+        parts = os.path.normpath(name).split(sep)
+        dirs = parts[0:-1]
+        filename = "%s[%s]"%(parts[-1][:-1],parts[-1][-1:])
+        if dirs[0] == os.path.splitdrive(name)[0]:
+            test_name = [dirs[0].upper()]
+        else:
+            test_name = [sep + dirs[0]]
+        for d in dirs[1:]:
+            test_name += ["%s[%s]"%(d[: - 1], d[-1])]
+        path = glob(sep.join(test_name))[0]
+        res = glob(sep.join((path, filename)))
+        if not res:
+            return name
+        return res[0]

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -562,11 +562,11 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         if self.launch_arguments is None:
             return
 
-        if self.launch_arguments.get('redirectOutput', False):
-            redirect_stdout = 'STDOUT\tSTDERR'
-        else:
-            redirect_stdout = ''
-        self.pydevd_request(pydevd_comm.CMD_REDIRECT_OUTPUT, redirect_stdout)
+        if self.launch_arguments.get('fixFilePathCase', False):
+            self.path_casing.enable()
+            
+        redirect_output = 'STDOUT\tSTDERR' if self.launch_arguments.get('redirectOutput', False) == True else ''
+        self.pydevd_request(pydevd_comm.CMD_REDIRECT_OUTPUT, redirect_output)
 
     def on_disconnect(self, request, args):
         # TODO: docstring

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -848,6 +848,7 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
             line = src_bp['line']
             vsc_bpid = self.bp_map.add(
                     lambda vsc_bpid: (path, vsc_bpid))
+            self.path_casing.track_file_path_case(path)
             msg = msgfmt.format(vsc_bpid, path, line,
                                 src_bp.get('condition', None))
             self.pydevd_notify(cmd, msg)

--- a/tests/ptvsd/test_pathutils.py
+++ b/tests/ptvsd/test_pathutils.py
@@ -1,0 +1,54 @@
+import os.path
+import sys
+import unittest
+import platform
+
+from ptvsd.pathutils import PathUnNormcase
+
+class PathUtilTests(unittest.TestCase):
+    def test_invalid_path_names(self):
+        tool = PathUnNormcase()
+        file_path = 'x:/this is an/invalid/file/invalid_file_.csv'
+        self.assertEqual(file_path, tool.un_normcase(file_path))
+
+    def test_empty_path_names(self):
+        tool = PathUnNormcase()
+        file_path = ''
+        self.assertEqual(file_path, tool.un_normcase(file_path))
+
+    def test_valid_names(self):
+        tool = PathUnNormcase()
+        file_path = __file__
+        self.assertEqual(file_path, tool.un_normcase(file_path))
+
+    def test_path_names_normcased(self):
+        tool = PathUnNormcase()
+        tool.enable()
+        file_path = __file__
+        self.assertEqual(file_path, tool.un_normcase(os.path.normcase(file_path)))
+
+    @unittest.skipIf(platform.system() != 'Windows', "Windows OS specific test")
+    def test_path_names_uppercase_disabled(self):
+        tool = PathUnNormcase()
+        file_path = __file__
+        self.assertNotEqual(file_path, tool.un_normcase(file_path.upper()))
+
+    @unittest.skipIf(platform.system() != 'Windows', "Windows OS specific test")
+    def test_path_names_uppercase_enabled(self):
+        tool = PathUnNormcase()
+        tool.enable()
+        file_path = __file__
+        self.assertEqual(file_path, tool.un_normcase(file_path.upper()))
+
+    @unittest.skipIf(platform.system() != 'Windows', "Windows OS specific test")
+    def test_path_names_lowercase_disabled(self):
+        tool = PathUnNormcase()
+        file_path = __file__
+        self.assertNotEqual(file_path, tool.un_normcase(file_path.lower()))
+
+    @unittest.skipIf(platform.system() != 'Windows', "Windows OS specific test")
+    def test_path_names_lowercase_enabled(self):
+        tool = PathUnNormcase()
+        tool.enable()
+        file_path = __file__
+        self.assertEqual(file_path, tool.un_normcase(file_path.lower()))


### PR DESCRIPTION
Fixes #88 
@int19h 
I had to revert the change where we were setting the `os_id` to `UNIX` even on `Widows OS`.
This was because breakpoints didn't work at all on Windows for Visual Studio (#163).
However breakpoints continued to work for VS Code.

**We have two solutions:**

1. Ensure `os_id` is always set to `UNIX` for VS Code (on all OS).
However in light of the recent issue in VS (#163), I'm tempted not to go down this path. 
Its better to have duplicate editors than not having breakpoints being hit at all. Who knows what else could break.

2. The solution in the PR
Not elegant, but i believe this is the safest, at least until we fully understand why changing `os_id` to 'UNIX` caused breakpoints to fail on Windows for VS and NOT for VSCode.
Possibly because the breakpoints were sent to VS Code as `