### PR TITLE
Enable build and sign on Windows

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+global-exclude *.py[cdo]

--- a/ptvsd/pydevd/_pydevd_bundle/pydevd_frame.py
+++ b/ptvsd/pydevd/_pydevd_bundle/pydevd_frame.py
@@ -36,7 +36,7 @@ TRACE_PROPERTY = 'pydevd_traceproperty.py'
 get_file_type = DONT_TRACE.get
 
 
-def handle_breakpoint_condition(py_db, info, breakpoint, new_frame):
+def handle_breakpoint_condition(py_db, info, breakpoint, new_frame, default_return_value=None):
     condition = breakpoint.condition
     try:
         return eval(condition, new_frame.f_globals, new_frame.f_locals)

--- a/ptvsd/pydevd/_pydevd_bundle/pydevd_frame.py
+++ b/ptvsd/pydevd/_pydevd_bundle/pydevd_frame.py
@@ -36,7 +36,7 @@ TRACE_PROPERTY = 'pydevd_traceproperty.py'
 get_file_type = DONT_TRACE.get
 
 
-def handle_breakpoint_condition(py_db, info, breakpoint, new_frame, default_return_value=None):
+def handle_breakpoint_condition(py_db, info, breakpoint, new_frame):
     condition = breakpoint.condition
     try:
         return eval(condition, new_frame.f_globals, new_frame.f_locals)
