### PR TITLE
Suspend all threads on pause

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1622,12 +1622,8 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
                 )
                 return
 
-        vsc_tid = int(args['threadId'])
-        if vsc_tid == 0:  # VS does this to mean "stop all threads":
-            for pyd_tid in self.thread_map.pydevd_ids():
-                self.pydevd_notify(pydevd_comm.CMD_THREAD_SUSPEND, pyd_tid)
-        else:
-            pyd_tid = self.thread_map.to_pydevd(vsc_tid)
+        # Always suspend all threads.
+        for pyd_tid in self.thread_map.pydevd_ids():
             self.pydevd_notify(pydevd_comm.CMD_THREAD_SUSPEND, pyd_tid)
         self.send_response(request)
 

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -805,6 +805,15 @@ class VSCTest(object):
         expected = list(daemon.protocol.parse_each(expected))
         self.assertEqual(received, expected)
 
+    def assert_received_unordered_payload(self, daemon, expected):
+        """Ensure that the received messages match the expected ones
+        regardless of payload order."""
+        received = sorted(m.payload for m in
+                          daemon.protocol.parse_each(daemon.received))
+        expected = sorted(m.payload for m in
+                          daemon.protocol.parse_each(expected))
+        self.assertEqual(received, expected)
+
 
 class HighlevelTest(VSCTest):
     """The base mixin class for high-level ptvsd tests."""

--- a/tests/highlevel/test_messages.py
+++ b/tests/highlevel/test_messages.py
@@ -729,10 +729,10 @@ class PauseTests(NormalRequestTest, unittest.TestCase):
     PYDEVD_CMD = CMD_THREAD_SUSPEND
     PYDEVD_RESP = None
 
-    def test_pause_one(self):
+    def test_pause(self):
         with self.launched():
             with self.hidden():
-                threads = self.set_threads('spam', 'eggs')
+                threads = self.set_threads('spam', 'eggs', 'abc')
             tid, thread = threads[0]
             self.send_request(
                 threadId=tid,
@@ -743,14 +743,12 @@ class PauseTests(NormalRequestTest, unittest.TestCase):
             self.expected_response(),
             # no events
         ])
-        self.assert_received(self.debugger, [
-            self.expected_pydevd_request(str(thread.id)),
-        ])
 
-    # TODO: finish!
-    @unittest.skip('not finished')
-    def test_pause_all(self):
-        raise NotImplementedError
+        expected = [self.expected_pydevd_request('1')]
+        for _, t in threads:
+            expected.append(self.expected_pydevd_request(str(t.id)))
+
+        self.assert_received_unordered_payload(self.debugger, expected)
 
 
 class ContinueTests(NormalRequestTest, unittest.TestCase):


### PR DESCRIPTION
Fixes #349
The change here is to request all threads to be suspended. This is different from suspend policy, which is what we need for breakpoints to suspend all thread when a breakpoint is hit.