### PR TITLE
GH-512: Fix single-frame stack trace handling.

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1491,6 +1491,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
                 # This means the stack was requested before the
                 # thread was suspended
                 xframes = []
+            else:
+                xframes = list(xframes)
         totalFrames = len(xframes)
 
         if levels == 0:

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1491,8 +1491,6 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
                 # This means the stack was requested before the
                 # thread was suspended
                 xframes = []
-            else:
-                xframes = list(xframes)
         totalFrames = len(xframes)
 
         if levels == 0:
@@ -2186,7 +2184,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         vsc_tid = self.thread_map.to_vscode(pyd_tid, autogen=False)
 
         with self.stack_traces_lock:
-            self.stack_traces[pyd_tid] = xml.thread.frame
+            self.stack_traces[pyd_tid] = list(xml.thread.frame)
 
         description = None
         text = None

--- a/tests/highlevel/test_messages.py
+++ b/tests/highlevel/test_messages.py
@@ -281,6 +281,36 @@ class StackTraceTests(NormalRequestTest, unittest.TestCase):
         ])
         self.assert_received(self.debugger, [])
 
+    def test_one_frame(self):
+        with self.launched():
+            with self.hidden():
+                tid, thread = self.set_thread('x')
+                self.suspend(thread, CMD_THREAD_SUSPEND, *[
+                    # (pfid, func, file, line)
+                    (2, 'spam', 'abc.py', 10),
+                ])
+            self.send_request(
+                threadId=tid,
+            )
+            received = self.vsc.received
+
+        self.assert_vsc_received(received, [
+            self.expected_response(
+                stackFrames=[
+                    {
+                        'id': 1,
+                        'name': 'spam',
+                        'source': {'path': 'abc.py', 'sourceReference': 0},
+                        'line': 10,
+                        'column': 1,
+                    },
+                ],
+                totalFrames=1,
+            ),
+            # no events
+        ])
+        self.assert_received(self.debugger, [])
+
     def test_with_frame_format(self):
         with self.launched():
             with self.hidden():


### PR DESCRIPTION
(fixes #512)

The XML library we are using treats a single-item list as a single item instead of a list.  This breaks `on_stackTrace()`.  This PR fixes the problem by converting `xframes` to a list before checking its size.