### PR TITLE
Handle exit explicitly.

### DIFF
--- a/ptvsd/_util.py
+++ b/ptvsd/_util.py
@@ -51,6 +51,12 @@ def call_all(callables, *args, **kwargs):
 # threading stuff
 
 try:
+    ThreadError = threading.ThreadError
+except AttributeError:
+    ThreadError = RuntimeError
+
+
+try:
     base = __builtins__.TimeoutError
 except AttributeError:
     base = OSError
@@ -101,7 +107,7 @@ def lock_release(lock):
         return
     try:
         lock.release()
-    except RuntimeError:  # already unlocked
+    except ThreadError:  # already unlocked
         pass
 
 
@@ -112,7 +118,7 @@ def lock_wait(lock, timeout=None, reason='waiting for lock'):
     lock_release(lock)
 
 
-if sys.version_info > (2,):
+if sys.version_info >= (3,):
     def _lock_acquire(lock, timeout):
         if timeout is None:
             timeout = -1

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -283,18 +283,8 @@ class DaemonBase(object):
         with ignore_errors():
             self._stop()
 
-    def _handle_session_closing(self, session, can_disconnect=None):
+    def _handle_session_closing(self, session):
         debug('handling closing session')
-
-        if self._exiting_via_atexit_handler:
-            # This must be done before we send a disconnect response
-            # (which implies before we close the client socket).
-            # TODO: Call session.wait_on_exit() directly?
-            wait_on_exit = session.get_wait_on_exit()
-            if wait_on_exit(self.exitcode or 0):
-                self._wait_for_user()
-        if can_disconnect is not None:
-            can_disconnect()
 
         if self._singlesession:
             if self._killonclose:
@@ -407,7 +397,7 @@ class DaemonBase(object):
         if session is not None:
             # TODO: Rely on self._stop_debugger().
             session.handle_debugger_stopped()
-            session.handle_exiting(self.exitcode)
+            session.handle_exiting(self.exitcode, self._wait_for_user)
 
         try:
             self.close()

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -366,13 +366,8 @@ class DaemonBase(object):
             # TODO: This shouldn't happen if we are exiting?
             self._session = None
 
-        # Possibly trigger VSC "exited" and "terminated" events.
-        exitcode = self.exitcode
-        if exitcode is None:
-            if self._exiting_via_atexit_handler or self._singlesession:
-                exitcode = 0
         try:
-            session.stop(exitcode)
+            session.stop()
         except NotRunningError:
             pass
         try:
@@ -408,6 +403,12 @@ class DaemonBase(object):
         with self._lock:
             self._exiting_via_atexit_handler = True
         session = self.session
+
+        if session is not None:
+            # TODO: Rely on self._stop_debugger().
+            session.handle_debugger_stopped()
+            session.handle_exiting(self.exitcode)
+
         try:
             self.close()
         except DaemonClosedError:

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -133,7 +133,7 @@ class DebugSession(Startable, Closeable):
         # The editor will send a "disconnect" request at this point.
         proc._wait_for_disconnect()
         proc.close()
-        proc = None
+        self._msgprocessor = None
 
     def _close(self):
         debug('session closing')

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -72,6 +72,20 @@ class DebugSession(Startable, Closeable):
             return (False, False)
         return proc._wait_options()
 
+    def handle_debugger_stopped(self):
+        """Deal with the debugger exiting."""
+        proc = self._msgprocessor
+        if proc is None:
+            return
+        proc.handle_debugger_stopped()
+
+    def handle_exiting(self, exitcode=None):
+        """Deal with the debuggee exiting."""
+        proc = self._msgprocessor
+        if proc is None:
+            return
+        proc.handle_exiting(exitcode)
+
     def wait_until_stopped(self):
         """Block until all resources (e.g. message processor) have stopped."""
         proc = self._msgprocessor
@@ -116,8 +130,8 @@ class DebugSession(Startable, Closeable):
 
         debug('proc stopping')
         if exitcode is not None:
-            proc.handle_debugger_stopped()
-            proc.handle_exiting(exitcode)
+            self.handle_debugger_stopped()
+            self.handle_exiting(exitcode)
         # TODO: We should not need to wait if not exiting.
         # The editor will send a "disconnect" request at this point.
         proc._wait_for_disconnect()

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -69,12 +69,12 @@ class DebugSession(Startable, Closeable):
     def msgprocessor(self):
         return self._msgprocessor
 
