### PR TITLE
Add support for remote source references

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
             "Jinja",                // Enables Jinja (Flask) Template debugging
             "FixFilePathCase",      // See FIX_FILE_PATH_CASE in wrapper.py
             "DebugStdLib"           // Whether to enable debugging of standard library functions
+            "UseSourceReferences"   // Whether to use source references (making `pathMappings` optional)
     ],
     "pathMappings": [
         {

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
             "Jinja",                // Enables Jinja (Flask) Template debugging
             "FixFilePathCase",      // See FIX_FILE_PATH_CASE in wrapper.py
             "DebugStdLib"           // Whether to enable debugging of standard library functions
-            "UseSourceReferences"   // Whether to use source references (making `pathMappings` optional)
     ],
     "pathMappings": [
         {

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1034,7 +1034,7 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
 
     @async_handler
     def on_source(self, request, args):
-        """Request to get the source"""        
+        """Request to get the source"""
         source_reference = args.get('sourceReference', 0)
         filename = '' if source_reference == 0 else \
             self.source_map.to_pydevd(source_reference)
@@ -1128,7 +1128,10 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
             stackFrames.append({
                 'id': fid,
                 'name': frame_name,
-                'source': {'path': norm_path, 'sourceReference': source_reference},
+                'source': {
+                    'path': norm_path,
+                    'sourceReference': source_reference
+                },
                 'line': line, 'column': 1,
             })
 

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -893,7 +893,6 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
             'Jinja': 'FLASK_DEBUG=True',
             'FixFilePathCase': 'FIX_FILE_PATH_CASE=True',
             'DebugStdLib': 'DEBUG_STD_LIB=True',
-            'UseSourceReferences': 'SOURCE_REFERENCE=True'
         }
         return ';'.join(debug_option_mapping[option]
                         for option in debug_options
@@ -908,7 +907,6 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
             INTERPRETER_OPTIONS=string
             WEB_BROWSER_URL=string url
             DJANGO_DEBUG=True|False
-            SOURCE_REFERENCE=True|False
         """
         DEBUG_OPTIONS_PARSER = {
             'WAIT_ON_ABNORMAL_EXIT': bool,
@@ -920,7 +918,6 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
             'DJANGO_DEBUG': bool,
             'FLASK_DEBUG': bool,
             'FIX_FILE_PATH_CASE': bool,
-            'SOURCE_REFERENCE': bool
         }
 
         options = {}
@@ -1053,8 +1050,7 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         And we know that the path returned is the same as the server path
         (i.e. path has not been translated)"""
 
-        if self.start_reason == 'launch' or \
-            not self.debug_options.get('SOURCE_REFERENCE', False):
+        if self.start_reason == 'launch':
             return 0
 
         try:

--- a/tests/highlevel/test_messages.py
+++ b/tests/highlevel/test_messages.py
@@ -285,14 +285,14 @@ class StackTraceTests(NormalRequestTest, unittest.TestCase):
                     {
                         'id': 1,
                         'name': 'spam',
-                        'source': {'path': 'abc.py'},
+                        'source': {'path': 'abc.py', 'sourceReference': 0},
                         'line': 10,
                         'column': 1,
                     },
                     {
                         'id': 2,
                         'name': 'eggs',
-                        'source': {'path': 'xyz.py'},
+                        'source': {'path': 'xyz.py', 'sourceReference': 0},
                         'line': 2,
                         'column': 1,
                     },
@@ -329,14 +329,14 @@ class StackTraceTests(NormalRequestTest, unittest.TestCase):
                     {
                         'id': 1,
                         'name': 'abc.spam : 10',
-                        'source': {'path': 'abc.py'},
+                        'source': {'path': 'abc.py', 'sourceReference': 0},
                         'line': 10,
                         'column': 1,
                     },
                     {
                         'id': 2,
                         'name': 'xyz.eggs : 2',
-                        'source': {'path': 'xyz.py'},
+                        'source': {'path': 'xyz.py', 'sourceReference': 0},
                         'line': 2,
                         'column': 1,
                     },

--- a/tests/highlevel/test_messages.py
+++ b/tests/highlevel/test_messages.py
@@ -1886,9 +1886,7 @@ class SourceTests(NormalRequestTest, unittest.TestCase):
             )
             received = self.vsc.received
 
-        self.assert_vsc_received(received, [
-            self.expected_failure('Unknown command'),
-        ])
+        self.assert_vsc_received(received, [])
         self.assert_received(self.debugger, [])
 
 


### PR DESCRIPTION
Fixes #318
This is an opt in feature.
We'll be enabling this as a default feature in VSC.
* If users provide source mappings then, that wins over source references.
* If users do not provide source mappings, then source references are used
* If user provides source mappings, but PTVSD is unable to map the files (e.g. standard lib code), then source references are used