### PR TITLE
Add explicit CLI handling for ptvsd.

### DIFF
--- a/ptvsd/__init__.py
+++ b/ptvsd/__init__.py
@@ -8,18 +8,21 @@ __version__ = "4.0.0a5"
 import sys
 import os.path
 
-# ptvsd must always be imported before pydevd
-if 'pydevd' in sys.modules:
-    raise ImportError('ptvsd must be imported before pydevd')
 
-# Add our vendored pydevd directory to path, so that it gets found first.
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'pydevd'))
+PYDEVD_ROOT = os.path.join(os.path.dirname(__file__), 'pydevd')
 del os
 
-# Load our wrapper module, which will detour various functionality
-# inside pydevd.  This must be done before the imports below, otherwise
-# some modules will end up with local copies of pre-detour functions.
-import ptvsd.wrapper  # noqa
+# Ensure that pydevd is our vendored copy.
+for modname in sys.modules:
+    if not modname.startswith('pydev') and not modname.startswith('_pydev'):
+        continue
+    mod = sys.modules[modname]
+    if hasattr(mod, '__file__') and not mod.__file__.startswith(PYDEVD_ROOT):
+        print(mod.__file__)
+        #raise ImportError('incompatible copy of pydevd already imported')
+
+# Add our vendored pydevd directory to path, so that it gets found first.
+sys.path.insert(0, PYDEVD_ROOT)
 
 # Now make sure all the top-level modules and packages in pydevd are loaded.
 import _pydev_bundle  # noqa

--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -34,6 +34,7 @@ def _run_argv(address, filename, *extra):
         extra = list(extra[len(pydevd) + 1:])
     else:
         pydevd = []
+        extra = list(extra)
 
     host, port = address
     #if host is None:

--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -2,14 +2,13 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
+import ptvsd.wrapper
+
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
 __version__ = "4.0.0a5"
 
 
 if __name__ == '__main__':
-    # import the wrapper first, so that it gets a chance
-    # to detour pydevd socket functionality.
-    import ptvsd.wrapper  # noqa
-    import pydevd
+    pydevd = ptvsd.wrapper.install()
     pydevd.main()

--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
+import argparse
+import os.path
 import sys
 
 import ptvsd.wrapper
@@ -11,36 +13,48 @@ __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
 __version__ = "4.0.0a5"
 
 
-def run_module(address, modname, **kwargs):
+def run_module(address, modname, *extra, **kwargs):
     """Run pydevd for the given module."""
     filename = modname + ':'
-    argv = _run_argv(address, filename)
+    argv = _run_argv(address, filename, *extra)
     argv.insert(argv.index('--file'), '--module')
     _run(argv, **kwargs)
 
 
-def run_file(address, filename, **kwargs):
+def run_file(address, filename, *extra, **kwargs):
     """Run pydevd for the given Python file."""
-    argv = _run_argv(address, filename)
+    argv = _run_argv(address, filename, *extra)
     _run(argv, **kwargs)
 
 
-def _run_argv(address, filename):
+def _run_argv(address, filename, *extra):
     """Convert the given values to an argv that pydevd.main() supports."""
+    if '--' in extra:
+        pydevd = list(extra[:extra.index('--')])
+        extra = list(extra[len(pydevd) + 1:])
+    else:
+        pydevd = []
+
     host, port = address