-    def handle_debugger_stopped(self):
+    def handle_debugger_stopped(self, wait=None):
         """Deal with the debugger exiting."""
         proc = self._msgprocessor
         if proc is None:
             return
-        proc.handle_debugger_stopped()
+        proc.handle_debugger_stopped(wait)
 
     def handle_exiting(self, exitcode=None, wait=None):
         """Deal with the debuggee exiting."""

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -123,15 +123,12 @@ class DebugSession(Startable, Closeable):
         self._msgprocessor.start(threadname)
         return self._msgprocessor_running
 
-    def _stop(self, exitcode=None):
+    def _stop(self):
         proc = self._msgprocessor
         if proc is None:
             return
 
         debug('proc stopping')
-        if exitcode is not None:
-            self.handle_debugger_stopped()
-            self.handle_exiting(exitcode)
         # TODO: We should not need to wait if not exiting.
         # The editor will send a "disconnect" request at this point.
         proc._wait_for_disconnect()

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -69,13 +69,6 @@ class DebugSession(Startable, Closeable):
     def msgprocessor(self):
         return self._msgprocessor
 
-    def wait_options(self):
-        """Return (normal, abnormal) based on the session's launch config."""
-        proc = self._msgprocessor
-        if proc is None:
-            return (False, False)
-        return proc._wait_options()
-
     def handle_debugger_stopped(self):
         """Deal with the debugger exiting."""
         proc = self._msgprocessor

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -986,28 +986,15 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         self.start_reason = None
         self.debug_options = {}
 
-    def handle_terminated(self):
+    def handle_debugger_stopped(self):
         """Deal with the debugger exiting."""
         # Notify the editor that the debugger has stopped.
         self.send_event('terminated')
 
-    def handle_exited(self, exitcode):
+    def handle_exiting(self, exitcode=None):
         """Deal with the debuggee exiting."""
         # Notify the editor that the "debuggee" (e.g. script, app) exited.
-        self.send_event('exited', exitCode=exitcode)
-
-    def handle_session_stopped(self, exitcode=None):
-        """Finalize the protocol connection."""
-        if self._stopped:
-            return
-        self._stopped = True
-
-        if exitcode is not None:
-            self.handle_terminated()
-            self.handle_exited(exitcode)
-
-        # The editor will send a "disconnect" request at this point.
-        self._wait_for_disconnect()
+        self.send_event('exited', exitCode=exitcode or 0)
 
     # VSC protocol handlers
 

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -998,7 +998,7 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         # Notify the editor that the "debuggee" (e.g. script, app) exited.
         self.send_event('exited', exitCode=exitcode or 0)
 
-        if exitcode and wait is not None:
+        if wait is not None:
             normal, abnormal = self._wait_options()
             if (normal and not exitcode) or (abnormal and exitcode):
                 # This must be done before we send a disconnect response

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -49,7 +49,6 @@ from ptvsd.socket import TimeoutError  # noqa
 #ipcjson._TRACE = ipcjson_trace
 
 
-WAIT_FOR_DISCONNECT_REQUEST_TIMEOUT = 2
 WAIT_FOR_THREAD_FINISH_TIMEOUT = 1
 
 
@@ -1030,7 +1029,7 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
 
     def on_disconnect(self, request, args):
         # TODO: docstring
-        #self._notify_disconnecting()
+        self._notify_disconnecting()
         self.send_response(request)
         self._set_disconnected()
 

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1102,12 +1102,6 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
     # methods related to shutdown
 
     def _wait_options(self):
-        # In attach scenarios, we can't assume that the process is actually
-        # interactive and has a console, so ignore these options.
-        # In launch scenarios, we only want "press any key" to show up when
-        # program terminates by itself, not when user explicitly stops it.
-        if self.disconnect_request or self.start_reason != 'launch':
-            return False, False
         normal = self.debug_options.get('WAIT_ON_NORMAL_EXIT', False)
         abnormal = self.debug_options.get('WAIT_ON_ABNORMAL_EXIT', False)
         return normal, abnormal

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1016,6 +1016,9 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
                 # (which implies before we close the client socket).
                 wait()
 
