### PR TITLE
Move shared functions to their own module (from __main__).

### DIFF
--- a/ptvsd/__init__.py
+++ b/ptvsd/__init__.py
@@ -2,10 +2,12 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
+__all__ = [
+    'enable_attach', 'wait_for_attach', 'break_into_debugger', 'is_attached',
+]
+
 import sys
 import os.path
-
-__all__ = ['enable_attach', 'wait_for_attach', 'break_into_debugger', 'is_attached'] # noqa
 
 from ptvsd.version import __version__, __author__  # noqa
 
@@ -35,7 +37,9 @@ import pydevd_concurrency_analyser  # noqa
 import pydevd_plugins  # noqa
 import pydevd  # noqa
 
-from ptvsd.attach_server import enable_attach, wait_for_attach, break_into_debugger, is_attached # noqa
+from ptvsd.attach_server import (
+    enable_attach, wait_for_attach, break_into_debugger, is_attached,
+)  # noqa
 
 # Remove sys.path entry added above - any pydevd modules that aren't
 # loaded at this point, will be loaded using their parent package's

--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -5,132 +5,14 @@
 import argparse
 import os.path
 import sys
-import time
-import threading
 
-import pydevd
-
-from ptvsd.pydevd_hooks import install
-from ptvsd.socket import Address, create_server
+from ptvsd._main import debug_main, run_main
+from ptvsd.socket import Address
 from ptvsd.version import __version__, __author__  # noqa
-from ptvsd.runner import run as no_debug_runner
-from _pydevd_bundle.pydevd_comm import get_global_debugger
 
-
-def run_module(address, modname, *extra, **kwargs):
-    """Run pydevd for the given module."""
-    addr = Address.from_raw(address)
-    run = kwargs.pop('_run', _run)
-    prog = kwargs.pop('_prog', sys.argv[0])
-    filename = modname + ':'
-    argv = _run_argv(addr, filename, extra, _prog=prog)
-    argv.insert(argv.index('--file'), '--module')
-    run(argv, addr, **kwargs)
-
-
-def run_file(address, filename, *extra, **kwargs):
-    """Run pydevd for the given Python file."""
-    addr = Address.from_raw(address)
-    run = kwargs.pop('_run', _run)
-    prog = kwargs.pop('_prog', sys.argv[0])
-    argv = _run_argv(addr, filename, extra, _prog=prog)
-    run(argv, addr, **kwargs)
-
-
-def _run_argv(address, filename, extra, _prog=sys.argv[0]):
-    """Convert the given values to an argv that pydevd.main() supports."""
-    if '--' in extra:
-        pydevd = list(extra[:extra.index('--')])
-        extra = list(extra[len(pydevd) + 1:])
-    else:
-        pydevd = []
-        extra = list(extra)
-
-    host, port = address
-    argv = [
-        _prog,
-        '--port', str(port),
-    ]
-    if not address.isserver:
-        argv.extend([
-            '--client', host or 'localhost',
-        ])
-    return argv + pydevd + [
-        '--file', filename,
-    ] + extra
-
-
-def _run(argv, addr, _pydevd=pydevd, _install=install, **kwargs):
-    """Start pydevd with the given commandline args."""
-    #print(' '.join(argv))
-
-    # Pydevd assumes that the "__main__" module is the "pydevd" module
-    # and does some tricky stuff under that assumption.  For example,
-    # when the debugger starts up it calls save_main_module()
-    # (in pydevd_bundle/pydevd_utils.py).  That function explicitly sets
-    # sys.modules["pydevd"] to sys.modules["__main__"] and then sets
-    # the __main__ module to a new one.  This makes some sense since
-    # it gives the debugged script a fresh __main__ module.
-    #
-    # This complicates things for us since we are running a different
-    # file (i.e. this one) as the __main__ module.  Consequently,
-    # sys.modules["pydevd"] gets set to ptvsd/__main__.py.  Subsequent
-    # imports of the "pydevd" module then return the wrong module.  We
-    # work around this by avoiding lazy imports of the "pydevd" module.
-    # We also replace the __main__ module with the "pydevd" module here.
-    if sys.modules['__main__'].__file__ != _pydevd.__file__:
-        sys.modules['__main___orig'] = sys.modules['__main__']
-        sys.modules['__main__'] = _pydevd
-
-    daemon = _install(_pydevd, addr, **kwargs)
-    sys.argv[:] = argv
-    try:
-        _pydevd.main()
-    except SystemExit as ex:
-        daemon.exitcode = int(ex.code)
-        raise
-
-
-def enable_attach(address, redirect_output=True,
-                  _pydevd=pydevd, _install=install,
-                  on_attach=lambda: None, **kwargs):
-    host, port = address
-
-    def wait_for_connection(daemon, host, port):
-        debugger = get_global_debugger()
-        while debugger is None:
-            time.sleep(0.1)
-            debugger = get_global_debugger()
-
-        debugger.ready_to_run = True
-        server = create_server(host, port)
-        client, _ = server.accept()
-        daemon.set_connection(client)
-
-        daemon.re_build_breakpoints()
-        on_attach()
-
-    daemon = _install(_pydevd,
-                      address,
-                      start_server=None,
-                      start_client=(lambda daemon, h, port: daemon.start()),
-                      **kwargs)
-
-    connection_thread = threading.Thread(target=wait_for_connection,
-                                         args=(daemon, host, port),
-                                         name='ptvsd.listen_for_connection')
-    connection_thread.daemon = True
-    connection_thread.start()
-
-    _pydevd.settrace(host=host,
-                     stdoutToServer=redirect_output,
-                     stderrToServer=redirect_output,
-                     port=port,
-                     suspend=False)
 
 ##################################
 # the script
