### PR TITLE
Ignore errors when closing the socket

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -558,7 +558,7 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
             try:
                 self.socket.shutdown(socket.SHUT_RDWR)
                 self.socket.close()
-            except:
+            except Exception:
                 pass
 
     def pydevd_notify(self, cmd_id, args):

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -555,8 +555,11 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         self.event_loop_thread.join(WAIT_FOR_THREAD_FINISH_TIMEOUT)
 
         if self.socket:
-            self.socket.shutdown(socket.SHUT_RDWR)
-            self.socket.close()
+            try:
+                self.socket.shutdown(socket.SHUT_RDWR)
+                self.socket.close()
+            except:
+                pass
 
     def pydevd_notify(self, cmd_id, args):
         # TODO: docstring


### PR DESCRIPTION
Fixes #228 
I believe its safe to just ignore all errors when shutting down & releasing resources.
At the moment, the error is `socket.error`.
Its very difficult to replicate this issue (was able to replicate it consistently earlier today).