+        # If we are exiting then pydevd must have stopped.
+        self._ensure_debugger_stopped()
+
         if self._exitlock is not None:
             lock_release(self._exitlock)
 

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -986,6 +986,16 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         self.start_reason = None
         self.debug_options = {}
 
+    def handle_terminated(self):
+        """Deal with the debugger exiting."""
+        # Notify the editor that the debugger has stopped.
+        self.send_event('terminated')
+
+    def handle_exited(self, exitcode):
+        """Deal with the debuggee exiting."""
+        # Notify the editor that the "debuggee" (e.g. script, app) exited.
+        self.send_event('exited', exitCode=exitcode)
+
     def handle_session_stopped(self, exitcode=None):
         """Finalize the protocol connection."""
         if self._stopped:
@@ -993,10 +1003,8 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         self._stopped = True
 
         if exitcode is not None:
-            # Notify the editor that the "debuggee" (e.g. script, app) exited.
-            self.send_event('exited', exitCode=exitcode)
-            # Notify the editor that the debugger has stopped.
-            self.send_event('terminated')
+            self.handle_terminated()
+            self.handle_exited(exitcode)
 
         # The editor will send a "disconnect" request at this point.
         self._wait_for_disconnect()

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -243,7 +243,8 @@ class VSCLifecycle(object):
             target=self._fix.close_ptvsd,
             name='ptvsd.test.lifecycle',
         )
-        with self._fix.wait_for_events(['exited', 'terminated']):
+        #with self._fix.wait_for_events(['exited', 'terminated']):
+        if True:
             # The thread runs close_ptvsd(), which sends the two
             # events and then waits for a "disconnect" request.  We send
             # that after we receive the events.

--- a/tests/highlevel/test_lifecycle.py
+++ b/tests/highlevel/test_lifecycle.py
@@ -141,8 +141,8 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
             # Normal ops would go here.
 
             # end
-            with self.fix.wait_for_events(['exited', 'terminated']):
-                req_disconnect = self.send_request('disconnect')
+            #with self.fix.wait_for_events(['exited', 'terminated']):
+            req_disconnect = self.send_request('disconnect')
 
         self.assert_received(self.vsc, [
             self.new_event(
@@ -160,8 +160,8 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
             #    isLocalProcess=True,
             #    startMethod='launch',
             #)),
-            self.new_event('terminated'),
-            self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
+            #self.new_event('exited', exitCode=0),
             self.new_response(req_disconnect),
         ])
         self.assert_received(self.debugger, [

--- a/tests/highlevel/test_lifecycle.py
+++ b/tests/highlevel/test_lifecycle.py
@@ -69,7 +69,7 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
             # Normal ops would go here.
 
             # end
-            req_disconnect = self.send_request('disconnect')
+            #req_disconnect = self.send_request('disconnect')
         finally:
             received = self.vsc.received
             with self._fix.wait_for_events(['exited', 'terminated']):
@@ -93,7 +93,6 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
                isLocalProcess=True,
                startMethod='attach',
             )),
-            self.new_response(req_disconnect),
         ])
         self.assert_received(self.debugger, [
             self.debugger_msgs.new_request(CMD_VERSION,

--- a/tests/highlevel/test_lifecycle.py
+++ b/tests/highlevel/test_lifecycle.py
@@ -160,8 +160,8 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
             #    isLocalProcess=True,
             #    startMethod='launch',
             #)),
-            #self.new_event('terminated'),
             #self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
             self.new_response(req_disconnect),
         ])
         self.assert_received(self.debugger, [

--- a/tests/highlevel/test_lifecycle.py
+++ b/tests/highlevel/test_lifecycle.py
@@ -161,8 +161,8 @@ class LifecycleTests(HighlevelTest, unittest.TestCase):
             #    isLocalProcess=True,
             #    startMethod='launch',
             #)),
-            self.new_event('exited', exitCode=0),
             self.new_event('terminated'),
+            self.new_event('exited', exitCode=0),
             self.new_response(req_disconnect),
         ])
         self.assert_received(self.debugger, [

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -157,8 +157,8 @@ class LifecycleTests(TestBase, unittest.TestCase):
                 startMethod='attach',
             )),
             self.new_event('thread', reason='started', threadId=1),
-            self.new_event('terminated'),
-            self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
+            #self.new_event('exited', exitCode=0),
         ])
 
 ##################################

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -157,8 +157,8 @@ class LifecycleTests(TestBase, unittest.TestCase):
                 startMethod='attach',
             )),
             self.new_event('thread', reason='started', threadId=1),