@@ -50,7 +50,7 @@ def handle_breakpoint_condition(py_db, info, breakpoint, new_frame, default_retu
         sys.stderr.write(msg)
         traceback.print_exc()
         if not py_db.suspend_on_breakpoint_exception:
-            return default_return_value
+            return
         else:
             stop = True
             try:

--- a/ptvsd/pydevd/_pydevd_bundle/pydevd_frame.py
+++ b/ptvsd/pydevd/_pydevd_bundle/pydevd_frame.py
@@ -50,7 +50,7 @@ def handle_breakpoint_condition(py_db, info, breakpoint, new_frame):
         sys.stderr.write(msg)
         traceback.print_exc()
         if not py_db.suspend_on_breakpoint_exception:
-            return
+            return False
         else:
             stop = True
             try:

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,11 @@ import sys
 
 from setuptools import setup, Extension
 
+if not os.getenv('SKIP_CYTHON_BUILD'):
+    print('Compiling extension modules (set SKIP_CYTHON_BUILD=1 to omit)')
+    subprocess.check_call(
+        [sys.executable, 'ptvsd/pydevd/setup_cython.py', 'build_ext', '-i'])
+
 ROOT = os.path.dirname(os.path.abspath(__file__))
 
 # Add pydevd files as data files for this package. They are not treated

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,12 @@
 
 import os
 import os.path
+import subprocess
 import sys
 
 from setuptools import setup, Extension
 
-
 ROOT = os.path.dirname(os.path.abspath(__file__))
-
 
 # Add pydevd files as data files for this package. They are not treated
 # as a package of their own, because we don't actually want to provide
@@ -32,22 +31,13 @@ def get_pydevd_package_data():
             files[:] = [f
                         for f in files
                         if f.endswith('.py') and 'pydev' in f]
+        dirs[:] = [d for d in dirs if d != '__pycache__']
         for f in files:
             yield os.path.join(root[len(ptvsd_prefix) + 1:], f)
 
-
-cmdclass = {}
-
-if sys.version_info[0] == 2:
-    from setuptools.command.build_ext import build_ext
-
-    class build_optional_ext(build_ext):
-        def build_extension(self, ext):
-            try:
-                super(build_optional_ext, self).build_extension(ext)
-            except Exception:
-                pass
-    cmdclass = {'build_ext': build_optional_ext}
+PACKAGE_DATA = {
+    'ptvsd': list(get_pydevd_package_data()) + ['ThirdPartyNotices.txt']
+}
 
 setup(
     name='ptvsd',
@@ -65,15 +55,5 @@ setup(
         'License :: OSI Approved :: MIT License',
     ],
     packages=['ptvsd'],
-    package_data={
-        'ptvsd': list(get_pydevd_package_data()) + [
-            'ThirdPartyNotices.txt',
-         ],
-    },
-    ext_modules=[
-        Extension('ptvsd.pydevd._pydevd_bundle.pydevd_cython',
-                  ['ptvsd/pydevd/_pydevd_bundle/pydevd_cython.c'],
-                  optional=True),
-    ],
-    cmdclass=cmdclass,
+    package_data=PACKAGE_DATA,
 )

--- a/win/build_all.ps1
+++ b/win/build_all.ps1
@@ -14,7 +14,7 @@ if ($env:BUILD_BINARIESDIRECTORY) {
 if (-not $pack) {
     (gci $packages\python* -Directory) | %{ gi $_\tools\python.exe } | ?{ Test-Path $_ } | %{
         Write-Host "Building with $_"
-        & $_ -m pip install -U D:\repos\pyfindvs setuptools wheel cython
+        & $_ -m pip install -U pyfindvs setuptools wheel cython
         pushd "$root\..\ptvsd\pydevd"
         & $_ setup_cython.py enable_msbuildcompiler build_ext -b "$bin" -t "$obj"
         popd

--- a/win/build_all.ps1
+++ b/win/build_all.ps1
@@ -23,9 +23,12 @@ if (-not $pack) {
     }
 
 } else {
-    gci $dist\*.whl | Remove-Item -Force
+    gci $dist\*.whl, $dist\*.zip | Remove-Item -Force
 
     (gci $packages\python* -Directory) | %{ gi $_\tools\python.exe } | ?{ Test-Path $_ } | select -last 1 | %{
+        Write-Host "Building sdist with $_"
+        & $_ setup.py sdist -d "$dist" --formats zip
+
         Write-Host "Building wheel with $_"
         & $_ setup.py build -b "$bin" -t "$obj" bdist_wheel -d "$dist"
         gci $dist\ptvsd-*.whl | %{
@@ -35,5 +38,6 @@ if (-not $pack) {
             Remove-Item $_
         }
     }
+
 }
 

--- a/win/build_all.ps1
+++ b/win/build_all.ps1
@@ -1,0 +1,35 @@
+param($packages, [switch]$pack)
+
+$root = $script:MyInvocation.MyCommand.Path | Split-Path -parent;
+if ($env:BUILD_BINARIESDIRECTORY) {
+    $bin = mkdir -Force $env:BUILD_BINARIESDIRECTORY\$bin
+    $obj = mkdir -Force $env:BUILD_BINARIESDIRECTORY\$obj
+    $dist = mkdir -Force $env:BUILD_BINARIESDIRECTORY\$dist
+} else {
+    $bin = mkdir -Force $root\bin
+    $obj = mkdir -Force $root\obj
+    $dist = mkdir -Force $root\dist
+}
+
+if (-not $pack) {
+    (gci $packages\python* -Directory) | %{ gi $_\tools\python.exe } | ?{ Test-Path $_ } | %{
+        Write-Host "Building with $_"
+        & $_ -m pip install -U D:\repos\pyfindvs setuptools wheel cython
+        pushd "$root\..\ptvsd\pydevd"
+        & $_ setup_cython.py enable_msbuildcompiler build_ext -b "$bin" -t "$obj"
+        popd
+    }
+
+} else {
+    gci $dist\*.whl | Remove-Item -Force
+
+    (gci $packages\python* -Directory) | %{ gi $_\tools\python.exe } | ?{ Test-Path $_ } | select -last 1 | %{
+        Write-Host "Building wheel with $_"
+        & $_ setup.py build -b "$bin" -t "$obj" bdist_wheel -d "$dist"
+        gci $dist\ptvsd-*.whl | %{
+            Copy-Item $_ (Join-Path $_.Directory ($_.Name -replace '(ptvsd-.+?)-any\.whl', '$1-win_amd64.whl'))
+            Copy-Item $_ (Join-Path $_.Directory ($_.Name -replace '(ptvsd-.+?)-any\.whl', '$1-win32.whl'))
+        }
+    }
+}
+

--- a/win/build_all.ps1
+++ b/win/build_all.ps1
@@ -11,6 +11,8 @@ if ($env:BUILD_BINARIESDIRECTORY) {
     $dist = mkdir -Force $root\dist
 }
 
+$env:SKIP_CYTHON_BUILD = "1"
+
 if (-not $pack) {
     (gci $packages\python* -Directory) | %{ gi $_\tools\python.exe } | ?{ Test-Path $_ } | %{
         Write-Host "Building with $_"

--- a/win/build_all.ps1
+++ b/win/build_all.ps1
@@ -2,9 +2,9 @@ param($packages, [switch]$pack)
 
 $root = $script:MyInvocation.MyCommand.Path | Split-Path -parent;
 if ($env:BUILD_BINARIESDIRECTORY) {
-    $bin = mkdir -Force $env:BUILD_BINARIESDIRECTORY\$bin
-    $obj = mkdir -Force $env:BUILD_BINARIESDIRECTORY\$obj
-    $dist = mkdir -Force $env:BUILD_BINARIESDIRECTORY\$dist
+    $bin = mkdir -Force $env:BUILD_BINARIESDIRECTORY\bin
+    $obj = mkdir -Force $env:BUILD_BINARIESDIRECTORY\obj
+    $dist = mkdir -Force $env:BUILD_BINARIESDIRECTORY\dist
 } else {
     $bin = mkdir -Force $root\bin
     $obj = mkdir -Force $root\obj
@@ -27,8 +27,10 @@ if (-not $pack) {
         Write-Host "Building wheel with $_"
         & $_ setup.py build -b "$bin" -t "$obj" bdist_wheel -d "$dist"
         gci $dist\ptvsd-*.whl | %{
+            Write-Host "Built wheel found at $_"
             Copy-Item $_ (Join-Path $_.Directory ($_.Name -replace '(ptvsd-.+?)-any\.whl', '$1-win_amd64.whl'))
             Copy-Item $_ (Join-Path $_.Directory ($_.Name -replace '(ptvsd-.+?)-any\.whl', '$1-win32.whl'))
+            Remove-Item $_
         }
     }
 }

--- a/win/packages.config
+++ b/win/packages.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microbuild.Core" version="0.3.0" />
+  <package id="Python" version="3.6.4" />
+  <package id="Pythonx86" version="3.6.4" />
+  <package id="Python" version="3.5.4" />
+  <package id="Pythonx86" version="3.5.4" />
+</packages>

--- a/win/sign.proj
+++ b/win/sign.proj
@@ -1,0 +1,63 @@
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <RootPath>$(MSBuildThisFileDirectory)\..\ptvsd\</RootPath>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="$(BUILD_BINARIESDIRECTORY) != ''">
+    <IntDir>$(BUILD_BinariesDirectory)\obj\sign\</IntDir>
+    <OutDir>$(BUILD_BinariesDirectory)\bin\sign\</OutDir>
+    <RootDir>$(BUILD_BinariesDirectory)\bin\</RootDir>
+    <PackagesDir>$(BUILD_BinariesDirectory)\packages</PackagesDir>
+  </PropertyGroup>
+  <PropertyGroup>
+    <IntDir Condition="$(IntDir) == ''">$(MSBuildThisFileDirectory)\obj\sign\</IntDir>
+    <OutDir Condition="$(OutDir) == ''">$(MSBuildThisFileDirectory)\bin\sign\</OutDir>
+    <RootDir Condition="$(RootDir) == ''">$(MSBuildThisFileDirectory)\bin\</RootDir>
+    <PackagesDir Condition="$(PackagesDir) == ''">$(MSBuildThisFileDirectory)</PackagesDir>
+
+    <IntermediateOutputPath>$(IntDir)</IntermediateOutputPath>
+    <OutputPath>$(OutDir)</OutputPath>
+  </PropertyGroup>
+
+  <Import Project="$(PackagesDir)\Microbuild.Core.0.3.0\build\MicroBuild.Core.props" />
+
+  <ItemGroup>
+    <SourceFiles Include="$(RootDir)_pydevd_bundle\*.pyd">
+      <TargetPath>$(MSBuildThisFileDirectory)..\ptvsd\pydevd\_pydevd_bundle\%(Filename)%(Extension)</TargetPath>
+    </SourceFiles>
+    <SourceFiles Include="$(RootDir)_pydevd_frame_eval\*.pyd">
+      <TargetPath>$(MSBuildThisFileDirectory)..\ptvsd\pydevd\_pydevd_frame_eval\%(Filename)%(Extension)</TargetPath>
+    </SourceFiles>
+    <SourceFiles Include="$(MSBuildThisFileDirectory)..\ptvsd\pydevd\pydevd_attach_to_process\*.dll">
+      <TargetPath>%(FullPath)</TargetPath>
+    </SourceFiles>
+  </ItemGroup>
+
+  <Target Name="Build">
+    <MakeDir Directories="$(IntDir);$(OutDir)" />
+    <Copy SourceFiles="@(SourceFiles)" DestinationFolder="$(OutDir)">
+      <Output TaskParameter="CopiedFiles" ItemName="FilesToSign" />
+    </Copy>
+    <ItemGroup>
+      <FilesToSign>
+        <Authenticode>3PartySHA2</Authenticode>
+      </FilesToSign>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="AfterBuild" AfterTargets="Build" />
+
+  <Target Name="_GetBinariesInLayout">
+    <ItemGroup>
+      <_SignedFile Include="$(OutDir)%(SourceFiles.Filename)%(SourceFiles.Extension)">
+        <TargetPath>%(SourceFiles.TargetPath)</TargetPath>
+      </_SignedFile>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_UpdateLayoutWithSignedBinaries" DependsOnTargets="_GetBinariesInLayout" AfterTargets="SignFiles">
+    <Copy SourceFiles="%(_SignedFile.FullPath)" DestinationFiles="%(_SignedFile.TargetPath)" />
+  </Target>
+
+  <Import Project="$(PackagesDir)\Microbuild.Core.0.3.0\build\MicroBuild.Core.targets" />
+</Project>


### PR DESCRIPTION
This script can be run to generate a semi-pure wheel that includes precompiled extension modules for 3.5 and 3.6, both 32-bit and 64-bit. (Python 3.5 is when Windows started using ABI suffix on extension modules - we can't replicate this as easily for earlier versions.) I already have an internal build definition using this that can also sign all the binaries as needed.

I also fixed #112 by changing how we build the extension modules (i.e. with the correct names). I'm also not quite sure why the `default_return_value` change became necessary, but it was, so I assume it was one of our patches?