### PR TITLE
Fix #193: Capture usage of the experimental debugger

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -7,6 +7,7 @@ from __future__ import print_function, absolute_import
 import atexit
 import contextlib
 import errno
+import getpass
 import os
 import platform
 import re
@@ -629,6 +630,12 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         self.event_loop_thread.daemon = True
         self.event_loop_thread.start()
         self.wait_on_exit_func = waitonexitfunc
+
+        self.send_event(
+            'output',
+            category='telemetry',
+            output='ptvsd',
+            data={'version': __version__})
 
     def _handle_exit(self):
         wait_on_normal_exit = self.debug_options.get(
@@ -1384,6 +1391,52 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
                      'stackTrace': exc.stack,
                      'source': exc.source},
         )
+
+    # Custom ptvsd message
+    def on_ptvsd_systemInfo(self, request, args):
+        try:
+            pid = os.getpid()
+        except AttributeError:
+            pid = None
+
+        try:
+            username = getpass.getuser()
+        except AttributeError:
+            username = None
+
+        try:
+            impl_desc = platform.python_implementation()
+        except AttributeError:
+            try:
+                impl_desc = sys.implementation.name
+            except AttributeError:
+                impl_desc = 'Python'
+
+        sys_info = {
+            'ptvsd': {
+                'version': __version__,
+            },
+            'python': {
+                'version': list(sys.version_info),
+                'implementation': {
+                    'name': sys.implementation.name,
+                    'version': list(sys.implementation.version),
+                    'description': impl_desc,
+                },
+            },
+            'platform': {
+                'name': sys.platform,
+            },
+            'process': {
+                'pid': pid,
+                'executable': sys.executable,
+                'bitness': 64 if sys.maxsize > 2**32 else 32,
+            },
+            'user': {
+                'name': username,
+            },
+        }
+        self.send_response(request, **sys_info)
 
     @pydevd_events.handler(pydevd_comm.CMD_THREAD_CREATE)
     def on_pydevd_thread_create(self, seq, args):

--- a/tests/helpers/socket.py
+++ b/tests/helpers/socket.py
@@ -57,7 +57,10 @@ def bind(address):
 
 def close(sock):
     """Shutdown and close the socket."""
-    sock.shutdown(socket.SHUT_RDWR)
+    try:
+        sock.shutdown(socket.SHUT_RDWR)
+    except Exception:
+        pass
     sock.close()
 
 

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -345,10 +345,15 @@ class VSCLifecycle(object):
     def _handshake(self, command, threadnames=None, config=None,
                    default_threads=True, process=True, reset=True,
                    **kwargs):
+        with self._hidden():
+            with self._fix.wait_for_event('output'):
+                pass
+
         initargs = dict(
             kwargs.pop('initargs', None) or {},
             disconnect=kwargs.pop('disconnect', True),
         )
+
         with self._fix.wait_for_event('initialized'):
             self._initialize(**initargs)
             self._fix.send_request(command, **kwargs)

--- a/tests/highlevel/test_lifecycle.py
+++ b/tests/highlevel/test_lifecycle.py
@@ -1,5 +1,4 @@
-#import os
-#import sys
+import ptvsd
 import unittest
 
 from _pydevd_bundle.pydevd_comm import (
@@ -8,7 +7,11 @@ from _pydevd_bundle.pydevd_comm import (
     CMD_VERSION,
 )
 
-from . import OS_ID, HighlevelTest, HighlevelFixture
+from . import (
+    OS_ID,
+    HighlevelTest,
+    HighlevelFixture,
+)
 
 
 # TODO: Make sure we are handling the following properly:
@@ -30,6 +33,9 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
         version = self.debugger.VERSION
         addr = (None, 8888)
         with self.vsc.start(addr):
+            with self.vsc.wait_for_event('output'):
+                pass
+
             with self.vsc.wait_for_event('initialized'):
                 # initialize
                 self.set_debugger_response(CMD_VERSION, version)
@@ -50,6 +56,11 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
         # An "exited" event comes once self.vsc closes.
 
         self.assert_received(self.vsc, [
+            self.new_event(
+                'output',
+                category='telemetry',
+                output='ptvsd',
+                data={'version': ptvsd.__version__}),
             self.new_response(req_initialize, **dict(
                 supportsExceptionInfoRequest=True,
                 supportsConfigurationDoneRequest=True,
@@ -95,6 +106,9 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
         version = self.debugger.VERSION
         addr = (None, 8888)
         with self.vsc.start(addr):
+            with self.vsc.wait_for_event('output'):
+                pass
+
             with self.vsc.wait_for_event('initialized'):
                 # initialize
                 self.set_debugger_response(CMD_VERSION, version)
@@ -115,6 +129,11 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
         # An "exited" event comes once self.vsc closes.
 
         self.assert_received(self.vsc, [
+            self.new_event(
+                'output',
+                category='telemetry',
+                output='ptvsd',
+                data={'version': ptvsd.__version__}),
             self.new_response(req_initialize, **dict(
                 supportsExceptionInfoRequest=True,
                 supportsConfigurationDoneRequest=True,

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -1,9 +1,14 @@
 import contextlib
 import unittest
 
+import ptvsd
 from tests.helpers.pydevd._live import LivePyDevd
 from tests.helpers.workspace import PathEntry
-from . import VSCFixture, VSCTest
+
+from . import (
+    VSCFixture,
+    VSCTest,
+)
 
 
 class Fixture(VSCFixture):
@@ -104,6 +109,11 @@ class LifecycleTests(TestBase, unittest.TestCase):
             received = self.vsc.received
 
         self.assert_vsc_received(received, [
+            self.new_event(
+                'output',
+                category='telemetry',
+                output='ptvsd',
+                data={'version': ptvsd.__version__}),
             self.new_response(req_initialize, **dict(
                 supportsExceptionInfoRequest=True,
                 supportsConfigurationDoneRequest=True,


### PR DESCRIPTION
Provide a telemetry message incorporating ptvsd version in response to initialization request.

Add a custom message for more detailed information about ptvsd and its environment.