### PR TITLE
Perform case insensitive file path comparisons on windows

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1211,7 +1211,11 @@ class VSCodeMessageProcessor(ipcjson.SocketIO, ipcjson.IpcChannel):
         except KeyError:
             # If attaching to a local process (then remote and local are same)
             for local_prefix, remote_prefix in pydevd_file_utils.PATHS_FROM_ECLIPSE_TO_PYTHON: # noqa
-                if local_prefix == remote_prefix and filename.startswith(local_prefix): # noqa
+                if local_prefix != remote_prefix:
+                    continue
+                if filename.startswith(local_prefix): # noqa
+                    return 0
+                if platform.system() == 'Windows' and filename.upper().startswith(local_prefix.upper()): # noqa
                     return 0
 
         server_filename = pydevd_file_utils.norm_file_to_server(filename)


### PR DESCRIPTION
Fixes #447 
Note: This fix also requires a change in VSC Python Extension https://github.com/Microsoft/vscode-python/pull/1830