### PR TITLE
Reset session-dependent debugger state upon detach.

### DIFF
--- a/ptvsd/_util.py
+++ b/ptvsd/_util.py
@@ -48,6 +48,36 @@ def call_all(callables, *args, **kwargs):
 
 
 ########################
+# pydevd stuff
+
+from _pydevd_bundle import pydevd_comm  # noqa
+
+
+def log_pydevd_msg(cmdid, seq, args, inbound,
+                   log=debug, prefix=None, verbose=False):
+    """Log a representation of the given pydevd msg."""
+    if log is None or (log is debug and not DEBUG):
+        return
+    if not verbose and cmdid == pydevd_comm.CMD_WRITE_TO_CONSOLE:
+        return
+
+    if prefix is None:
+        prefix = '-> ' if inbound else '<- '
+    try:
+        cmdname = pydevd_comm.ID_TO_MEANING[str(cmdid)]
+    except KeyError:
+        for cmdname, value in vars(pydevd_comm).items():
+            if cmdid == value:
+                break
+        else:
+            cmdname = '???'
+    cmd = '{} ({})'.format(cmdid, cmdname)
+    args = args.replace('\n', '\\n')
+    msg = '{}{:28} [{:>10}]: |{}|'.format(prefix, cmd, seq, args)
+    log(msg)
+
+
+########################
 # threading stuff
 
 try:

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1410,9 +1410,21 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
     def _handle_detach(self):
         debug('detaching')
+        # TODO: Skip if already detached?
         self._detached = True
+
+        self._clear_output_redirection()
+        self._reset_project_roots()
         self._clear_breakpoints()
+        self.exceptions_mgr.remove_all_exception_breaks()
         self._resume_all_threads()
+
+    def _clear_output_redirection(self):
+        self.pydevd_request(pydevd_comm.CMD_REDIRECT_OUTPUT, '')
+
+    def _reset_project_roots(self):
+        # We leave the "project roots" alone (see CMD_SET_PROJECT_ROOTS).
+        pass
 
     def _clear_breakpoints(self, filename=None):
         cmd = pydevd_comm.CMD_REMOVE_BREAK

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2024,6 +2024,9 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
                 'verified': True,
                 'line': line,
             })
+        # Ensure that all breakpoint requests have been handled
+        # (see GH-448).
+        yield self._send_cmd_version_command()
 
         if request is not None:
             self.send_response(request, breakpoints=bps)

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -383,6 +383,7 @@ class PydevdSocket(object):
         cmd_id, seq, args = data.split('\t', 2)
         cmd_id = int(cmd_id)
         seq = int(seq)
+        _util.log_pydevd_msg(cmd_id, seq, args, inbound=True)
         with self.lock:
             loop, fut = self.requests.pop(seq, (None, None))
         if fut is None:
@@ -405,12 +406,14 @@ class PydevdSocket(object):
 
     def pydevd_notify(self, cmd_id, args):
         # TODO: docstring
-        _, s = self.make_packet(cmd_id, args)
+        seq, s = self.make_packet(cmd_id, args)
+        _util.log_pydevd_msg(cmd_id, seq, args, inbound=False)
         os.write(self.pipe_w, s.encode('utf8'))
 
     def pydevd_request(self, loop, cmd_id, args):
         # TODO: docstring
         seq, s = self.make_packet(cmd_id, args)
+        _util.log_pydevd_msg(cmd_id, seq, args, inbound=False)
         fut = loop.create_future()
         with self.lock:
             self.requests[seq] = loop, fut


### PR DESCRIPTION
(fixes #285)

We were not clearing things like breakpoints nor resuming threads when an "attach" session disconnnected.  This caused problems, e.g. when disconnect happened with a thread stopped for a breakpoint.  This PR fixes the problem by resetting all session-dependent debugger resources after the "disconnect" response has been sent (only for an "attach" session).