-    if host is None:
-        host = '127.0.0.1'
-    return [
+    #if host is None:
+    #    host = '127.0.0.1'
+    argv = [
         sys.argv[0],
         '--port', str(port),
-        '--client', host,
-        '--file', filename,
     ]
+    if host is not None:
+        argv.extend([
+            '--client', host,
+        ])
+    return argv + pydevd + [
+        '--file', filename,
+    ] + extra
 
 
 def _run(argv, **kwargs):
     """Start pydevd with the given commandline args."""
     pydevd = ptvsd.wrapper.install(**kwargs)
+    #print(' '.join(argv))
     sys.argv[:] = argv
     try:
         pydevd.main()
@@ -52,9 +66,163 @@ def _run(argv, **kwargs):
 ##################################
 # the script
 
-def main():
-    _run(sys.argv)
+PYDEVD_OPTS = {
+    '--file',
+    '--client',
+    #'--port',
+    '--vm_type',
+}
+
+PYDEVD_FLAGS = {
+    '--DEBUG',
+    '--DEBUG_RECORD_SOCKET_READS',
+    '--cmd-line',
+    '--module',
+    '--multiproc',
+    '--multiprocess',
+    '--print-in-debugger-startup',
+    '--save-signatures',
+    '--save-threading',
+    '--save-asyncio',
+    '--server',
+}
+
+USAGE = """
+  {0} [-h] [--host HOST] --port PORT -m MODULE [arg ...]
+  {0} [-h] [--host HOST] --port PORT FILENAME [arg ...]
+"""
+
+
+def parse_args(argv=None):
+    """Return the parsed args to use in main()."""
+    if argv is None:
+        argv = sys.argv
+        prog = argv[0]
+        if prog == __file__:
+            prog = '{} -m ptvsd'.format(os.path.basename(sys.executable))
+    else:
+        prog = argv[0]
+    argv = argv[1:]
+
+    supported, pydevd, script = _group_args(argv)
+    args = _parse_args(prog, supported)
+    return args, pydevd + ['--'] + script
+
+
+def _group_args(argv):
+    supported = []
+    pydevd = []
+    script = []
+
+    try:
+        pos = argv.index('--')
+    except ValueError:
+        script = []
+    else:
+        script = argv[pos + 1:]
+        argv = argv[:pos]
+
+    for arg in argv:
+        if arg == '-h' or arg == '--help':
+            return argv, [], script
+
+    gottarget = False
+    skip = 0
+    for i in range(len(argv)):
+        if skip:
+            skip -= 1
+            continue
+
+        arg = argv[i]
+        try:
+            nextarg = argv[i + 1]
+        except IndexError:
+            nextarg = None
+
+        # TODO: Deprecate the PyDevd arg support.
+        # PyDevd support
+        if gottarget:
+            script = argv[i:] + script
+            break
+        if arg == '--client':
+            arg = '--host'
+        elif arg == '--file':
+            if nextarg is None:
+                pydevd.append(arg)
+                continue
+            if nextarg.endswith(':') and '--module' in pydevd:
+                pydevd.remove('--module')
+                arg = '-m'
+                argv[i + 1] = nextarg = nextarg[:-1]
+            else:
+                arg = nextarg
+                skip += 1
+        if arg in PYDEVD_OPTS:
+            pydevd.append(arg)
+            if nextarg is not None:
+                pydevd.append(nextarg)
+            skip += 1
+        elif arg in PYDEVD_FLAGS:
+            pydevd.append(arg)
+
+        # ptvsd support
+        elif arg in ('--host', '--port', '-m'):
+            if arg == '-m':
+                gottarget = True
+            supported.append(arg)
+            if nextarg is not None:
+                supported.append(nextarg)
+            skip += 1
+        elif not arg.startswith('-'):
+            supported.append(arg)
+            gottarget = True
+
+        # unsupported arg
+        else:
+            supported.append(arg)
+            break
+
+    return supported, pydevd, script
+
+
+def _parse_args(prog, argv):
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        usage=USAGE.format(prog),
+    )
+    parser.add_argument('--host')
+    parser.add_argument('--port', type=int, required=True)
+
+    target = parser.add_mutually_exclusive_group(required=True)
+    target.add_argument('-m', dest='module')
+    target.add_argument('filename', nargs='?')
+
+    args = parser.parse_args(argv)
+    ns = vars(args)
+
+    args.address = (ns.pop('host'), ns.pop('port'))
+
+    module = ns.pop('module')
+    filename = ns.pop('filename')
+    if module is None:
+        args.name = filename
+        args.kind = 'script'
+    else:
+        args.name = module
+        args.kind = 'module'
+    #if argv[-1] != args.name or (module and argv[-1] != '-m'):
+    #    parser.error('script/module must be last arg')
+
+    return args
+
+
+def main(address, name, kind, *extra, **kwargs):
+    if kind == 'module':
+        run_module(address, name, *extra, **kwargs)
+    else:
+        run_file(address, name, *extra, **kwargs)
 
 
 if __name__ == '__main__':
