### PR TITLE
Add missing 'import os'.

### DIFF
--- a/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_tracing.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_tracing.py
@@ -5,7 +5,7 @@ from _pydev_imps._pydev_saved_modules import threading
 from _pydevd_bundle.pydevd_comm import get_global_debugger, CMD_SET_BREAK, CMD_SET_NEXT_STATEMENT
 from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame, NORM_PATHS_AND_BASE_CONTAINER
 from _pydevd_bundle.pydevd_frame import handle_breakpoint_condition, handle_breakpoint_expression
-
+import os
 
 class DummyTracingHolder:
     dummy_trace_func = None


### PR DESCRIPTION
Note: this broke with the latest logpoint integration (this path is not actually active right now because frame evaluation needs work before it can be made active).