-
 
 """
 For the PyDevd CLI handling see:
@@ -308,20 +190,13 @@ def _parse_args(prog, argv):
     return args
 
 
-def debug_main(address, name, kind, *extra, **kwargs):
-    if kind == 'module':
-        run_module(address, name, *extra, **kwargs)
+def main(addr, name, kind, extra=(), nodebug=False):
+    if nodebug:
+        run_main(addr, name, kind, *extra)
     else:
-        run_file(address, name, *extra, **kwargs)
-
-
-def run_main(address, name, kind, *extra, **kwargs):
-    no_debug_runner(address, name, kind == 'module', *extra, **kwargs)
+        debug_main(addr, name, kind, *extra)
 
 
 if __name__ == '__main__':
     args, extra = parse_args()
-    if args.nodebug:
-        run_main(args.address, args.name, args.kind, *extra)
-    else:
-        debug_main(args.address, args.name, args.kind, *extra)
+    main(args.address, args.name, args.kind, extra, nodebug=args.nodebug)

--- a/ptvsd/_main.py
+++ b/ptvsd/_main.py
@@ -1,0 +1,139 @@
+import sys
+import threading
+import time
+
+import pydevd
+from _pydevd_bundle.pydevd_comm import get_global_debugger
+
+from ptvsd.pydevd_hooks import install
+from ptvsd.runner import run as no_debug_runner
+from ptvsd.socket import Address, create_server
+
+
+########################
+# high-level functions
+
+def debug_main(address, name, kind, *extra, **kwargs):
+    if kind == 'module':
+        run_module(address, name, *extra, **kwargs)
+    else:
+        run_file(address, name, *extra, **kwargs)
+
+
+def run_main(address, name, kind, *extra, **kwargs):
+    no_debug_runner(address, name, kind == 'module', *extra, **kwargs)
+
+
+########################
+# low-level functions
+
+def run_module(address, modname, *extra, **kwargs):
+    """Run pydevd for the given module."""
+    addr = Address.from_raw(address)
+    run = kwargs.pop('_run', _run)
+    prog = kwargs.pop('_prog', sys.argv[0])
+    filename = modname + ':'
+    argv = _run_argv(addr, filename, extra, _prog=prog)
+    argv.insert(argv.index('--file'), '--module')
+    run(argv, addr, **kwargs)
+
+
+def run_file(address, filename, *extra, **kwargs):
+    """Run pydevd for the given Python file."""
+    addr = Address.from_raw(address)
+    run = kwargs.pop('_run', _run)
+    prog = kwargs.pop('_prog', sys.argv[0])
+    argv = _run_argv(addr, filename, extra, _prog=prog)
+    run(argv, addr, **kwargs)
+
+
+def _run_argv(address, filename, extra, _prog=sys.argv[0]):
+    """Convert the given values to an argv that pydevd.main() supports."""
+    if '--' in extra:
+        pydevd = list(extra[:extra.index('--')])
+        extra = list(extra[len(pydevd) + 1:])
+    else:
+        pydevd = []
+        extra = list(extra)
+
+    host, port = address
+    argv = [
+        _prog,
+        '--port', str(port),
+    ]
+    if not address.isserver:
+        argv.extend([
+            '--client', host or 'localhost',
+        ])
+    return argv + pydevd + [
+        '--file', filename,
+    ] + extra
+
+
+def _run(argv, addr, _pydevd=pydevd, _install=install, **kwargs):
+    """Start pydevd with the given commandline args."""
+    #print(' '.join(argv))
+
+    # Pydevd assumes that the "__main__" module is the "pydevd" module
+    # and does some tricky stuff under that assumption.  For example,
+    # when the debugger starts up it calls save_main_module()
+    # (in pydevd_bundle/pydevd_utils.py).  That function explicitly sets
+    # sys.modules["pydevd"] to sys.modules["__main__"] and then sets
+    # the __main__ module to a new one.  This makes some sense since
+    # it gives the debugged script a fresh __main__ module.
+    #
+    # This complicates things for us since we are running a different
+    # file (i.e. this one) as the __main__ module.  Consequently,
+    # sys.modules["pydevd"] gets set to ptvsd/__main__.py.  Subsequent
+    # imports of the "pydevd" module then return the wrong module.  We
+    # work around this by avoiding lazy imports of the "pydevd" module.
+    # We also replace the __main__ module with the "pydevd" module here.
+    if sys.modules['__main__'].__file__ != _pydevd.__file__:
+        sys.modules['__main___orig'] = sys.modules['__main__']
+        sys.modules['__main__'] = _pydevd
+
+    daemon = _install(_pydevd, addr, **kwargs)
+    sys.argv[:] = argv
+    try:
+        _pydevd.main()
+    except SystemExit as ex:
+        daemon.exitcode = int(ex.code)
+        raise
+
+
+def enable_attach(address, redirect_output=True,
+                  _pydevd=pydevd, _install=install,
+                  on_attach=lambda: None, **kwargs):
+    host, port = address
+
+    def wait_for_connection(daemon, host, port):
+        debugger = get_global_debugger()
+        while debugger is None:
+            time.sleep(0.1)
+            debugger = get_global_debugger()
+
+        debugger.ready_to_run = True
+        server = create_server(host, port)
+        client, _ = server.accept()
+        daemon.set_connection(client)
+
+        daemon.re_build_breakpoints()
+        on_attach()
+
+    daemon = _install(_pydevd,
+                      address,
+                      start_server=None,
+                      start_client=(lambda daemon, h, port: daemon.start()),
+                      **kwargs)
+
+    connection_thread = threading.Thread(target=wait_for_connection,
+                                         args=(daemon, host, port),
+                                         name='ptvsd.listen_for_connection')
+    connection_thread.daemon = True
+    connection_thread.start()
+
+    _pydevd.settrace(host=host,
+                     stdoutToServer=redirect_output,
+                     stderrToServer=redirect_output,
+                     port=port,
+                     suspend=False)

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -4,12 +4,22 @@
 
 import threading
 
-from ptvsd.__main__ import run_module, run_file, enable_attach as ptvsd_enable_attach  # noqa
+# TODO: Why import run_module & run_file?
+from ptvsd._main import (  # noqa
+    run_module, run_file, enable_attach as ptvsd_enable_attach,
+)
 import pydevd
 
-from _pydevd_bundle.pydevd_custom_frames import CustomFramesContainer, custom_frames_container_init # noqa
-from _pydevd_bundle.pydevd_additional_thread_info import PyDBAdditionalThreadInfo # noqa
-from _pydevd_bundle.pydevd_comm import get_global_debugger, CMD_THREAD_SUSPEND
+# TODO: Why import these?
+from _pydevd_bundle.pydevd_custom_frames import (  # noqa
+    CustomFramesContainer, custom_frames_container_init,
+)
+from _pydevd_bundle.pydevd_additional_thread_info import (
+    PyDBAdditionalThreadInfo,
+)
+from _pydevd_bundle.pydevd_comm import (
+    get_global_debugger, CMD_THREAD_SUSPEND,
+)
 
 DEFAULT_HOST = '0.0.0.0'
 DEFAULT_PORT = 5678
@@ -61,7 +71,7 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
     if get_global_debugger() is not None:
         return
     _attached.clear()
-    ptvsd_enable_attach(address, redirect_output, on_attach=_attached.set) # noqa
+    ptvsd_enable_attach(address, redirect_output, on_attach=_attached.set)
 
 
 def is_attached():

--- a/ptvsd/debugger.py
+++ b/ptvsd/debugger.py
@@ -4,7 +4,7 @@
 
 import sys
 
-from ptvsd.__main__ import run_module, run_file
+from ptvsd._main import run_module, run_file
 
 
 # TODO: not needed?

--- a/tests/helpers/pydevd/_live.py
+++ b/tests/helpers/pydevd/_live.py
@@ -3,7 +3,7 @@ import os.path
 import threading
 import warnings
 
-import ptvsd.__main__
+import ptvsd._main
 from tests.helpers import protocol
 from ._binder import BinderBase
 
@@ -22,10 +22,10 @@ class Binder(BinderBase):
             self._start_ptvsd()
             return self.ptvsd.fakesock
         if self.module is None:
-            run = ptvsd.__main__.run_file
+            run = ptvsd._main.run_file
             name = self.filename
         else:
-            run = ptvsd.__main__.run_module
+            run = ptvsd._main.run_module
             name = self.module
         run(
             self.address,

--- a/tests/ptvsd/test___main__.py
+++ b/tests/ptvsd/test___main__.py
@@ -1,27 +1,27 @@
 import contextlib
-from io import StringIO
+from io import StringIO, BytesIO
 import sys
 import unittest
 
-from _pydevd_bundle import pydevd_comm
-
-import ptvsd.pydevd_hooks
 from ptvsd.socket import Address
-from ptvsd.__main__ import run_module, run_file, parse_args
+from ptvsd.__main__ import parse_args
+
 
 if sys.version_info < (3,):
-    from io import BytesIO as StringIO  # noqa
+    Buffer = BytesIO
+else:
+    Buffer = StringIO
 
 
 @contextlib.contextmanager
 def captured_stdio(out=None, err=None):
     if out is None:
         if err is None:
-            out = err = StringIO()
+            out = err = Buffer()
         elif err is False:
-            out = StringIO()
+            out = Buffer()
     elif err is None and out is False:
-        err = StringIO()
+        err = Buffer()
     if out is False:
         out = None
     if err is False:
@@ -36,312 +36,6 @@ def captured_stdio(out=None, err=None):
         yield out, err
     finally:
         sys.stdout, sys.stderr = orig
-
-
-class FakePyDevd(object):
-
-    def __init__(self, __file__, handle_main):
-        self.__file__ = __file__
-        self.handle_main = handle_main
-
-    @property
-    def __name__(self):
-        return object.__repr__(self)
-
-    def main(self):
-        self.handle_main()
-
-
-class RunBase(object):
-
-    def setUp(self):
-        super(RunBase, self).setUp()
-        self.argv = None
-        self.addr = None
-        self.kwargs = None
-
-    def _run(self, argv, addr, **kwargs):
-        self.argv = argv
-        self.addr = addr
-        self.kwargs = kwargs
-
-
-class RunModuleTests(RunBase, unittest.TestCase):
-
-    def test_local(self):
-        addr = (None, 8888)
-        run_module(addr, 'spam', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--module',
-            '--file', 'spam:',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_server(self):
-        addr = Address.as_server('10.0.1.1', 8888)
-        run_module(addr, 'spam', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--module',
-            '--file', 'spam:',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_remote(self):
-        addr = ('1.2.3.4', 8888)
-        run_module(addr, 'spam', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--client', '1.2.3.4',
-            '--module',
-            '--file', 'spam:',
-        ])
-        self.assertEqual(self.addr, Address.as_client(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_remote_localhost(self):
-        addr = Address.as_client(None, 8888)
-        run_module(addr, 'spam', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--client', 'localhost',
-            '--module',
-            '--file', 'spam:',
-        ])
-        self.assertEqual(self.addr, Address.as_client(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_extra(self):
-        addr = (None, 8888)
-        run_module(addr, 'spam', '--vm_type', 'xyz', '--', '--DEBUG',
-                   _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--vm_type', 'xyz',
-            '--module',
-            '--file', 'spam:',
-            '--DEBUG',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_executable(self):
-        addr = (None, 8888)
-        run_module(addr, 'spam', _run=self._run)
-
-        self.assertEqual(self.argv, [
-            sys.argv[0],
-            '--port', '8888',
-            '--module',
-            '--file', 'spam:',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-
-class RunScriptTests(RunBase, unittest.TestCase):
-
-    def test_local(self):
-        addr = (None, 8888)
-        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_server(self):
-        addr = Address.as_server('10.0.1.1', 8888)
-        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_remote(self):
-        addr = ('1.2.3.4', 8888)
-        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--client', '1.2.3.4',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.addr, Address.as_client(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_remote_localhost(self):
-        addr = Address.as_client(None, 8888)
-        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--client', 'localhost',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.addr, Address.as_client(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_extra(self):
-        addr = (None, 8888)
-        run_file(addr, 'spam.py', '--vm_type', 'xyz', '--', '--DEBUG',
-                 _run=self._run, _prog='eggs')
-
-        self.assertEqual(self.argv, [
-            'eggs',
-            '--port', '8888',
-            '--vm_type', 'xyz',
-            '--file', 'spam.py',
-            '--DEBUG',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-    def test_executable(self):
-        addr = (None, 8888)
-        run_file(addr, 'spam.py', _run=self._run)
-
-        self.assertEqual(self.argv, [
-            sys.argv[0],
-            '--port', '8888',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-
-
-class IntegratedRunTests(unittest.TestCase):
-
-    def setUp(self):
-        super(IntegratedRunTests, self).setUp()
-        self.___main__ = sys.modules['__main__']
-        self._argv = sys.argv
-        self._start_server = pydevd_comm.start_server
-        self._start_client = pydevd_comm.start_client
-
-        self.pydevd = None
-        self.addr = None
-        self.kwargs = None
-        self.maincalls = 0
-        self.mainexc = None
-        self.exitcode = -1
-
-    def tearDown(self):
-        sys.argv[:] = self._argv
-        sys.modules['__main__'] = self.___main__
-        sys.modules.pop('__main___orig', None)
-        pydevd_comm.start_server = self._start_server
-        pydevd_comm.start_client = self._start_client
-        # We shouldn't need to restore __main__.start_*.
-        super(IntegratedRunTests, self).tearDown()
-
-    def _install(self, pydevd, addr, **kwargs):
-        self.pydevd = pydevd
-        self.addr = addr
-        self.kwargs = kwargs
-        return self
-
-    def _main(self):
-        self.maincalls += 1
-        if self.mainexc is not None:
-            raise self.mainexc
-
-    def test_run(self):
-        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
-        addr = (None, 8888)
-        run_file(addr, 'spam.py', _pydevd=pydevd, _install=self._install)
-
-        self.assertEqual(self.pydevd, pydevd)
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-        self.assertEqual(self.maincalls, 1)
-        self.assertEqual(sys.argv, [
-            sys.argv[0],
-            '--port', '8888',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.exitcode, -1)
-
-    def test_failure(self):
-        self.mainexc = RuntimeError('boom!')
-        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
-        addr = (None, 8888)
-        with self.assertRaises(RuntimeError) as cm:
-            run_file(addr, 'spam.py', _pydevd=pydevd, _install=self._install)
-        exc = cm.exception
-
-        self.assertEqual(self.pydevd, pydevd)
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-        self.assertEqual(self.maincalls, 1)
-        self.assertEqual(sys.argv, [
-            sys.argv[0],
-            '--port', '8888',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.exitcode, -1)  # TODO: Is this right?
-        self.assertIs(exc, self.mainexc)
-
-    def test_exit(self):
-        self.mainexc = SystemExit(1)
-        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
-        addr = (None, 8888)
-        with self.assertRaises(SystemExit):
-            run_file(addr, 'spam.py', _pydevd=pydevd, _install=self._install)
-
-        self.assertEqual(self.pydevd, pydevd)
-        self.assertEqual(self.addr, Address.as_server(*addr))
-        self.assertEqual(self.kwargs, {})
-        self.assertEqual(self.maincalls, 1)
-        self.assertEqual(sys.argv, [
-            sys.argv[0],
-            '--port', '8888',
-            '--file', 'spam.py',
-        ])
-        self.assertEqual(self.exitcode, 1)
-
-    def test_installed(self):
-        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
-        addr = (None, 8888)
-        run_file(addr, 'spam.py', _pydevd=pydevd)
-
-        __main__ = sys.modules['__main__']
-        expected_server = ptvsd.pydevd_hooks.start_server
-        expected_client = ptvsd.pydevd_hooks.start_client
-        for mod in (pydevd_comm, pydevd, __main__):
-            start_server = getattr(mod, 'start_server')
-            if hasattr(start_server, 'orig'):
-                start_server = start_server.orig
-            start_client = getattr(mod, 'start_client')
-            if hasattr(start_client, 'orig'):
-                start_client = start_client.orig
-
-            self.assertIs(start_server, expected_server,
-                          '(module {})'.format(mod.__name__))
-            self.assertIs(start_client, expected_client,
-                          '(module {})'.format(mod.__name__))
 
 
 class ParseArgsTests(unittest.TestCase):

--- a/tests/ptvsd/test_main.py
+++ b/tests/ptvsd/test_main.py
@@ -1,0 +1,314 @@
+import sys
+import unittest
+
+from _pydevd_bundle import pydevd_comm
+
+import ptvsd.pydevd_hooks
+from ptvsd.socket import Address
+from ptvsd._main import run_module, run_file
+
+
+class FakePyDevd(object):
+
+    def __init__(self, __file__, handle_main):
+        self.__file__ = __file__
+        self.handle_main = handle_main
+
+    @property
+    def __name__(self):
+        return object.__repr__(self)
+
+    def main(self):
+        self.handle_main()
+
+
+class RunBase(object):
+
+    def setUp(self):
+        super(RunBase, self).setUp()
+        self.argv = None
+        self.addr = None
+        self.kwargs = None
+
+    def _run(self, argv, addr, **kwargs):
+        self.argv = argv
+        self.addr = addr
+        self.kwargs = kwargs
+
+
+class RunModuleTests(RunBase, unittest.TestCase):
+
+    def test_local(self):
+        addr = (None, 8888)
+        run_module(addr, 'spam', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--module',
+            '--file', 'spam:',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_server(self):
+        addr = Address.as_server('10.0.1.1', 8888)
+        run_module(addr, 'spam', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--module',
+            '--file', 'spam:',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_remote(self):
+        addr = ('1.2.3.4', 8888)
+        run_module(addr, 'spam', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--client', '1.2.3.4',
+            '--module',
+            '--file', 'spam:',
+        ])
+        self.assertEqual(self.addr, Address.as_client(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_remote_localhost(self):
+        addr = Address.as_client(None, 8888)
+        run_module(addr, 'spam', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--client', 'localhost',
+            '--module',
+            '--file', 'spam:',
+        ])
+        self.assertEqual(self.addr, Address.as_client(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_extra(self):
+        addr = (None, 8888)
+        run_module(addr, 'spam', '--vm_type', 'xyz', '--', '--DEBUG',
+                   _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--vm_type', 'xyz',
+            '--module',
+            '--file', 'spam:',
+            '--DEBUG',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_executable(self):
+        addr = (None, 8888)
+        run_module(addr, 'spam', _run=self._run)
+
+        self.assertEqual(self.argv, [
+            sys.argv[0],
+            '--port', '8888',
+            '--module',
+            '--file', 'spam:',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+
+class RunScriptTests(RunBase, unittest.TestCase):
+
+    def test_local(self):
+        addr = (None, 8888)
+        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_server(self):
+        addr = Address.as_server('10.0.1.1', 8888)
+        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_remote(self):
+        addr = ('1.2.3.4', 8888)
+        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--client', '1.2.3.4',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.addr, Address.as_client(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_remote_localhost(self):
+        addr = Address.as_client(None, 8888)
+        run_file(addr, 'spam.py', _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--client', 'localhost',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.addr, Address.as_client(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_extra(self):
+        addr = (None, 8888)
+        run_file(addr, 'spam.py', '--vm_type', 'xyz', '--', '--DEBUG',
+                 _run=self._run, _prog='eggs')
+
+        self.assertEqual(self.argv, [
+            'eggs',
+            '--port', '8888',
+            '--vm_type', 'xyz',
+            '--file', 'spam.py',
+            '--DEBUG',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+    def test_executable(self):
+        addr = (None, 8888)
+        run_file(addr, 'spam.py', _run=self._run)
+
+        self.assertEqual(self.argv, [
+            sys.argv[0],
+            '--port', '8888',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+
+
+class IntegratedRunTests(unittest.TestCase):
+
+    def setUp(self):
+        super(IntegratedRunTests, self).setUp()
+        self.___main__ = sys.modules['__main__']
+        self._argv = sys.argv
+        self._start_server = pydevd_comm.start_server
+        self._start_client = pydevd_comm.start_client
+
+        self.pydevd = None
+        self.addr = None
+        self.kwargs = None
+        self.maincalls = 0
+        self.mainexc = None
+        self.exitcode = -1
+
+    def tearDown(self):
+        sys.argv[:] = self._argv
+        sys.modules['__main__'] = self.___main__
+        sys.modules.pop('__main___orig', None)
+        pydevd_comm.start_server = self._start_server
+        pydevd_comm.start_client = self._start_client
+        # We shouldn't need to restore __main__.start_*.
+        super(IntegratedRunTests, self).tearDown()
+
+    def _install(self, pydevd, addr, **kwargs):
+        self.pydevd = pydevd
+        self.addr = addr
+        self.kwargs = kwargs
+        return self
+
+    def _main(self):
+        self.maincalls += 1
+        if self.mainexc is not None:
+            raise self.mainexc
+
+    def test_run(self):
+        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
+        addr = (None, 8888)
+        run_file(addr, 'spam.py', _pydevd=pydevd, _install=self._install)
+
+        self.assertEqual(self.pydevd, pydevd)
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+        self.assertEqual(self.maincalls, 1)
+        self.assertEqual(sys.argv, [
+            sys.argv[0],
+            '--port', '8888',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.exitcode, -1)
+
+    def test_failure(self):
+        self.mainexc = RuntimeError('boom!')
+        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
+        addr = (None, 8888)
+        with self.assertRaises(RuntimeError) as cm:
+            run_file(addr, 'spam.py', _pydevd=pydevd, _install=self._install)
+        exc = cm.exception
+
+        self.assertEqual(self.pydevd, pydevd)
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+        self.assertEqual(self.maincalls, 1)
+        self.assertEqual(sys.argv, [
+            sys.argv[0],
+            '--port', '8888',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.exitcode, -1)  # TODO: Is this right?
+        self.assertIs(exc, self.mainexc)
+
+    def test_exit(self):
+        self.mainexc = SystemExit(1)
+        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
+        addr = (None, 8888)
+        with self.assertRaises(SystemExit):
+            run_file(addr, 'spam.py', _pydevd=pydevd, _install=self._install)
+
+        self.assertEqual(self.pydevd, pydevd)
+        self.assertEqual(self.addr, Address.as_server(*addr))
+        self.assertEqual(self.kwargs, {})
+        self.assertEqual(self.maincalls, 1)
+        self.assertEqual(sys.argv, [
+            sys.argv[0],
+            '--port', '8888',
+            '--file', 'spam.py',
+        ])
+        self.assertEqual(self.exitcode, 1)
+
+    def test_installed(self):
+        pydevd = FakePyDevd('pydevd/pydevd.py', self._main)
+        addr = (None, 8888)
+        run_file(addr, 'spam.py', _pydevd=pydevd)
+
+        __main__ = sys.modules['__main__']
+        expected_server = ptvsd.pydevd_hooks.start_server
+        expected_client = ptvsd.pydevd_hooks.start_client
+        for mod in (pydevd_comm, pydevd, __main__):
+            start_server = getattr(mod, 'start_server')
+            if hasattr(start_server, 'orig'):
+                start_server = start_server.orig
+            start_client = getattr(mod, 'start_client')
+            if hasattr(start_client, 'orig'):
+                start_client = start_client.orig
+
+            self.assertIs(start_server, expected_server,
+                          '(module {})'.format(mod.__name__))
+            self.assertIs(start_client, expected_client,
+                          '(module {})'.format(mod.__name__))


### PR DESCRIPTION
(fixes #370)

This eliminates a warning emitted from runpy due to __init__.py indirectly importing __main__.py.