### PR TITLE
Wait until the end of VSCodeMessageProcessor.start() to start handling incoming messages.

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -656,6 +656,8 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         self.modules_mgr = ModulesManager(self)
 
         # adapter state
+        self.readylock = threading.Lock()
+        self.readylock.acquire()  # Unlock at the end of start().
         self.disconnect_request = None
         self.debug_options = {}
         self.disconnect_request_event = threading.Event()
@@ -674,8 +676,11 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         self.event_loop_thread.start()
 
         # VSC msg processing loop
+        def process_messages():
+            self.readylock.acquire()
+            self.process_messages()
         self.server_thread = threading.Thread(
-            target=self.process_messages,
+            target=process_messages,
             name=threadname,
         )
         self.server_thread.daemon = True
@@ -688,6 +693,7 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
             output='ptvsd',
             data={'version': __version__},
         )
+        self.readylock.release()
 
     # closing the adapter
 

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -200,6 +200,7 @@ class VSCLifecycle(object):
         with self._hidden():
             # Anything that gets sent in VSCodeMessageProcessor.__init__()
             # must be waited for here.
+            # TODO: Is this necessary any more since we added the "readylock"?
             with self._fix.wait_for_event('output'):
                 daemon = self._fix.fake.start(addr)
                 daemon.wait_until_connected()

--- a/tests/highlevel/test_lifecycle.py
+++ b/tests/highlevel/test_lifecycle.py
@@ -104,10 +104,6 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
         version = self.debugger.VERSION
         addr = (None, 8888)
         with self.vsc.start(addr):
-            # TODO: There's a race with the initial "output" event.
-            with self.vsc.wait_for_event('output'):
-                pass
-
             with self.vsc.wait_for_event('initialized'):
                 # initialize
                 self.set_debugger_response(CMD_VERSION, version)

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -95,10 +95,6 @@ class LifecycleTests(TestBase, unittest.TestCase):
     def test_launch(self):
         addr = (None, 8888)
         with self.fake.start(addr):
-            # TODO: There's a race with the initial "output" event.
-            with self.vsc.wait_for_event('output'):
-                pass
-
             with self.vsc.wait_for_event('initialized'):
                 # initialize
                 req_initialize = self.send_request('initialize', {

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -224,14 +224,11 @@ class LifecycleTests(TestsBase, unittest.TestCase):
         done, waitscript = lockfile.wait_in_script()
         filename = self.write_script('spam.py', waitscript)
         script = self.write_debugger_script(filename, 9876, run_as='script')
-        handlers, wait_for_started = self._wait_for_started()
         with DebugClient(port=9876) as editor:
             adapter, session = editor.host_local_debugger(
                 argv,
                 script,
-                handlers=handlers,
             )
-            wait_for_started()
 
             (req_initialize, req_launch, req_config
              ) = lifecycle_handshake(session, 'launch')
@@ -257,14 +254,11 @@ class LifecycleTests(TestsBase, unittest.TestCase):
         lockfile = self.workspace.lockfile()
         done, waitscript = lockfile.wait_in_script()
         filename = self.write_script('spam.py', waitscript)
-        handlers, wait_for_started = self._wait_for_started()
         with DebugClient() as editor:
             adapter, session = editor.launch_script(
                 filename,
-                handlers=handlers,
                 timeout=3.0,
             )
-            wait_for_started()
 
             (req_initialize, req_launch, req_config
              ) = lifecycle_handshake(session, 'launch')
@@ -290,7 +284,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
         lockfile = self.workspace.lockfile()
         done, waitscript = lockfile.wait_in_script()
         filename = self.write_script('spam.py', waitscript)
-        handlers, wait_for_started = self._wait_for_started()
         with DebugClient() as editor:
             # Launch and detach.
             # TODO: This is not an ideal way to spin up a process
@@ -299,9 +292,7 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             # running isn't an option currently.
             adapter, session = editor.launch_script(
                 filename,
-                handlers=handlers,
             )
-            wait_for_started()
 
             lifecycle_handshake(session, 'launch')
             editor.detach()


### PR DESCRIPTION
This guarantees that the `output` message is always sent first.