### PR TITLE
Wait-on-exit before sending "disconnect" response.

### DIFF
--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -350,6 +350,7 @@ class DaemonBase(object):
                     self.close()
                 except DaemonClosedError:
                     pass
+        return session
 
     def _release_session(self):
         session = self.session

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -382,12 +382,13 @@ class DaemonBase(object):
 
     def _handle_atexit(self):
         self._exiting_via_atexit_handler = True
+        session = self.session
         try:
             self.close()
         except DaemonClosedError:
             pass
-        if self.session is not None:
-            self.session.wait_until_stopped()
+        if session is not None:
+            session.wait_until_stopped()
 
     def _handle_signal(self, signum, frame):
         try:

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -54,7 +54,7 @@ class DaemonBase(object):
 
     SESSION = None
 
-    exitcode = 0
+    exitcode = None
 
     def __init__(self, wait_for_user=_wait_for_user,
                  addhandlers=True, killonclose=True,
@@ -255,7 +255,7 @@ class DaemonBase(object):
 
         self._sock = None
 
-        if self._wait_on_exit(self.exitcode):
+        if self._wait_on_exit(self.exitcode or 0):
             self._wait_for_user()
 
     def _stop(self):
@@ -349,11 +349,11 @@ class DaemonBase(object):
         if not self._singlesession:
             self._session = None
 
-        if stop:
-            exitcode = None
-            if self._server is None:
-                # Trigger a VSC "exited" event.
-                exitcode = self.exitcode or 0
+        if stop and session is not None:
+            # Possibly trigger VSC "exited" and "terminated" events.
+            exitcode = self.exitcode
+            if self._server is None or self._singlesession:
+                exitcode = exitcode or 0
             session.stop(exitcode)
             session.close()
 

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -283,7 +283,7 @@ class DaemonBase(object):
         with ignore_errors():
             self._stop()
 
-    def _handle_session_closing(self, session):
+    def _handle_session_closing(self, session, can_disconnect=None):
         debug('handling closing session')
 
         if self._exiting_via_atexit_handler:
@@ -293,6 +293,8 @@ class DaemonBase(object):
             wait_on_exit = session.get_wait_on_exit()
             if wait_on_exit(self.exitcode or 0):
                 self._wait_for_user()
+        if can_disconnect is not None:
+            can_disconnect()
 
         if self._singlesession:
             if self._killonclose:

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -36,7 +36,7 @@ class DebugSession(Startable, Closeable):
         if notify_closing is not None:
             def handle_closing(before):
                 if before:
-                    notify_closing(self)
+                    notify_closing(self, can_disconnect=self._can_disconnect)
             self.add_close_handler(handle_closing)
 
         self._sock = sock
@@ -55,6 +55,7 @@ class DebugSession(Startable, Closeable):
             self.add_close_handler(handle_closing)
 
         self._msgprocessor = None
+        self._can_disconnect = None
 
     @property
     def socket(self):
@@ -129,8 +130,9 @@ class DebugSession(Startable, Closeable):
 
     # internal methods for VSCodeMessageProcessor
 
-    def _handle_vsc_disconnect(self):
+    def _handle_vsc_disconnect(self, can_disconnect=None):
         debug('disconnecting')
+        self._can_disconnect = can_disconnect
         try:
             self.close()
         except ClosedError:

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -33,20 +33,20 @@ class DebugSession(Startable, Closeable):
     def __init__(self, sock, notify_closing=None, ownsock=False):
         super(DebugSession, self).__init__()
 
-        self._sock = sock
-        if ownsock:
-            # TODO: Close the socket *after* calling sys.exit() (via notify_closing).
-            def handle_closing(before):
-                if before:
-                    return
-                close_socket(self._sock)
-            self.add_close_handler(handle_closing)
-
         if notify_closing is not None:
             def handle_closing(before):
                 if not before:
                     return
                 notify_closing(self)
+            self.add_close_handler(handle_closing)
+
+        self._sock = sock
+        if ownsock:
+            # Close the socket *after* calling sys.exit() (via notify_closing).
+            def handle_closing(before):
+                if before:
+                    return
+                close_socket(self._sock)
             self.add_close_handler(handle_closing)
 
         self._msgprocessor = None

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -1,6 +1,6 @@
 from .socket import is_socket, close_socket
 from .wrapper import VSCodeMessageProcessor
-from ._util import ClosedError, Closeable, Startable, debug
+from ._util import TimeoutError, ClosedError, Closeable, Startable, debug
 
 
 class DebugSession(Startable, Closeable):
@@ -35,9 +35,8 @@ class DebugSession(Startable, Closeable):
 
         if notify_closing is not None:
             def handle_closing(before):
-                if not before:
-                    return
-                notify_closing(self)
+                if before:
+                    notify_closing(self)
             self.add_close_handler(handle_closing)
 
         self._sock = sock
@@ -46,6 +45,12 @@ class DebugSession(Startable, Closeable):
             def handle_closing(before):
                 if before:
                     return
+                proc = self._msgprocessor
+                if proc is not None:
+                    try:
+                        proc.wait_while_connected(10)  # seconds
+                    except TimeoutError:
+                        debug('timed out waiting for disconnect')
                 close_socket(self._sock)
             self.add_close_handler(handle_closing)
 
@@ -61,16 +66,18 @@ class DebugSession(Startable, Closeable):
 
     def wait_options(self):
         """Return (normal, abnormal) based on the session's launch config."""
-        if self._msgprocessor is None:
+        proc = self._msgprocessor
+        if proc is None:
             return (False, False)
-        return self._msgprocessor._wait_options()
+        return proc._wait_options()
 
     def wait_until_stopped(self):
         """Block until all resources (e.g. message processor) have stopped."""
-        if self._msgprocessor is None:
+        proc = self._msgprocessor
+        if proc is None:
             return
         # TODO: Do this in VSCodeMessageProcessor.close()?
-        self._msgprocessor._wait_for_server_thread()
+        proc._wait_for_server_thread()
 
     def get_wait_on_exit(self):
         """Return a wait_on_exit(exitcode) func.

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -789,7 +789,7 @@ class VSCodeMessageProcessorBase(ipcjson.SocketIO, ipcjson.IpcChannel):
     """The base class for VSC message processors."""
 
     def __init__(self, socket, notify_closing,
-                 timeout=None, logfile=None,
+                 timeout=None, logfile=None, own_socket=False
                  ):
         super(VSCodeMessageProcessorBase, self).__init__(
             socket=socket,
@@ -798,6 +798,7 @@ class VSCodeMessageProcessorBase(ipcjson.SocketIO, ipcjson.IpcChannel):
             logfile=logfile,
         )
         self.socket = socket
+        self._own_socket = own_socket
         self._notify_closing = notify_closing
 
         self.server_thread = None
@@ -869,7 +870,7 @@ class VSCodeMessageProcessorBase(ipcjson.SocketIO, ipcjson.IpcChannel):
     def _stop_vsc_message_loop(self):
         self.set_exit()
         self._stop_event_loop()
-        if self.socket:
+        if self.socket is not None and self._own_socket:
             try:
                 self.socket.shutdown(socket.SHUT_RDWR)
                 self.socket.close()

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1031,9 +1031,9 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
 
     def on_disconnect(self, request, args):
         # TODO: docstring
+        self._notify_disconnecting()
         self.disconnect_request = request
         self.disconnect_request_event.set()
-        self._notify_disconnecting()
         # TODO: We should be able drop the remaining lines.
         if not self._closed and self.start_reason == 'launch':
             # Closing the socket causes pydevd to resume all threads,

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -931,7 +931,7 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         self._notify_launch = notify_launch or (lambda: None)
         self._notify_disconnecting = notify_disconnecting
 
-        self._exited = False
+        self._stopped = False
 
         # adapter state
         self.disconnect_request = None
@@ -941,9 +941,9 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
 
     def handle_session_stopped(self, exitcode=None):
         """Finalize the protocol connection."""
-        if self._exited:
+        if self._stopped:
             return
-        self._exited = True
+        self._stopped = True
 
         if exitcode is not None:
             # Notify the editor that the "debuggee" (e.g. script, app) exited.

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -948,8 +948,8 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         if exitcode is not None:
             # Notify the editor that the "debuggee" (e.g. script, app) exited.
             self.send_event('exited', exitCode=exitcode)
-        # Notify the editor that the debugger has stopped.
-        self.send_event('terminated')
+            # Notify the editor that the debugger has stopped.
+            self.send_event('terminated')
 
         # The editor will send a "disconnect" request at this point.
         self._wait_for_disconnect()

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -160,7 +160,7 @@ class EasyDebugClient(DebugClient):
 
         def run():
             self._session = DebugSession.create_server(addr, **kwargs)
-        t = threading.Thread(target=run)
+        t = threading.Thread(target=run, name='ptvsd.test.client')
         t.start()
 
         def wait():

--- a/tests/helpers/debugsession.py
+++ b/tests/helpers/debugsession.py
@@ -275,4 +275,4 @@ class DebugSession(Closeable):
         try:
             yield
         finally:
-            wait(timeout or self._timeout, handlername)
+            wait(timeout or self._timeout, handlername, fail=True)

--- a/tests/helpers/debugsession.py
+++ b/tests/helpers/debugsession.py
@@ -116,6 +116,8 @@ class DebugSession(Closeable):
     HOST = 'localhost'
     PORT = 8888
 
+    TIMEOUT = None
+
     @classmethod
     def create_client(cls, addr=None, **kwargs):
         if addr is None:
@@ -264,6 +266,8 @@ class DebugSession(Closeable):
 
     @contextlib.contextmanager
     def _wait_for_message(self, match, handlername, timeout=None):
+        if timeout is None:
+            timeout = self.TIMEOUT
         lock, wait = get_locked_and_waiter()
 
         def handler(msg):

--- a/tests/helpers/debugsession.py
+++ b/tests/helpers/debugsession.py
@@ -147,7 +147,10 @@ class DebugSession(Closeable):
             else:
                 self._add_handler(*handler)
         self._received = []
-        self._listenerthread = threading.Thread(target=self._listen)
+        self._listenerthread = threading.Thread(
+            target=self._listen,
+            name='ptvsd.test.session',
+        )
         self._listenerthread.start()
 
     @property

--- a/tests/helpers/http.py
+++ b/tests/helpers/http.py
@@ -28,7 +28,9 @@ class Server:
             raise RuntimeError('already started')
         self._server = HTTPServer(self._addr, self.handler)
         self._thread = threading.Thread(
-                target=lambda: self._server.serve_forever())
+            target=(lambda: self._server.serve_forever()),
+            name='ptvsd.test.http',
+        )
         self._thread.start()
 
     def stop(self):

--- a/tests/helpers/protocol.py
+++ b/tests/helpers/protocol.py
@@ -174,7 +174,10 @@ class Daemon(object):
         def run():
             self._sock = connect()
             self._handle_connected()
-        t = threading.Thread(target=run)
+        t = threading.Thread(
+            target=run,
+            name='ptvsd.test.daemon',
+        )
         t.pydev_do_not_trace = True
         t.is_pydev_daemon_thread  = True
         t.start()
@@ -292,7 +295,10 @@ class MessageDaemon(Daemon):
 
     def _handle_connected(self):
         # TODO: make it a daemon thread?
-        self._listener = threading.Thread(target=self._listen)
+        self._listener = threading.Thread(
+            target=self._listen,
+            name='ptvsd.test.msgdaemon',
+        )
         self._listener.pydev_do_not_trace = True
         self._listener.is_pydev_daemon_thread = True
         self._listener.start()

--- a/tests/helpers/pydevd/_binder.py
+++ b/tests/helpers/pydevd/_binder.py
@@ -18,14 +18,17 @@ class PTVSD(ptvsd.daemon.Daemon):
     """
 
     @classmethod
-    def from_connect_func(cls, connect):
+    def from_connect_func(cls, connect, singlesession=None):
         """Return a new instance using the socket returned by connect()."""
+        client, server = connect()
+        if singlesession is None:
+            singlesession = (server is None)
         self = cls(
             wait_for_user=(lambda: None),
             addhandlers=False,
             killonclose=False,
+            singlesession=singlesession,
         )
-        client, server = connect()
         self.start()
         self.start_session(client, 'ptvsd.Server')
         self.server = server
@@ -70,9 +73,11 @@ class BinderBase(object):
     runs the debugger in the background.
     """
 
-    def __init__(self, address=None, ptvsd=None):
+    def __init__(self, address=None, ptvsd=None, singlesession=None):
         if address is not None or ptvsd is not None:
             raise NotImplementedError
+
+        self.singlesession = singlesession
 
         # Set when bind() called:
         self.address = None
@@ -150,7 +155,10 @@ class BinderBase(object):
     def _start_ptvsd(self):
         if self.ptvsd is not None:
             raise RuntimeError('already connected')
-        self.ptvsd = PTVSD.from_connect_func(self._connect)
+        self.ptvsd = PTVSD.from_connect_func(
+            self._connect,
+            singlesession=self.singlesession,
+        )
         self._waiter.release()
 
     def _run(self):

--- a/tests/helpers/pydevd/_binder.py
+++ b/tests/helpers/pydevd/_binder.py
@@ -122,6 +122,8 @@ class BinderBase(object):
         def connect():
             if self._thread is not None:
                 raise RuntimeError('already connected')
+            # We do not give this thread a name because we actually do
+            # want ptvsd to track it.
             self._thread = threading.Thread(target=self._run)
             self._thread.start()
             # Wait for ptvsd to start up.

--- a/tests/helpers/pydevd/_fake.py
+++ b/tests/helpers/pydevd/_fake.py
@@ -19,8 +19,10 @@ PROTOCOL = protocol.MessageProtocol(
 
 class Binder(BinderBase):
 
-    def __init__(self):
-        super(Binder, self).__init__()
+    def __init__(self, singlesession=True):
+        super(Binder, self).__init__(
+            singlesession=singlesession,
+        )
         self._lock = threading.Lock()
         self._lock.acquire()
 
@@ -108,8 +110,8 @@ class FakePyDevd(protocol.MessageDaemon):
         else:
             return None
 
-    def __init__(self, handler=None):
-        self.binder = Binder()
+    def __init__(self, handler=None, **kwargs):
+        self.binder = Binder(**kwargs)
 
         super(FakePyDevd, self).__init__(
             self.binder.bind,

--- a/tests/helpers/pydevd/_live.py
+++ b/tests/helpers/pydevd/_live.py
@@ -11,8 +11,11 @@ from ._binder import BinderBase
 
 class Binder(BinderBase):
 
-    def __init__(self, filename, module, **kwargs):
-        super(Binder, self).__init__(**kwargs)
+    def __init__(self, filename, module, singlesession=True, **kwargs):
+        super(Binder, self).__init__(
+            singlesession=singlesession,
+            **kwargs
+        )
         self.filename = filename
         self.module = module
         self._lock = threading.Lock()

--- a/tests/helpers/threading.py
+++ b/tests/helpers/threading.py
@@ -5,6 +5,8 @@ import threading
 import time
 import warnings
 
+from ptvsd._util import TimeoutError
+
 
 if sys.version_info < (3,):
     def acquire_with_timeout(lock, timeout):
@@ -26,14 +28,16 @@ def get_locked_and_waiter(timeout=1.0):
     lock = threading.Lock()
     lock.acquire()
 
-    def wait(timeout=_timeout, reason=None):
+    def wait(timeout=_timeout, reason=None, fail=False):
         if timeout is None:
             timeout = _timeout
         if acquire_with_timeout(lock, timeout):
             lock.release()
         else:
-            msg = 'timed out waiting'
+            msg = 'timed out (after {} seconds) waiting'.format(timeout)
             if reason:
                 msg += ' for {}'.format(reason)
-            warnings.warn(msg)
+            if fail:
+                raise TimeoutError(msg)
+            warnings.warn(msg, stacklevel=2)
     return lock, wait

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -239,7 +239,10 @@ class VSCLifecycle(object):
         # socket (i.e. "daemon").  This is because cloing ptvsd blocks,
         # keeping us from sending the disconnect request we need to send
         # at the end.
-        t = threading.Thread(target=self._fix.close_ptvsd)
+        t = threading.Thread(
+            target=self._fix.close_ptvsd,
+            name='ptvsd.test.lifecycle',
+        )
         with self._fix.wait_for_events(['exited', 'terminated']):
             # The thread runs close_ptvsd(), which sends the two
             # events and then waits for a "disconnect" request.  We send

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -605,12 +605,14 @@ class VSCFixture(FixtureBase):
         self.send_request('threads', handle_response=handle_response)
         return threads, threads.pop(None)
 
-    def close_ptvsd(self):
+    def close_ptvsd(self, exitcode=None):
         # TODO: Use the session instead.
         if self._proc is None:
             warnings.warn('"proc" not bound')
         else:
             self._proc.close()
+        self.daemon.exitcode = exitcode
+        self.daemon.close()
 
 
 class HighlevelFixture(object):

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -198,7 +198,7 @@ class VSCLifecycle(object):
             self._handshake('attach', **kwargs)
 
     def disconnect(self, exitcode=0, **reqargs):
-        self._fix.exitcode = exitcode
+        self._fix.daemon.exitcode = exitcode
         self._send_request('disconnect', reqargs)
         # TODO: wait for an exit event?
         # TODO: call self._fix.vsc.close()?
@@ -545,7 +545,7 @@ class VSCFixture(FixtureBase):
             return self._lifecycle
 
     @property
-    def _daemon(self):
+    def daemon(self):
         # TODO: This is a horrendous use of internal details!
         return self.fake._adapter.daemon.binder.ptvsd
 
@@ -553,18 +553,10 @@ class VSCFixture(FixtureBase):
     def _proc(self):
         # This is used below in close_ptvsd().
         try:
-            return self._daemon.proc
+            return self.daemon.proc
         except AttributeError:
-            # TODO: Fall back to self._daemon.session._msgprocessor?
+            # TODO: Fall back to self.daemon.session._msgprocessor?
             return None
-
-    @property
-    def exitcode(self):
-        return self._daemon.exitcode
-
-    @exitcode.setter
-    def exitcode(self, value):
-        self._daemon.exitcode = value
 
     def send_request(self, cmd, args=None, handle_response=None, timeout=1):
         kwargs = dict(args or {}, handler=handle_response)
@@ -700,12 +692,8 @@ class HighlevelFixture(object):
         return self._vsc.ishidden and self._pydevd.ishidden
 
     @property
-    def exitcode(self):
-        return self._vsc.exitcode
-
-    @exitcode.setter
-    def exitcode(self, value):
-        self._vsc.exitcode = value
+    def daemon(self):
+        return self._vsc.daemon
 
     @contextlib.contextmanager
     def hidden(self):
@@ -763,8 +751,8 @@ class HighlevelFixture(object):
     def send_debugger_event(self, cmdid, payload):
         self._pydevd.send_event(cmdid, payload)
 
-    def close_ptvsd(self):
-        self._vsc.close_ptvsd()
+    def close_ptvsd(self, **kwargs):
+        self._vsc.close_ptvsd(**kwargs)
 
     # combinations
 

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -170,6 +170,7 @@ class VSCFlowTest(TestBase):
     @contextlib.contextmanager
     def launched(self, port=8888, **kwargs):
         kwargs.setdefault('process', False)
+        kwargs.setdefault('disconnect', False)
         with self.lifecycle.launched(port=port, hide=True, **kwargs):
             yield
             self.fix.binder.done(close=False)

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -375,6 +375,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'name': filename,
             }),
             self.new_event('output', output='success!', category='stdout'),
+            self.new_event('exited', exitCode=0),
+            self.new_event('terminated'),
         ])
         self.assertIn('success!', out)
 
@@ -431,6 +433,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'startMethod': 'attach',
                 'name': filename,
             }),
+            self.new_event('exited', exitCode=0),
+            self.new_event('terminated'),
         ])
 
     @unittest.skip('not implemented')

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -501,7 +501,7 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             done()
             adapter.wait()
 
-        self.assert_received(session.received, [
+        self.assert_received(session.received[:11], [
             self.new_version_event(session.received),
             self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -251,8 +251,7 @@ class LifecycleTests(TestsBase, unittest.TestCase):
 
         # Skipping the 'thread exited' and 'terminated' messages which
         # may appear randomly in the received list.
-        received = session.received[:8]
-        self.assert_received(received, [
+        self.assert_received(session.received[:7], [
             self.new_version_event(session.received),
             self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
@@ -265,7 +264,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'name': filename,
             }),
             self.new_event('thread', reason='started', threadId=1),
-            self.new_event('exited', exitCode=0),
         ])
 
     def test_launch_ptvsd_server(self):
@@ -286,7 +284,7 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             adapter.wait()
 
         self.maxDiff = None
-        self.assert_received(session.received, [
+        self.assert_received(session.received[:7], [
             self.new_version_event(session.received),
             self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
@@ -299,8 +297,9 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'name': filename,
             }),
             self.new_event('thread', reason='started', threadId=1),
-            self.new_event('exited', exitCode=0),
-            self.new_event('terminated'),
+            #self.new_event('thread', reason='exited', threadId=1),
+            #self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
         ])
 
     def test_attach_started_separately(self):
@@ -319,7 +318,7 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 done()
                 adapter.wait()
 
-        self.assert_received(session.received, [
+        self.assert_received(session.received[:7], [
             self.new_version_event(session.received),
             self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
@@ -332,8 +331,9 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'name': filename,
             }),
             self.new_event('thread', reason='started', threadId=1),
-            self.new_event('exited', exitCode=0),
-            self.new_event('terminated'),
+            #self.new_event('thread', reason='exited', threadId=1),
+            #self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
         ])
 
     def test_attach_embedded(self):

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -99,7 +99,6 @@ class CLITests(TestsBase, unittest.TestCase):
             )
             lifecycle_handshake(session, 'launch')
             lockwait(timeout=2.0)
-            session.send_request('disconnect')
         out = adapter.output
 
         self.assertIn(u"[{!r}, '--eggs']".format(filename),

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -375,8 +375,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'name': filename,
             }),
             self.new_event('output', output='success!', category='stdout'),
-            self.new_event('exited', exitCode=0),
-            self.new_event('terminated'),
         ])
         self.assertIn('success!', out)
 
@@ -405,7 +403,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
 
                 adapter.wait()
 
-        # self.maxDiff = None
         self.assert_received(session1.received, [
             self.new_version_event(session1.received),
             self.new_response(reqs[0], **INITIALIZE_RESPONSE),
@@ -420,8 +417,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             }),
             self.new_event('thread', reason='started', threadId=1),
             self.new_response(req_disconnect),
-            # TODO: Shouldn't there be a "terminated" event?
-            # self.new_event('terminated'),
         ])
         self.messages.reset_all()
         self.assert_received(session2.received, [
@@ -436,9 +431,12 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'startMethod': 'attach',
                 'name': filename,
             }),
-            self.new_event('exited', exitCode=0),
-            self.new_event('terminated'),
         ])
+
+    @unittest.skip('not implemented')
+    def test_attach_exit_during_session(self):
+        # TODO: Ensure we see the "terminated" and "exited" events.
+        raise NotImplementedError
 
     @unittest.skip('re-attach needs fixing')
     def test_attach_unknown(self):


### PR DESCRIPTION
(fixes gh-459)

We must wait-for-user before the "disconnect" response is sent.  This PR fixes that.