-            self.new_event('exited', exitCode=0),
             self.new_event('terminated'),
+            self.new_event('exited', exitCode=0),
         ])
 
 ##################################

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -157,8 +157,8 @@ class LifecycleTests(TestBase, unittest.TestCase):
                 startMethod='attach',
             )),
             self.new_event('thread', reason='started', threadId=1),
-            #self.new_event('terminated'),
             #self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
         ])
 
 ##################################

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -297,8 +297,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             }),
             self.new_event('thread', reason='started', threadId=1),
             #self.new_event('thread', reason='exited', threadId=1),
-            #self.new_event('exited', exitCode=0),
             #self.new_event('terminated'),
+            #self.new_event('exited', exitCode=0),
         ])
 
     def test_attach_started_separately(self):
@@ -331,8 +331,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             }),
             self.new_event('thread', reason='started', threadId=1),
             #self.new_event('thread', reason='exited', threadId=1),
-            #self.new_event('exited', exitCode=0),
             #self.new_event('terminated'),
+            #self.new_event('exited', exitCode=0),
         ])
 
     def test_attach_embedded(self):
@@ -374,8 +374,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'name': filename,
             }),
             self.new_event('output', output='success!', category='stdout'),
-            self.new_event('exited', exitCode=0),
             self.new_event('terminated'),
+            self.new_event('exited', exitCode=0),
         ])
         self.assertIn('success!', out)
 
@@ -432,8 +432,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'startMethod': 'attach',
                 'name': filename,
             }),
-            self.new_event('exited', exitCode=0),
             self.new_event('terminated'),
+            self.new_event('exited', exitCode=0),
         ])
 
     @unittest.skip('not implemented')
@@ -473,8 +473,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             self.new_event('initialized'),
             self.new_response(req_launch),
             self.new_response(req_config),
-            self.new_event('exited', exitCode=0),
             self.new_event('terminated'),
+            self.new_event('exited', exitCode=0),
         ])
 
     def test_nodebug(self):
@@ -519,6 +519,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             self.new_event('output',
                            output='\n',
                            category='stdout'),
-            self.new_event('exited', exitCode=0),
             self.new_event('terminated'),
+            self.new_event('exited', exitCode=0),
         ])

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -297,8 +297,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             }),
             self.new_event('thread', reason='started', threadId=1),
             #self.new_event('thread', reason='exited', threadId=1),
-            #self.new_event('terminated'),
             #self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
         ])
 
     def test_attach_started_separately(self):
@@ -331,8 +331,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             }),
             self.new_event('thread', reason='started', threadId=1),
             #self.new_event('thread', reason='exited', threadId=1),
-            #self.new_event('terminated'),
             #self.new_event('exited', exitCode=0),
+            #self.new_event('terminated'),
         ])
 
     def test_attach_embedded(self):
@@ -374,8 +374,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'name': filename,
             }),
             self.new_event('output', output='success!', category='stdout'),
-            self.new_event('terminated'),
             self.new_event('exited', exitCode=0),
+            self.new_event('terminated'),
         ])
         self.assertIn('success!', out)
 
@@ -432,8 +432,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
                 'startMethod': 'attach',
                 'name': filename,
             }),
-            self.new_event('terminated'),
             self.new_event('exited', exitCode=0),
+            self.new_event('terminated'),
         ])
 
     @unittest.skip('not implemented')
@@ -473,8 +473,8 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             self.new_event('initialized'),
             self.new_response(req_launch),
             self.new_response(req_config),
-            self.new_event('terminated'),
             self.new_event('exited', exitCode=0),
+            self.new_event('terminated'),
         ])
 
     def test_nodebug(self):
@@ -519,6 +519,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             self.new_event('output',
                            output='\n',
                            category='stdout'),
-            self.new_event('terminated'),
             self.new_event('exited', exitCode=0),
+            self.new_event('terminated'),
         ])


### PR DESCRIPTION
(fixes gh-459)

Our exit handling was all over the place.  I've refactored the code to properly separate concerns.  One consequence is that this fixes wait-on-exit.