### PR TITLE
Add breakpoints before CMD_RUN is issued.

### DIFF
--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -5,7 +5,7 @@ import pydevd
 from _pydevd_bundle.pydevd_comm import get_global_debugger
 
 from ptvsd.pydevd_hooks import install
-from ptvsd.socket import create_server
+from ptvsd.socket import create_server, Address
 
 
 # TODO: Split up enable_attach() to align with module organization.
@@ -14,43 +14,47 @@ from ptvsd.socket import create_server
 # Then move at least some parts to the appropriate modules.  This module
 # is focused on running the debugger.
 
-def enable_attach(address, redirect_output=True,
+def enable_attach(address,
+                  on_attach=(lambda: None),
+                  redirect_output=True,
                   _pydevd=pydevd, _install=install,
-                  on_attach=lambda: None, **kwargs):
-    host, port = address
+                  **kwargs):
+    daemon = _install(
+        _pydevd,
+        address,
+        start_server=None,
+        start_client=(lambda daemon, h, p: daemon.start()),
+        notify_session_ready_to_debug=(lambda s: on_attach()),
+        singlesession=False,
+        **kwargs
+    )
+    _start_pydevd(daemon, address, redirect_output, _pydevd)
 
-    def wait_for_connection(daemon, host, port):
+
+def _start_pydevd(daemon, address, redirect_output, _pydevd):
+    addr = Address.from_raw(address)
+
+    def wait_for_connection():
         debugger = get_global_debugger()
         while debugger is None:
             time.sleep(0.1)
             debugger = get_global_debugger()
 
         debugger.ready_to_run = True
-        server = create_server(host, port)
+        server = create_server(addr.host, addr.port)
         client, _ = server.accept()
         daemon.start_session(client, 'ptvsd.Server')
-
-    def notify_ready_to_debug(session):
-        on_attach()
-
-    daemon = _install(_pydevd,
-                      address,
-                      start_server=None,
-                      start_client=(lambda daemon, h, port: daemon.start()),
-                      notify_session_ready_to_debug=notify_ready_to_debug,
-                      singlesession=False,
-                      **kwargs)
-
     connection_thread = threading.Thread(target=wait_for_connection,
-                                         args=(daemon, host, port),
                                          name='ptvsd.listen_for_connection')
     connection_thread.pydev_do_not_trace = True
     connection_thread.is_pydev_daemon_thread = True
     connection_thread.daemon = True
     connection_thread.start()
 
