### PR TITLE
Fix #319: VS "Stop Debugging" triggers "Press any key to continue"

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -635,6 +635,7 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         self.disconnect_request_event = threading.Event()
         self._exited = False
         self.path_casing = PathUnNormcase()
+        self.start_reason = None
 
     def start(self, threadname):
         # event loop
@@ -687,6 +688,12 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
                 pass
 
     def _wait_options(self):
+        # In attach scenarios, we can't assume that the process is actually
+        # interactive and has a console, so ignore these options.
+        # In launch scenarios, we only want "press any key" to show up when
+        # program terminates by itself, not when user explicitly stops it.
+        if self.disconnect_request or self.start_reason != 'launch':
+            return False, False
         normal = self.debug_options.get('WAIT_ON_NORMAL_EXIT', False)
         abnormal = self.debug_options.get('WAIT_ON_ABNORMAL_EXIT', False)
         return normal, abnormal


### PR DESCRIPTION
Do not stop on exit if attaching, or if disconnect request has been received.