-    main()
+    args, extra = parse_args()
+    main(args.address, args.name, args.kind, *extra)

--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
+import sys
+
 import ptvsd.wrapper
 
 
@@ -9,6 +11,50 @@ __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
 __version__ = "4.0.0a5"
 
 
+def run_module(address, modname, **kwargs):
+    """Run pydevd for the given module."""
+    filename = modname + ':'
+    argv = _run_argv(address, filename)
+    argv.insert(argv.index('--file'), '--module')
+    _run(argv, **kwargs)
+
+
+def run_file(address, filename, **kwargs):
+    """Run pydevd for the given Python file."""
+    argv = _run_argv(address, filename)
+    _run(argv, **kwargs)
+
+
+def _run_argv(address, filename):
+    """Convert the given values to an argv that pydevd.main() supports."""
+    host, port = address
+    if host is None:
+        host = '127.0.0.1'
+    return [
+        sys.argv[0],
+        '--port', str(port),
+        '--client', host,
+        '--file', filename,
+    ]
+
+
+def _run(argv, **kwargs):
+    """Start pydevd with the given commandline args."""
+    pydevd = ptvsd.wrapper.install(**kwargs)
+    sys.argv[:] = argv
+    try:
+        pydevd.main()
+    except SystemExit as ex:
+        ptvsd.wrapper.ptvsd_sys_exit_code = int(ex.code)
+        raise
+
+
+##################################
+# the script
+
+def main():
+    _run(sys.argv)
+
+
 if __name__ == '__main__':
-    pydevd = ptvsd.wrapper.install()
-    pydevd.main()
+    main()

--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -66,6 +66,13 @@ def _run(argv, **kwargs):
 ##################################
 # the script
 