-    _pydevd.settrace(host=host,
-                     stdoutToServer=redirect_output,
-                     stderrToServer=redirect_output,
-                     port=port,
-                     suspend=False)
+    _pydevd.settrace(
+        host=addr.host,
+        stdoutToServer=redirect_output,
+        stderrToServer=redirect_output,
+        port=addr.port,
+        suspend=False,
+    )

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -31,7 +31,6 @@ def enable_attach(address, redirect_output=True,
         daemon.start_session(client, 'ptvsd.Server')
 
     def notify_ready_to_debug(session):
-        session.re_build_breakpoints()
         on_attach()
 
     daemon = _install(_pydevd,

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -24,7 +24,7 @@ def enable_attach(address,
         address,
         start_server=None,
         start_client=(lambda daemon, h, p: daemon.start()),
-        notify_session_ready_to_debug=(lambda s: on_attach()),
+        notify_session_debugger_ready=(lambda s: on_attach()),
         singlesession=False,
         **kwargs
     )

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -30,13 +30,15 @@ def enable_attach(address, redirect_output=True,
         client, _ = server.accept()
         daemon.start_session(client, 'ptvsd.Server')
 
-        daemon.re_build_breakpoints()
+    def notify_ready_to_debug(session):
+        session.re_build_breakpoints()
         on_attach()
 
     daemon = _install(_pydevd,
                       address,
                       start_server=None,
                       start_client=(lambda daemon, h, port: daemon.start()),
+                      notify_session_ready_to_debug=notify_ready_to_debug,
                       singlesession=False,
                       **kwargs)
 

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -1,11 +1,7 @@
-import threading
-import time
-
 import pydevd
-from _pydevd_bundle.pydevd_comm import get_global_debugger
 
-from ptvsd.pydevd_hooks import install
-from ptvsd.socket import create_server, Address
+from ptvsd.pydevd_hooks import install, start_server
+from ptvsd.socket import Address
 
 
 # TODO: Split up enable_attach() to align with module organization.
@@ -19,42 +15,22 @@ def enable_attach(address,
                   redirect_output=True,
                   _pydevd=pydevd, _install=install,
                   **kwargs):
+    addr = Address.as_server(*address)
+    # pydevd.settrace() forces a "client" connection, so we trick it
+    # by setting start_client to start_server..
     daemon = _install(
         _pydevd,
-        address,
-        start_server=None,
-        start_client=(lambda daemon, h, p: daemon.start()),
+        addr,
+        start_client=start_server,
         notify_session_debugger_ready=(lambda s: on_attach()),
         singlesession=False,
         **kwargs
     )
-    _start_pydevd(daemon, address, redirect_output, _pydevd)
-
-
-def _start_pydevd(daemon, address, redirect_output, _pydevd):
-    addr = Address.from_raw(address)
-
-    def wait_for_connection():
-        debugger = get_global_debugger()
-        while debugger is None:
-            time.sleep(0.1)
-            debugger = get_global_debugger()
-
-        debugger.ready_to_run = True
-        server = create_server(addr.host, addr.port)
-        client, _ = server.accept()
-        daemon.start_session(client, 'ptvsd.Server')
-    connection_thread = threading.Thread(target=wait_for_connection,
-                                         name='ptvsd.listen_for_connection')
-    connection_thread.pydev_do_not_trace = True
-    connection_thread.is_pydev_daemon_thread = True
-    connection_thread.daemon = True
-    connection_thread.start()
-
+    # Only pass the port so start_server() gets triggered.
     _pydevd.settrace(
-        host=addr.host,
         stdoutToServer=redirect_output,
         stderrToServer=redirect_output,
         port=addr.port,
         suspend=False,
     )
+    return daemon

--- a/ptvsd/_util.py
+++ b/ptvsd/_util.py
@@ -144,6 +144,22 @@ def _wait(check, timeout):
         return False
 
 
+def new_hidden_thread(name, target, prefix='ptvsd.', daemon=True, **kwargs):
+    """Return a thread that will be ignored by pydevd."""
+    if prefix is not None and not name.startswith(prefix):
+        name = prefix + name
+    t = threading.Thread(
+        name=name,
+        target=target,
+        **kwargs
+    )
+    t.pydev_do_not_trace = True
+    if daemon:
+        t.is_pydev_daemon_thread = True
+        t.daemon = True
+    return t
+
+
 ########################
 # closing stuff
 

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -63,7 +63,11 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
     if get_global_debugger() is not None:
         return
     _attached.clear()
-    ptvsd_enable_attach(address, redirect_output, on_attach=_attached.set)
+    ptvsd_enable_attach(
+        address,
+        on_attach=_attached.set,
+        redirect_output=redirect_output,
+    )
 
 # TODO: Add disable_attach()?
 

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -5,17 +5,16 @@
 import threading
 
 import pydevd
-from _pydevd_bundle.pydevd_comm import (
-    get_global_debugger,
-)
 
 # TODO: Why import run_module & run_file?
 from ptvsd._local import run_module, run_file  # noqa
 from ptvsd._remote import enable_attach as ptvsd_enable_attach
 
+
 DEFAULT_HOST = '0.0.0.0'
 DEFAULT_PORT = 5678
 
+_enabled = False
 _attached = threading.Event()
 
 
@@ -60,9 +59,12 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
     attached. Any threads that are already running before this function is
     called will not be visible.
     """
-    if get_global_debugger() is not None:
+    global _enabled
+    if _enabled:
         return
+    _enabled = True
     _attached.clear()
+
     ptvsd_enable_attach(
         address,
         on_attach=_attached.set,
@@ -81,8 +83,7 @@ def break_into_debugger():
     """If a remote debugger is attached, pauses execution of all threads,
     and breaks into the debugger with current thread as active.
     """
-    debugger = get_global_debugger()
-    if not _attached.isSet() or debugger is None:
+    if not _attached.isSet() or not _enabled:
         return
 
     import sys
@@ -90,4 +91,5 @@ def break_into_debugger():
         suspend=True,
         trace_only_current_thread=True,
         patch_multiprocessing=False,
-        stop_at_frame=sys._getframe().f_back)
+        stop_at_frame=sys._getframe().f_back,
+    )

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -479,12 +479,6 @@ class Daemon(DaemonBase):
     def pydevd(self):
         return self._sock
 
-    def re_build_breakpoints(self):
-        """Restore the breakpoints to their last values."""
-        if self.session is None:
-            return
-        return self.session.re_build_breakpoints()
-
     # internal methods
 
     def _start(self):

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -469,11 +469,11 @@ class Daemon(DaemonBase):
     SESSION = PyDevdDebugSession
 
     def __init__(self, wait_for_user=_wait_for_user,
-                 notify_session_ready_to_debug=None,
+                 notify_session_debugger_ready=None,
                  **kwargs):
         super(Daemon, self).__init__(wait_for_user, **kwargs)
 
-        self._notify_session_ready_to_debug = notify_session_ready_to_debug
+        self._notify_session_debugger_ready = notify_session_debugger_ready
 
     @property
     def pydevd(self):
@@ -498,12 +498,12 @@ class Daemon(DaemonBase):
         )
 
     def _session_kwargs(self):
-        def ready_to_debug(session):
-            if self._notify_session_ready_to_debug is not None:
-                self._notify_session_ready_to_debug(session)
+        def debugger_ready(session):
+            if self._notify_session_debugger_ready is not None:
+                self._notify_session_debugger_ready(session)
 
         return dict(
-            notify_ready_to_debug=ready_to_debug,
+            notify_debugger_ready=debugger_ready,
         )
 
     # internal methods for PyDevdSocket().

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -57,7 +57,8 @@ class DaemonBase(object):
 
     exitcode = None
 
-    def __init__(self, wait_for_user=_wait_for_user, notify_debugging=None,
+    def __init__(self, wait_for_user=_wait_for_user,
+                 notify_ready_to_debug=None,
                  addhandlers=True, killonclose=True,
                  singlesession=False):
 
@@ -73,7 +74,7 @@ class DaemonBase(object):
 
         # session-related
 
-        self._notify_debugging = notify_debugging
+        self._notify_ready_to_debug = notify_ready_to_debug
         self._singlesession = singlesession
 
         self._session = None
@@ -285,10 +286,10 @@ class DaemonBase(object):
         with ignore_errors():
             self._stop()
 
-    def _handle_session_debugging(self, session):
+    def _handle_session_ready_to_debug(self, session):
         debug('handling started debugging')
-        if self._notify_debugging is not None:
-            self._notify_debugging(session)
+        if self._notify_ready_to_debug is not None:
+            self._notify_ready_to_debug(session)
 
     def _handle_session_disconnecting(self, session):
         debug('handling disconnecting session')
@@ -349,7 +350,7 @@ class DaemonBase(object):
             session,
             notify_closing=self._handle_session_closing,
             notify_disconnecting=self._handle_session_disconnecting,
-            notify_debugging=self._handle_session_debugging,
+            notify_ready_to_debug=self._handle_session_ready_to_debug,
             ownsock=True,
         )
         self._session = session

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -57,7 +57,7 @@ class DaemonBase(object):
 
     exitcode = None
 
-    def __init__(self, wait_for_user=_wait_for_user,
+    def __init__(self, wait_for_user=_wait_for_user, notify_debugging=None,
                  addhandlers=True, killonclose=True,
                  singlesession=False):
 
@@ -73,6 +73,7 @@ class DaemonBase(object):
 
         # session-related
 
+        self._notify_debugging = notify_debugging
         self._singlesession = singlesession
 
         self._session = None
@@ -284,6 +285,11 @@ class DaemonBase(object):
         with ignore_errors():
             self._stop()
 
+    def _handle_session_debugging(self, session):
+        debug('handling started debugging')
+        if self._notify_debugging is not None:
+            self._notify_debugging(session)
+
     def _handle_session_disconnecting(self, session):
         debug('handling disconnecting session')
         if self._singlesession:
@@ -338,10 +344,12 @@ class DaemonBase(object):
     # internal session-related methods
 
     def _bind_session(self, session):
+        # TODO: Pass notify_* to session.start() instead.
         session = self.SESSION.from_raw(
             session,
             notify_closing=self._handle_session_closing,
             notify_disconnecting=self._handle_session_disconnecting,
+            notify_debugging=self._handle_session_debugging,
             ownsock=True,
         )
         self._session = session

--- a/ptvsd/pydevd_hooks.py
+++ b/ptvsd/pydevd_hooks.py
@@ -1,11 +1,10 @@
 import sys
-import threading
 
 from _pydevd_bundle import pydevd_comm
 
 from ptvsd.socket import Address
 from ptvsd.daemon import Daemon, DaemonStoppedError, DaemonClosedError
-from ptvsd._util import debug
+from ptvsd._util import debug, new_hidden_thread
 
 
 def start_server(daemon, host, port, **kwargs):
@@ -46,13 +45,10 @@ def start_server(daemon, host, port, **kwargs):
                 break
         debug('done')
 
-    t = threading.Thread(
+    t = new_hidden_thread(
         target=serve_forever,
-        name='ptvsd.sessions',
-        )
-    t.pydev_do_not_trace = True
-    t.is_pydev_daemon_thread = True
-    t.daemon = True
+        name='sessions',
+    )
     t.start()
     return sock
 

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -152,18 +152,18 @@ class PyDevdDebugSession(DebugSession):
     MESSAGE_PROCESSOR = VSCodeMessageProcessor
 
     def __init__(self, sock,
-                 notify_ready_to_debug=None,
+                 notify_debugger_ready=None,
                  **kwargs):
         super(PyDevdDebugSession, self).__init__(sock, **kwargs)
 
-        def notify_ready_to_debug(session, _notify=notify_ready_to_debug):
-            if self._notified_ready_to_debug:
+        def notify_debugger_ready(session, _notify=notify_debugger_ready):
+            if self._notified_debugger_ready:
                 return
-            self._notified_ready_to_debug = True
+            self._notified_debugger_ready = True
             if _notify is not None:
                 _notify(session)
-        self._notified_ready_to_debug = False
-        self._notify_ready_to_debug = notify_ready_to_debug
+        self._notified_debugger_ready = False
+        self._notify_debugger_ready = notify_debugger_ready
 
     def handle_pydevd_message(self, cmdid, seq, text):
         if self._msgprocessor is None:
@@ -175,12 +175,12 @@ class PyDevdDebugSession(DebugSession):
 
     def _new_msg_processor(self, **kwargs):
         return super(PyDevdDebugSession, self)._new_msg_processor(
-            notify_ready_to_debug=self._handle_vsc_ready_to_debug,
+            notify_debugger_ready=self._handle_vsc_debugger_ready,
             **kwargs
         )
 
     # internal methods for VSCodeMessageProcessor
 
-    def _handle_vsc_ready_to_debug(self):
+    def _handle_vsc_debugger_ready(self):
         debug('ready to debug')
-        self._notify_ready_to_debug(self)
+        self._notify_debugger_ready(self)

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -33,7 +33,7 @@ class DebugSession(Startable, Closeable):
     def __init__(self, sock,
                  notify_closing=None,
                  notify_disconnecting=None,
-                 notify_debugging=None,
+                 notify_ready_to_debug=None,
                  ownsock=False):
         super(DebugSession, self).__init__()
 
@@ -47,14 +47,14 @@ class DebugSession(Startable, Closeable):
             notify_disconnecting = (lambda _: None)
         self._notify_disconnecting = notify_disconnecting
 
-        def notify_debugging(session, _notify=notify_debugging):
-            if self._notified_debugging:
+        def notify_ready_to_debug(session, _notify=notify_ready_to_debug):
+            if self._notified_ready_to_debug:
                 return
-            self._notified_debugging = True
+            self._notified_ready_to_debug = True
             if _notify is not None:
                 _notify(session)
-        self._notified_debugging = False
-        self._notify_debugging = notify_debugging
+        self._notified_ready_to_debug = False
+        self._notify_ready_to_debug = notify_ready_to_debug
 
         self._sock = sock
         if ownsock:
@@ -108,7 +108,7 @@ class DebugSession(Startable, Closeable):
     def _new_msg_processor(self, **kwargs):
         return self.MESSAGE_PROCESSOR(
             self._sock,
-            notify_debugging=self._handle_vsc_debugging,
+            notify_ready_to_debug=self._handle_vsc_ready_to_debug,
             notify_disconnecting=self._handle_vsc_disconnect,
             notify_closing=self._handle_vsc_close,
             **kwargs
@@ -145,9 +145,9 @@ class DebugSession(Startable, Closeable):
 
     # internal methods for VSCodeMessageProcessor
 
-    def _handle_vsc_debugging(self):
-        debug('debugging')
-        self._notify_debugging(self)
+    def _handle_vsc_ready_to_debug(self):
+        debug('ready to debug')
+        self._notify_ready_to_debug(self)
 
     def _handle_vsc_disconnect(self):
         debug('disconnecting')

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -171,12 +171,6 @@ class PyDevdDebugSession(DebugSession):
             return
         return self._msgprocessor.on_pydevd_event(cmdid, seq, text)
 
-    def re_build_breakpoints(self):
-        """Restore the breakpoints to their last values."""
-        if self._msgprocessor is None:
-            return
-        return self._msgprocessor.re_build_breakpoints()
-
     # internal methods
 
     def _new_msg_processor(self, **kwargs):

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1080,11 +1080,14 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         self.send_response(request)
         self._set_disconnected()
 
-        # TODO: We should be able drop the remaining lines.
-        if not self._closed and self.start_reason == 'launch':
-            # Closing the socket causes pydevd to resume all threads,
-            # so just terminate the process altogether.
-            sys.exit(0)
+        if self.start_reason == 'attach' and not self._debuggerstopped:
+            self._handle_detach()
+        # TODO: We should be able drop the "launch" branch.
+        elif self.start_reason == 'launch':
+            if not self._closed:
+                # Closing the socket causes pydevd to resume all threads,
+                # so just terminate the process altogether.
+                sys.exit(0)
 
     # internal methods
 
@@ -1131,6 +1134,9 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         pass
 
     def _handle_launch(self, args):
+        pass
+
+    def _handle_detach(self):
         pass
 
 
@@ -1381,6 +1387,10 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     def _handle_launch(self, args):
         self._initialize_path_maps(args)
         yield self._send_cmd_version_command()
+
+    # TODO: Implement _handle_detach() (see GH-285):
+    #   Remove all breakpoints.
+    #   Resume if stopped.
 
     def send_process_event(self, start_method):
         # TODO: docstring

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -970,7 +970,8 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
     EXITWAIT = 1
 
     def __init__(self, socket,
-                 notify_disconnecting, notify_closing, notify_launch=None,
+                 notify_debugging, notify_disconnecting, notify_closing,
+                 notify_launch=None,
                  timeout=None, logfile=None, debugging=True,
                  ):
         super(VSCLifecycleMsgProcessor, self).__init__(
@@ -980,6 +981,7 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
             logfile=logfile,
         )
         self._notify_launch = notify_launch or (lambda: None)
+        self._notify_debugging = notify_debugging
         self._notify_disconnecting = notify_disconnecting
 
         self._stopped = False
@@ -1056,6 +1058,7 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         self._process_debug_options(self.debug_options)
         self._handle_configurationDone(args)
         _util.lock_release(self._handshakelock)
+        self._notify_debugging()
 
     def on_attach(self, request, args):
         # TODO: docstring
@@ -1142,11 +1145,12 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     """
 
     def __init__(self, socket, pydevd_notify, pydevd_request,
-                 notify_disconnecting, notify_closing,
+                 notify_debugging, notify_disconnecting, notify_closing,
                  timeout=None, logfile=None,
                  ):
         super(VSCodeMessageProcessor, self).__init__(
             socket=socket,
+            notify_debugging=notify_debugging,
             notify_disconnecting=notify_disconnecting,
             notify_closing=notify_closing,
             timeout=timeout,

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1287,10 +1287,16 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
             provider._lock.release()
         yield futures.Result(context())
 
+    def _wait_for_pydevd_ready(self):
+        # TODO: Possibly send a request and wait for a response.
+        # See GH-448.
+        pass
+
     # VSC protocol handlers
 
     def _handle_configurationDone(self, args):
         self.pydevd_request(pydevd_comm.CMD_RUN, '')
+        self._wait_for_pydevd_ready()
         self._notify_debugger_ready()
 
         if self.start_reason == 'attach':

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1158,7 +1158,6 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
         self.loop = None
         self.event_loop_thread = None
-        self.bkpoints = None
 
         # debugger state
         self.is_process_created = False
@@ -1952,15 +1951,9 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
         return hit_condition
 
-    def re_build_breakpoints(self):
-        if self.bkpoints is None:
-            return
-        self.on_setBreakpoints(None, self.bkpoints)
-
     @async_handler
     def on_setBreakpoints(self, request, args):
         # TODO: docstring
-        self.bkpoints = args
         bps = []
         path = args['source']['path']
         self.path_casing.track_file_path_case(path)

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1142,7 +1142,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     """
 
     def __init__(self, socket, pydevd_notify, pydevd_request,
-                 notify_ready_to_debug, notify_disconnecting, notify_closing,
+                 notify_debugger_ready,
+                 notify_disconnecting, notify_closing,
                  timeout=None, logfile=None,
                  ):
         super(VSCodeMessageProcessor, self).__init__(
@@ -1154,7 +1155,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         )
         self._pydevd_notify = pydevd_notify
         self._pydevd_request = pydevd_request
-        self._notify_ready_to_debug = notify_ready_to_debug
+        self._notify_debugger_ready = notify_debugger_ready
 
         self.loop = None
         self.event_loop_thread = None
@@ -1283,8 +1284,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     # VSC protocol handlers
 
     def _handle_configurationDone(self, args):
-        self._notify_ready_to_debug()
         self.pydevd_request(pydevd_comm.CMD_RUN, '')
+        self._notify_debugger_ready()
 
         if self.start_reason == 'attach':
             # Send event notifying the creation of the process.

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -7,8 +7,6 @@ import subprocess
 import sys
 import unittest
 
-from xmlrunner import XMLTestRunner
-
 from . import TEST_ROOT, PROJECT_ROOT, VENDORED_ROOTS
 
 
@@ -190,12 +188,13 @@ def run_tests(argv, env, coverage, junit_xml):
             sys.exit(rc)
         print('...done')
     elif junit_xml:
+        from xmlrunner import XMLTestRunner  # noqa
         os.environ.update(env)
         with open(junit_xml, 'wb') as output:
             unittest.main(
                 testRunner=XMLTestRunner(output=output),
                 module=None,
-                argv=argv
+                argv=argv,
             )
     else:
         os.environ.update(env)

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import
 
-import threading
 import warnings
 
 from ptvsd.socket import Address
+from ptvsd._util import new_hidden_thread
 from . import Closeable
 from .debugadapter import DebugAdapter
 from .debugsession import DebugSession
@@ -160,7 +160,10 @@ class EasyDebugClient(DebugClient):
 
         def run():
             self._session = DebugSession.create_server(addr, **kwargs)
-        t = threading.Thread(target=run, name='ptvsd.test.client')
+        t = new_hidden_thread(
+            target=run,
+            name='test.client',
+        )
         t.start()
 
         def wait():

--- a/tests/helpers/debugsession.py
+++ b/tests/helpers/debugsession.py
@@ -8,6 +8,7 @@ import time
 import threading
 import warnings
 
+from ptvsd._util import new_hidden_thread
 from . import Closeable
 from .message import (
     raw_read_all as read_messages,
@@ -149,9 +150,9 @@ class DebugSession(Closeable):
             else:
                 self._add_handler(*handler)
         self._received = []
-        self._listenerthread = threading.Thread(
+        self._listenerthread = new_hidden_thread(
             target=self._listen,
-            name='ptvsd.test.session',
+            name='test.session',
         )
         self._listenerthread.start()
 

--- a/tests/helpers/http.py
+++ b/tests/helpers/http.py
@@ -4,7 +4,8 @@ try:
     from http.server import BaseHTTPRequestHandler, HTTPServer
 except ImportError:
     from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-import threading
+
+from ptvsd._util import new_hidden_thread
 
 
 class Server:
@@ -27,9 +28,9 @@ class Server:
         if self._server is not None:
             raise RuntimeError('already started')
         self._server = HTTPServer(self._addr, self.handler)
-        self._thread = threading.Thread(
+        self._thread = new_hidden_thread(
             target=(lambda: self._server.serve_forever()),
-            name='ptvsd.test.http',
+            name='test.http',
         )
         self._thread.start()
 

--- a/tests/helpers/proc.py
+++ b/tests/helpers/proc.py
@@ -6,8 +6,8 @@ except ImportError:
     import Queue as queue  # Python 2.7
 import subprocess
 import sys
-import threading
 
+from ptvsd._util import new_hidden_thread
 from . import Closeable
 
 
@@ -45,13 +45,12 @@ def collect_lines(stream, buf=None, notify_received=None, **kwargs):
             _notify(line)
             buf.put(line)
 
-    t = threading.Thread(
+    t = new_hidden_thread(
         target=process_lines,
         args=(stream, notify_received),
         kwargs=kwargs,
-        name='ptvsd.test.proc.output',
+        name='test.proc.output',
     )
-    t.daemon = True
     t.start()
 
     return buf, t

--- a/tests/helpers/protocol.py
+++ b/tests/helpers/protocol.py
@@ -6,6 +6,7 @@ import errno
 import threading
 import warnings
 
+from ptvsd._util import new_hidden_thread
 from . import socket
 from .counter import Counter
 from .threading import acquire_with_timeout
@@ -174,12 +175,10 @@ class Daemon(object):
         def run():
             self._sock = connect()
             self._handle_connected()
-        t = threading.Thread(
+        t = new_hidden_thread(
             target=run,
-            name='ptvsd.test.daemon',
+            name='test.daemon',
         )
-        t.pydev_do_not_trace = True
-        t.is_pydev_daemon_thread  = True
         t.start()
         return addr, t
 
@@ -295,12 +294,11 @@ class MessageDaemon(Daemon):
 
     def _handle_connected(self):
         # TODO: make it a daemon thread?
-        self._listener = threading.Thread(
+        self._listener = new_hidden_thread(
             target=self._listen,
-            name='ptvsd.test.msgdaemon',
+            name='test.msgdaemon',
+            daemon=False,
         )
-        self._listener.pydev_do_not_trace = True
-        self._listener.is_pydev_daemon_thread = True
         self._listener.start()
 
     def _listen(self):

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 import contextlib
 import inspect
 import platform
-import threading
 import time
 import warnings
 
@@ -20,6 +19,7 @@ from _pydevd_bundle.pydevd_comm import (
     CMD_SET_PROJECT_ROOTS,
 )
 
+from ptvsd._util import new_hidden_thread
 from tests.helpers.pydevd import FakePyDevd, PyDevdMessages
 from tests.helpers.vsc import FakeVSC, VSCMessages
 
@@ -239,17 +239,15 @@ class VSCLifecycle(object):
         # socket (i.e. "daemon").  This is because cloing ptvsd blocks,
         # keeping us from sending the disconnect request we need to send
         # at the end.
-        t = threading.Thread(
+        t = new_hidden_thread(
             target=self._fix.close_ptvsd,
-            name='ptvsd.test.lifecycle',
+            name='test.lifecycle',
         )
         #with self._fix.wait_for_events(['exited', 'terminated']):
         if True:
             # The thread runs close_ptvsd(), which sends the two
             # events and then waits for a "disconnect" request.  We send
             # that after we receive the events.
-            t.pydev_do_not_trace = True
-            t.is_pydev_daemon_thread = True
             t.start()
         if disconnect:
             self.disconnect()

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -609,7 +609,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
         # See https://github.com/Microsoft/ptvsd/issues/448.
         addr = Address('localhost', 8888)
         filename = self.write_script('spam.py', """
-            import time
             import sys
             sys.path.insert(0, {!r})
             import ptvsd
@@ -617,7 +616,6 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             addr = {}
             ptvsd.enable_attach(addr)
             print('waiting for attach')
-            time.sleep(0.1)
             # <waiting>
             ptvsd.wait_for_attach()
             # <attached>
@@ -642,7 +640,7 @@ class LifecycleTests(TestsBase, unittest.TestCase):
 
         adapter = DebugAdapter.start_embedded(addr, filename)
         with adapter:
-            out1 = next(adapter.output)
+            out1 = next(adapter.output)  # "waiting for attach"
             line = adapter.output.readline()
             while line:
                 out1 += line

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -17,22 +17,6 @@ from tests.helpers.workspace import Workspace, PathEntry
 ROOT = os.path.dirname(os.path.dirname(ptvsd.__file__))
 
 
-def attempt_with_retries(func, numretries=10, handle_failure=None):
-    if numretries > 0:
-        for _ in range(numretries - 1):
-            try:
-                return func()
-            except Exception as exc:
-                if handle_failure is not None:
-                    res = handle_failure(exc)
-                    if res is None or res:
-                        continue
-                    raise
-                #print('retrying', repr(exc))
-    # Try one last time.
-    return func()
-
-
 class ANYType(object):
     def __repr__(self):
         return 'ANY'
@@ -654,12 +638,11 @@ class LifecycleTests(TestsBase, unittest.TestCase):
             ],
         }]
 
+        #DebugAdapter.VERBOSE = True
         adapter = DebugAdapter.start_embedded(addr, filename)
         with adapter:
             with DebugClient() as editor:
-                session = attempt_with_retries(
-                    (lambda: editor.attach_socket(addr, adapter, timeout=0.1)),
-                )
+                session = editor.attach_socket(addr, adapter, timeout=1)
 
                 # TODO: There appears to be a small race that may
                 # cause the test to fail here.


### PR DESCRIPTION
(fixes #448)

While #502 helped with the race between enable_attached() and adding breakpoints, there was still a small race left.  This PR fixes it by CMD_RUN is not issued until after the breakpoints have been added.

This PR will also have an impact on #285, #460, and #472, though it might not resolve them completely.