### PR TITLE
Re-enable disabled test from prior PR

### DIFF
--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -351,7 +351,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
         out = _strip_pydevd_output(out)
         self.assertEqual(out, '')
 
-    @unittest.skipUnless(os.environ.get('HAS_NETWORK'), 'no network')
     def test_launch_ptvsd_client(self):
         argv = []
         lockfile = self.workspace.lockfile()


### PR DESCRIPTION
Remove the `skipUnless` condition I introduced in a prior PR.

- [x] Unit test affected run in VSTS cleanly