### PR TITLE
Fix for #501 and #479 (issues related to pausing a thread with debugger.set_suspend)

### DIFF
--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -346,7 +346,7 @@ class PyDBDaemonThread(threading.Thread):
                 disable_tracing = False
 
             if disable_tracing:
-                pydevd_tracing.SetTrace(None)  # no debugging on this thread
+                pydevd_tracing.SetTrace(None, apply_to_pydevd_thread=True)  # no debugging on this thread
 
 
 #=======================================================================================================================

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
@@ -26,7 +26,6 @@ get_file_type = DONT_TRACE.get
 # ELSE
 # ENDIF
 
-
 # Cache where we should keep that we completely skipped entering some context.
 # It needs to be invalidated when:
 # - Breakpoints are changed
@@ -79,6 +78,7 @@ def trace_dispatch(py_db, frame, event, arg):
         thread = threadingCurrentThread()
 
     if getattr(thread, 'pydev_do_not_trace', None):
+        SetTrace(None, apply_to_pydevd_thread=True)
         return None
 
     try:

--- a/ptvsd/_vendored/pydevd/pydevd_tracing.py
+++ b/ptvsd/_vendored/pydevd/pydevd_tracing.py
@@ -69,7 +69,7 @@ def _internal_set_trace(tracing_func):
         TracingFunctionHolder._original_tracing(tracing_func)
 
 
-def SetTrace(tracing_func, frame_eval_func=None, dummy_tracing_func=None):
+def SetTrace(tracing_func, frame_eval_func=None, dummy_tracing_func=None, apply_to_pydevd_thread=False):
     if tracing_func is not None and frame_eval_func is not None:
         # There is no need to set tracing function if frame evaluation is available
         frame_eval_func()
@@ -82,8 +82,9 @@ def SetTrace(tracing_func, frame_eval_func=None, dummy_tracing_func=None):
 
     current_thread = threading.currentThread()
     do_not_trace_before = getattr(current_thread, 'pydev_do_not_trace', None)
-    if do_not_trace_before:
-        return
+    if not apply_to_pydevd_thread:
+        if do_not_trace_before:
+            return
     try:
         TracingFunctionHolder._lock.acquire()
         current_thread.pydev_do_not_trace = True  # avoid settrace reentering

--- a/ptvsd/_vendored/pydevd/runfiles.py
+++ b/ptvsd/_vendored/pydevd/runfiles.py
@@ -262,8 +262,6 @@ def main():
 
             argv.append('-p')
             argv.append('_pydev_runfiles.pydev_runfiles_pytest2')
-            if 'unittest' in sys.modules or 'unittest2' in sys.modules:
-                sys.stderr.write('pydev test runner error: imported unittest before running pytest.main\n')
             return pytest.main(argv)
 
         else:

--- a/ptvsd/_vendored/pydevd/tests_python/_debugger_case_settrace.py
+++ b/ptvsd/_vendored/pydevd/tests_python/_debugger_case_settrace.py
@@ -1,0 +1,26 @@
+def ask_for_stop(use_back):
+    import pydevd
+    if use_back:
+        pydevd.settrace(stop_at_frame=sys._getframe().f_back)
+    else:
+        pydevd.settrace()
+    print('Will stop here if use_back==False.')
+
+
+def outer_method():
+    ask_for_stop(True)
+    print('will stop here.')
+    ask_for_stop(False)
+
+
+if __name__ == '__main__':
+    import os
+    import sys
+    root_dirname = os.path.dirname(os.path.dirname(__file__))
+    
+    if root_dirname not in sys.path:
+        sys.path.append(root_dirname)
+
+    outer_method()        
+    print('TEST SUCEEDED!')
+    

--- a/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
+++ b/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
@@ -1491,6 +1491,28 @@ class WriterThreadCaseHandledExceptions3(debugger_unittest.AbstractWriterThread)
         self.finished_ok = True
 
 #=======================================================================================================================
+# WriterCaseSetTrace
+#======================================================================================================================
+class WriterCaseSetTrace(debugger_unittest.AbstractWriterThread):
+
+    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_settrace.py')
+
+    def run(self):
+        self.start_socket()
+            
+        self.write_make_initial_run()
+        
+        thread_id, frame_id, line = self.wait_for_breakpoint_hit('108', True)
+        assert line == 12, 'Expected return to be in line 12, was: %s' % line
+        self.write_run_thread(thread_id)
+        
+        thread_id, frame_id, line = self.wait_for_breakpoint_hit('105', True)
+        assert line == 7, 'Expected return to be in line 7, was: %s' % line
+        self.write_run_thread(thread_id)
+
+        self.finished_ok = True
+
+#=======================================================================================================================
 # WriterThreadCaseRedirectOutput
 #======================================================================================================================
 class WriterThreadCaseRedirectOutput(debugger_unittest.AbstractWriterThread):
@@ -1740,6 +1762,9 @@ class Test(unittest.TestCase, debugger_unittest.DebuggerRunner):
     def test_case_handled_exceptions3(self):
         self.check_case(WriterThreadCaseHandledExceptions3)
         
+    def test_case_settrace(self):
+        self.check_case(WriterCaseSetTrace)
+
     def test_redirect_output(self):
         self.check_case(WriterThreadCaseRedirectOutput)
 

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -5,21 +5,13 @@
 import threading
 
 import pydevd
-# TODO: Why import these?
-from _pydevd_bundle.pydevd_custom_frames import (  # noqa
-    CustomFramesContainer, custom_frames_container_init,
-)
-from _pydevd_bundle.pydevd_additional_thread_info import (
-    PyDBAdditionalThreadInfo,
-)
 from _pydevd_bundle.pydevd_comm import (
-    get_global_debugger, CMD_THREAD_SUSPEND,
+    get_global_debugger,
 )
 
 # TODO: Why import run_module & run_file?
 from ptvsd._local import run_module, run_file  # noqa
 from ptvsd._remote import enable_attach as ptvsd_enable_attach
-
 
 DEFAULT_HOST = '0.0.0.0'
 DEFAULT_PORT = 5678
@@ -73,7 +65,6 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
     _attached.clear()
     ptvsd_enable_attach(address, redirect_output, on_attach=_attached.set)
 
-
 # TODO: Add disable_attach()?
 
 
@@ -90,11 +81,9 @@ def break_into_debugger():
     if not _attached.isSet() or debugger is None:
         return
 
-    thread = pydevd.threadingCurrentThread()
-    try:
-        additional_info = thread.additional_info
-    except AttributeError:
-        additional_info = PyDBAdditionalThreadInfo()
-        thread.additional_info = additional_info
-
-    debugger.set_suspend(thread, CMD_THREAD_SUSPEND)
+    import sys
+    pydevd.settrace(
+        suspend=True,
+        trace_only_current_thread=True,
+        patch_multiprocessing=False,
+        stop_at_frame=sys._getframe().f_back)


### PR DESCRIPTION
This patch makes sure that:
- When a thread is suspended the stepping function is properly set (otherwise it may end up not breaking if the function was previously cached to be skipped).
- pydevd threads are not traced even if the tracing function is set on them.
- Changes settrace to let users pass where exactly the tracing should pause and use that API to make the pause from ptvsd as the previous approach had some issues if a given function had been previously skipped and currently had no tracing set.