+"""
+For the PyDevd CLI handling see:
+
+  https://github.com/fabioz/PyDev.Debugger/blob/master/_pydevd_bundle/pydevd_command_line_handling.py
+  https://github.com/fabioz/PyDev.Debugger/blob/master/pydevd.py#L1450  (main func)
+"""  # noqa
+
 PYDEVD_OPTS = {
     '--file',
     '--client',

--- a/ptvsd/debugger.py
+++ b/ptvsd/debugger.py
@@ -2,56 +2,20 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-import sys
-
-# import the wrapper first, so that it gets a chance
-# to detour pydevd socket functionality.
-import ptvsd.wrapper
+from ptvsd.__main__ import run_module, run_file
 
 
 __author__ = "Microsoft Corporation <ptvshelp@microsoft.com>"
 __version__ = "4.0.0a5"
 
+# TODO: not needed?
 DONT_DEBUG = []
 
 
-def debug(filename, port_num, debug_id, debug_options, run_as):
+def debug(filename, port_num, debug_id, debug_options, run_as, **kwargs):
     # TODO: docstring
     address = (None, port_num)
     if run_as == 'module':
-        _run_module(address, filename)
+        run_module(address, filename, **kwargs)
     else:
-        _run_file(address, filename)
-
-
-def _run_module(address, modname):
-    filename = modname + ':'
-    argv = _run_argv(address, filename)
-    argv.insert(argv.index('--file'), '--module')
-    _run(argv)
-
-
-def _run_file(address, filename):
-    argv = _run_argv(address, filename)
-    _run(argv)
-
-
-def _run_argv(address, filename):
-    host, port = address
-    if host is None:
-        host = '127.0.0.1'
-    return [
-        '--port', str(port),
-        '--client', host,
-        '--file', filename,
-    ]
-
-
-def _run(argv):
-    pydevd = ptvsd.wrapper.install(argv)
-    sys.argv[1:0] = argv
-    try:
-        pydevd.main()
-    except SystemExit as ex:
-        ptvsd.wrapper.ptvsd_sys_exit_code = int(ex.code)
-        raise
+        run_file(address, filename, **kwargs)

--- a/ptvsd/debugger.py
+++ b/ptvsd/debugger.py
@@ -48,7 +48,7 @@ def _run_argv(address, filename):
 
 
 def _run(argv):
-    import pydevd
+    pydevd = ptvsd.wrapper.install(argv)
     sys.argv[1:0] = argv
     try:
         pydevd.main()

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1783,6 +1783,13 @@ def start_client(host, port, addhandlers=True):
     return pydevd
 
 
-# These are the functions pydevd invokes to get a socket to the client.
-pydevd_comm.start_server = start_server
-pydevd_comm.start_client = start_client
+def install(start_server=start_server, start_client=start_client):
+    """Configure pydevd to use our wrapper."""
+    # These are the functions pydevd invokes to get a socket to the client.
+    pydevd_comm.start_server = start_server
+    pydevd_comm.start_client = start_client
+
+    # Force a fresh pydevd.
+    sys.modules.pop('pydevd', None)
+    import pydevd  # noqa
+    return pydevd

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1783,13 +1783,22 @@ def start_client(host, port, addhandlers=True):
     return pydevd
 
 
-def install(start_server=start_server, start_client=start_client):
-    """Configure pydevd to use our wrapper."""
+def install(pydevd, start_server=start_server, start_client=start_client):
+    """Configure pydevd to use our wrapper.
+
+    This is a bit of a hack to allow us to run our VSC debug adapter
+    in the same process as pydevd.  Note that, as with most hacks,
+    this is somewhat fragile (since the monkeypatching sites may
+    change).
+    """
     # These are the functions pydevd invokes to get a socket to the client.
     pydevd_comm.start_server = start_server
     pydevd_comm.start_client = start_client
 
-    # Force a fresh pydevd.
-    sys.modules.pop('pydevd', None)
-    import pydevd  # noqa
-    return pydevd
+    # Ensure that pydevd is using our functions.
+    pydevd.start_server = start_server
+    pydevd.start_client = start_client
+    __main__ = sys.modules['__main__']
+    if __main__ is not pydevd and __main__.__file__ == pydevd.__file__:
+        __main__.start_server = start_server
+        __main__.start_client = start_client

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+
+# Trigger the pydevd vendoring.
+import ptvsd  # noqa

--- a/tests/helpers/pydevd/_live.py
+++ b/tests/helpers/pydevd/_live.py
@@ -1,12 +1,9 @@
 import os
 import os.path
-import sys
 import threading
 import warnings
 
-import _pydevd_bundle.pydevd_comm as pydevd_comm
-
-from ptvsd import debugger
+from ptvsd import debugger, wrapper
 from tests.helpers import protocol
 from ._binder import BinderBase
 
@@ -24,10 +21,10 @@ class Binder(BinderBase):
         def new_pydevd_sock(*args):
             self._start_ptvsd()
             return self.ptvsd.fakesock
-        pydevd_comm.start_server = new_pydevd_sock
-        pydevd_comm.start_client = new_pydevd_sock
-        # Force a fresh pydevd.
-        sys.modules.pop('pydevd', None)
+        wrapper.install(
+            start_server=new_pydevd_sock,
+            start_client=new_pydevd_sock,
+        )
         if self.module is None:
             debugger._run_file(self.address, self.filename)
         else:


### PR DESCRIPTION
This change is intended to accommodate future work (adding more CLI options where using the launch config is insufficient).  It also allows us to define a consistent and easy-to-discover CLI, independent of PyDevd.

To be backward compatible, the code also supports the PyDevd CLI (for now).