### PR TITLE
Fix issues related to path translations and case of files seen on client.

### DIFF
--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -90,7 +90,7 @@ from _pydevd_bundle import pydevd_vars
 import pydevd_tracing
 from _pydevd_bundle import pydevd_xml
 from _pydevd_bundle import pydevd_vm_type
-from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame, NORM_PATHS_AND_BASE_CONTAINER, norm_file_to_client
+from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame, NORM_PATHS_AND_BASE_CONTAINER
 import pydevd_file_utils
 import sys
 import traceback
@@ -726,7 +726,7 @@ class NetCommandFactory:
 
                 abs_path_real_path_and_base = get_abs_path_real_path_and_base_from_frame(curr_frame)
 
-                myFile = norm_file_to_client(abs_path_real_path_and_base[0])
+                myFile = pydevd_file_utils.norm_file_to_client(abs_path_real_path_and_base[0])
                 if file_system_encoding.lower() != "utf-8" and hasattr(myFile, "decode"):
                     # myFile is a byte string encoded using the file system encoding
                     # convert it to utf8

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
@@ -641,11 +641,12 @@ def process_net_command(py_db, cmd_id, seq, text):
             elif cmd_id == CMD_LOAD_SOURCE:
                 path = text
                 try:
+                    path = pydevd_file_utils.norm_file_to_server(path)
                     f = open(path, 'r')
                     source = f.read()
-                    py_db.cmd_factory.make_load_source_message(seq, source, py_db)
+                    cmd = py_db.cmd_factory.make_load_source_message(seq, source)
                 except:
-                    return py_db.cmd_factory.make_error_message(seq, pydevd_tracing.get_exception_traceback_str())
+                    cmd = py_db.cmd_factory.make_error_message(seq, pydevd_tracing.get_exception_traceback_str())
 
             elif cmd_id == CMD_ADD_DJANGO_EXCEPTION_BREAK:
                 exception = text

--- a/ptvsd/_vendored/pydevd/pydevd_file_utils.py
+++ b/ptvsd/_vendored/pydevd/pydevd_file_utils.py
@@ -41,32 +41,28 @@ r'''
         machine for the paths that'll actually have breakpoints).
 '''
 
-
-
-
-from _pydevd_bundle.pydevd_constants import IS_PY2, IS_PY3K
+from _pydevd_bundle.pydevd_constants import IS_PY2, IS_PY3K, DebugInfoHolder
 from _pydev_bundle._pydev_filesystem_encoding import getfilesystemencoding
 import json
-import os
 import os.path
 import sys
 import traceback
 
-os_normcase = os.path.normcase
+_os_normcase = os.path.normcase
 basename = os.path.basename
 exists = os.path.exists
 join = os.path.join
 
 try:
-    rPath = os.path.realpath  #@UndefinedVariable
+    rPath = os.path.realpath  # @UndefinedVariable
 except:
     # jython does not support os.path.realpath
     # realpath is a no-op on systems without islink support
     rPath = os.path.abspath
 
-#defined as a list of tuples where the 1st element of the tuple is the path in the client machine
-#and the 2nd element is the path in the server machine.
-#see module docstring for more details.
+# defined as a list of tuples where the 1st element of the tuple is the path in the client machine
+# and the 2nd element is the path in the server machine.
+# see module docstring for more details.
 try:
     PATHS_FROM_ECLIPSE_TO_PYTHON = json.loads(os.environ.get('PATHS_FROM_ECLIPSE_TO_PYTHON', '[]'))
 except Exception:
@@ -81,48 +77,86 @@ else:
         # Converting json lists to tuple
         PATHS_FROM_ECLIPSE_TO_PYTHON = [tuple(x) for x in PATHS_FROM_ECLIPSE_TO_PYTHON]
 
-
-#example:
-#PATHS_FROM_ECLIPSE_TO_PYTHON = [
+# example:
+# PATHS_FROM_ECLIPSE_TO_PYTHON = [
 #  (r'd:\temp\temp_workspace_2\test_python\src\yyy\yyy',
 #   r'd:\temp\temp_workspace_2\test_python\src\hhh\xxx')
-#]
+# ]
 
 
-normcase = os_normcase # May be rebound on set_ide_os
+convert_to_long_pathname = lambda filename:filename
+convert_to_short_pathname = lambda filename:filename
+get_path_with_real_case = lambda filename:filename
 
-convert_to_long_pathname = None
 if sys.platform == 'win32':
     try:
         import ctypes
-    except ImportError:
-        pass
-    else:
-        def convert_to_long_pathname(filename):
-            buf = ctypes.create_unicode_buffer(260)
-            GetLongPathName = ctypes.windll.kernel32.GetLongPathNameW
+        from ctypes.wintypes import MAX_PATH, LPCWSTR, LPWSTR, DWORD
+        
+        GetLongPathName = ctypes.windll.kernel32.GetLongPathNameW
+        GetLongPathName.argtypes = [LPCWSTR, LPWSTR, DWORD]
+        GetLongPathName.restype = DWORD
+        
+        GetShortPathName = ctypes.windll.kernel32.GetShortPathNameW
+        GetShortPathName.argtypes = [LPCWSTR, LPWSTR, DWORD]
+        GetShortPathName.restype = DWORD
+        
+        def _convert_to_long_pathname(filename):
+            buf = ctypes.create_unicode_buffer(MAX_PATH)
+
             if IS_PY2:
-                filename = unicode(filename, getfilesystemencoding())
-            rv = GetLongPathName(filename, buf, 260)
-            if rv != 0 and rv <= 260:
+                filename = filename.decode(getfilesystemencoding())
+            rv = GetLongPathName(filename, buf, MAX_PATH)
+            if rv != 0 and rv <= MAX_PATH:
                 return buf.value
             return filename
+        
+        def _convert_to_short_pathname(filename):
+            buf = ctypes.create_unicode_buffer(MAX_PATH)
 
-
-def norm_case(filename):
-    # `normcase` doesn't lower case on Python 2 for non-English locale, but Java side does it,
-    # so we should do it manually
-    if '~' in filename and convert_to_long_pathname:
-        filename = convert_to_long_pathname(filename)
-
-    filename = os_normcase(filename)
-    enc = getfilesystemencoding()
-    if IS_PY3K or enc is None or enc.lower() == "utf-8":
-        return filename
-    try:
-        return filename.decode(enc).lower().encode(enc)
+            if IS_PY2:
+                filename = filename.decode(getfilesystemencoding())
+            rv = GetShortPathName(filename, buf, MAX_PATH)
+            if rv != 0 and rv <= MAX_PATH:
+                return buf.value
+            return filename
+        
+        def _get_path_with_real_case(filename):
+            ret = convert_to_long_pathname(convert_to_short_pathname(filename))
+            # This doesn't handle the drive letter properly (it'll be unchanged).
+            # Make sure the drive letter is always uppercase.
+            if len(ret) > 1 and ret[1] == ':' and ret[0].islower():
+                return ret[0].upper() + ret[1:] 
+            return ret
+        
+        # Check that it actually works
+        _get_path_with_real_case(__file__)
     except:
-        return filename
+        # Something didn't quite work out, leave no-op conversions in place.
+        if DebugInfoHolder.DEBUG_TRACE_LEVEL > 2:
+            traceback.print_exc()
+    else:
+        convert_to_long_pathname = _convert_to_long_pathname
+        convert_to_short_pathname = _convert_to_short_pathname
+        get_path_with_real_case = _get_path_with_real_case
+
+if sys.platform == 'win32':
+    
+    def normcase(filename):
+        # `normcase` doesn't lower case on Python 2 for non-English locale, but Java
+        # side does it, so we should do it manually.
+        if '~' in filename:
+            filename = convert_to_long_pathname(filename)
+    
+        filename = _os_normcase(filename)
+        return filename.lower()
+    
+else:
+    def normcase(filename):
+        return filename # no-op
+
+
+_ide_os = 'WINDOWS' if sys.platform == 'win32' else 'UNIX'
 
 
 def set_ide_os(os):
@@ -130,32 +164,21 @@ def set_ide_os(os):
     We need to set the IDE os because the host where the code is running may be
     actually different from the client (and the point is that we want the proper
     paths to translate from the client to the server).
+    
+    :param os:
+        'UNIX' or 'WINDOWS'
     '''
-    global normcase
-    if os == 'UNIX':
-        normcase = lambda f:f #Change to no-op if the client side is on unix/mac.
-    else:
-        if sys.platform == 'win32':
-            normcase = norm_case
-        else:
-            normcase = os_normcase
-
-    # After setting the ide OS, apply the normcase to the existing paths.
-
-    # Note: not using enumerate nor list comprehension because it may not be available in older python versions...
-    i = 0
-    for path in PATHS_FROM_ECLIPSE_TO_PYTHON[:]:
-        PATHS_FROM_ECLIPSE_TO_PYTHON[i] = (normcase(path[0]), normcase(path[1]))
-        i += 1
+    assert os in ('WINDOWS', 'UNIX')
+    
+    global _ide_os
+    _ide_os = os
 
 
 DEBUG_CLIENT_SERVER_TRANSLATION = False
 
-#caches filled as requested during the debug session
+# Caches filled as requested during the debug session.
 NORM_PATHS_CONTAINER = {}
 NORM_PATHS_AND_BASE_CONTAINER = {}
-NORM_FILENAME_TO_SERVER_CONTAINER = {}
-NORM_FILENAME_TO_CLIENT_CONTAINER = {}
 
 
 def _NormFile(filename):
@@ -182,15 +205,15 @@ def _NormPaths(filename):
 
 def _NormPath(filename, normpath):
     r = normpath(filename)
-    #cache it for fast access later
+    # cache it for fast access later
     ind = r.find('.zip')
     if ind == -1:
         ind = r.find('.egg')
     if ind != -1:
-        ind+=4
+        ind += 4
         zip_path = r[:ind]
         if r[ind] == "!":
-            ind+=1
+            ind += 1
         inner_path = r[ind:]
         if inner_path.startswith('/') or inner_path.startswith('\\'):
             inner_path = inner_path[1:]
@@ -201,6 +224,8 @@ def _NormPath(filename, normpath):
 
 
 ZIP_SEARCH_CACHE = {}
+
+
 def exists(file):
     if os.path.exists(file):
         return file
@@ -210,10 +235,10 @@ def exists(file):
         ind = file.find('.egg')
 
     if ind != -1:
-        ind+=4
+        ind += 4
         zip_path = file[:ind]
         if file[ind] == "!":
-            ind+=1
+            ind += 1
         inner_path = file[ind:]
         try:
             zip = ZIP_SEARCH_CACHE[zip_path]
@@ -237,8 +262,8 @@ def exists(file):
     return None
 
 
-#Now, let's do a quick test to see if we're working with a version of python that has no problems
-#related to the names generated...
+# Now, let's do a quick test to see if we're working with a version of python that has no problems
+# related to the names generated...
 try:
     try:
         code = rPath.func_code
@@ -255,13 +280,14 @@ try:
         NORM_SEARCH_CACHE = {}
 
         initial_norm_paths = _NormPaths
-        def _NormPaths(filename):  #Let's redefine _NormPaths to work with paths that may be incorrect
+
+        def _NormPaths(filename):  # Let's redefine _NormPaths to work with paths that may be incorrect
             try:
                 return NORM_SEARCH_CACHE[filename]
             except KeyError:
                 abs_path, real_path = initial_norm_paths(filename)
                 if not exists(real_path):
-                    #We must actually go on and check if we can find it as if it was a relative path for some of the paths in the pythonpath
+                    # We must actually go on and check if we can find it as if it was a relative path for some of the paths in the pythonpath
                     for path in sys.path:
                         abs_path, real_path = initial_norm_paths(join(path, filename))
                         if exists(real_path):
@@ -275,65 +301,66 @@ try:
                 return abs_path, real_path
 
 except:
-    #Don't fail if there's something not correct here -- but at least print it to the user so that we can correct that
+    # Don't fail if there's something not correct here -- but at least print it to the user so that we can correct that
     traceback.print_exc()
 
-norm_file_to_client = _AbsFile
-norm_file_to_server = _NormFile
+# Note: as these functions may be rebound, users should always import
+# pydevd_file_utils and then use:
+#
+# pydevd_file_utils.norm_file_to_client
+# pydevd_file_utils.norm_file_to_server
+#
+# instead of importing any of those names to a given scope. 
+
+def _original_file_to_client(filename, cache={}):
+    try:
+        return cache[filename]
+    except KeyError:
+        cache[filename] = get_path_with_real_case(_AbsFile(filename))
+    return cache[filename]
+    
+_original_file_to_server = _NormFile
+
+norm_file_to_client = _original_file_to_client
+norm_file_to_server = _original_file_to_server
+
 
 def setup_client_server_paths(paths):
     '''paths is the same format as PATHS_FROM_ECLIPSE_TO_PYTHON'''
 
-    global NORM_FILENAME_TO_SERVER_CONTAINER
-    global NORM_FILENAME_TO_CLIENT_CONTAINER
-    global PATHS_FROM_ECLIPSE_TO_PYTHON
     global norm_file_to_client
     global norm_file_to_server
 
-    NORM_FILENAME_TO_SERVER_CONTAINER = {}
-    NORM_FILENAME_TO_CLIENT_CONTAINER = {}
-    PATHS_FROM_ECLIPSE_TO_PYTHON = paths[:]
+    norm_filename_to_server_container = {}
+    norm_filename_to_client_container = {}
+    initial_paths = list(paths)
+    paths_from_eclipse_to_python = initial_paths[:]
+    
+    # Apply normcase to the existing paths to follow the os preferences.
 
-    if not PATHS_FROM_ECLIPSE_TO_PYTHON:
-        #no translation step needed (just inline the calls)
-        norm_file_to_client = _AbsFile
-        norm_file_to_server = _NormFile
+    for i, path in enumerate(paths_from_eclipse_to_python[:]):
+        paths_from_eclipse_to_python[i] = (normcase(path[0]), normcase(path[1]))
+
+    if not paths_from_eclipse_to_python:
+        # no translation step needed (just inline the calls)
+        norm_file_to_client = _original_file_to_client
+        norm_file_to_server = _original_file_to_server
         return
 
-    #Work on the client and server slashes.
-    eclipse_sep = None
-    python_sep = None
-    for eclipse_prefix, server_prefix in PATHS_FROM_ECLIPSE_TO_PYTHON:
-        if eclipse_sep is not None and python_sep is not None:
-            break
+    # Work on the client and server slashes.
+    python_sep = '\\' if sys.platform == 'win32' else '/'
+    eclipse_sep = '\\' if _ide_os == 'WINDOWS' else '/'
 
-        if eclipse_sep is None:
-            for c in eclipse_prefix:
-                if c in ('/', '\\'):
-                    eclipse_sep = c
-                    break
-
-        if python_sep is None:
-            for c in server_prefix:
-                if c in ('/', '\\'):
-                    python_sep = c
-                    break
-
-    #If they're the same or one of them cannot be determined, just make it all None.
-    if eclipse_sep == python_sep or eclipse_sep is None or python_sep is None:
-        eclipse_sep = python_sep = None
-
-
-    #only setup translation functions if absolutely needed!
+    # only setup translation functions if absolutely needed!
     def _norm_file_to_server(filename):
-        #Eclipse will send the passed filename to be translated to the python process
-        #So, this would be 'NormFileFromEclipseToPython'
+        # Eclipse will send the passed filename to be translated to the python process
+        # So, this would be 'NormFileFromEclipseToPython'
         try:
-            return NORM_FILENAME_TO_SERVER_CONTAINER[filename]
+            return norm_filename_to_server_container[filename]
         except KeyError:
-            #used to translate a path from the client to the debug server
+            # used to translate a path from the client to the debug server
             translated = normcase(filename)
-            for eclipse_prefix, server_prefix in PATHS_FROM_ECLIPSE_TO_PYTHON:
+            for eclipse_prefix, server_prefix in paths_from_eclipse_to_python:
                 if translated.startswith(eclipse_prefix):
                     if DEBUG_CLIENT_SERVER_TRANSLATION:
                         sys.stderr.write('pydev debugger: replacing to server: %s\n' % (translated,))
@@ -344,49 +371,70 @@ def setup_client_server_paths(paths):
             else:
                 if DEBUG_CLIENT_SERVER_TRANSLATION:
                     sys.stderr.write('pydev debugger: to server: unable to find matching prefix for: %s in %s\n' % \
-                        (translated, [x[0] for x in PATHS_FROM_ECLIPSE_TO_PYTHON]))
+                        (translated, [x[0] for x in paths_from_eclipse_to_python]))
 
-            #Note that when going to the server, we do the replace first and only later do the norm file.
-            if eclipse_sep is not None:
+            # Note that when going to the server, we do the replace first and only later do the norm file.
+            if eclipse_sep != python_sep:
                 translated = translated.replace(eclipse_sep, python_sep)
             translated = _NormFile(translated)
 
-            NORM_FILENAME_TO_SERVER_CONTAINER[filename] = translated
+            norm_filename_to_server_container[filename] = translated
             return translated
 
     def _norm_file_to_client(filename):
-        #The result of this method will be passed to eclipse
-        #So, this would be 'NormFileFromPythonToEclipse'
+        # The result of this method will be passed to eclipse
+        # So, this would be 'NormFileFromPythonToEclipse'
         try:
-            return NORM_FILENAME_TO_CLIENT_CONTAINER[filename]
+            return norm_filename_to_client_container[filename]
         except KeyError:
-            #used to translate a path from the debug server to the client
+            # used to translate a path from the debug server to the client
             translated = _NormFile(filename)
-            for eclipse_prefix, python_prefix in PATHS_FROM_ECLIPSE_TO_PYTHON:
+            
+            # After getting the real path, let's get it with the path with
+            # the real case and then obtain a new normalized copy, just in case
+            # the path is different now.
+            translated_proper_case = get_path_with_real_case(translated)
+            translated = _NormFile(translated_proper_case)
+            
+            if sys.platform == 'win32':
+                if translated.lower() != translated_proper_case.lower():
+                    translated_proper_case = translated
+                    if DEBUG_CLIENT_SERVER_TRANSLATION:
+                        sys.stderr.write(
+                            'pydev debugger: _NormFile changed path (from: %s to %s)\n' % (
+                                translated_proper_case, translated))
+            
+            for i, (eclipse_prefix, python_prefix) in enumerate(paths_from_eclipse_to_python):
                 if translated.startswith(python_prefix):
                     if DEBUG_CLIENT_SERVER_TRANSLATION:
                         sys.stderr.write('pydev debugger: replacing to client: %s\n' % (translated,))
-                    translated = translated.replace(python_prefix, eclipse_prefix)
+                    
+                    # Note: use the non-normalized version.
+                    eclipse_prefix = initial_paths[i][0]
+                    translated = eclipse_prefix + translated_proper_case[len(python_prefix):]
                     if DEBUG_CLIENT_SERVER_TRANSLATION:
                         sys.stderr.write('pydev debugger: sent to client: %s\n' % (translated,))
                     break
             else:
                 if DEBUG_CLIENT_SERVER_TRANSLATION:
                     sys.stderr.write('pydev debugger: to client: unable to find matching prefix for: %s in %s\n' % \
-                        (translated, [x[1] for x in PATHS_FROM_ECLIPSE_TO_PYTHON]))
+                        (translated, [x[1] for x in paths_from_eclipse_to_python]))
+                    translated = translated_proper_case
 
-            if eclipse_sep is not None:
+            if eclipse_sep != python_sep:
                 translated = translated.replace(python_sep, eclipse_sep)
 
-            #The resulting path is not in the python process, so, we cannot do a _NormFile here,
-            #only at the beginning of this method.
-            NORM_FILENAME_TO_CLIENT_CONTAINER[filename] = translated
+            # The resulting path is not in the python process, so, we cannot do a _NormFile here,
+            # only at the beginning of this method.
+            norm_filename_to_client_container[filename] = translated
             return translated
 
     norm_file_to_server = _norm_file_to_server
     norm_file_to_client = _norm_file_to_client
 
+
 setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+
 
 # For given file f returns tuple of its absolute path, real path and base name
 def get_abs_path_real_path_and_base_from_file(f):
@@ -404,9 +452,9 @@ def get_abs_path_real_path_and_base_from_frame(frame):
     try:
         return NORM_PATHS_AND_BASE_CONTAINER[frame.f_code.co_filename]
     except:
-        #This one is just internal (so, does not need any kind of client-server translation)
+        # This one is just internal (so, does not need any kind of client-server translation)
         f = frame.f_code.co_filename
-        if f is not None and f.startswith (('build/bdist.','build\\bdist.')):
+        if f is not None and f.startswith (('build/bdist.', 'build\\bdist.')):
             # files from eggs in Python 2.7 have paths like build/bdist.linux-x86_64/egg/<path-inside-egg>
             f = frame.f_globals['__file__']
         if f is not None:

--- a/ptvsd/_vendored/pydevd/tests_python/_debugger_case_path_translation.py
+++ b/ptvsd/_vendored/pydevd/tests_python/_debugger_case_path_translation.py
@@ -1,0 +1,7 @@
+def main():
+    print('break here')
+    print('TEST SUCEEDED!')
+
+    
+if __name__ == '__main__':
+    main()

--- a/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -124,7 +124,7 @@ class ReaderThread(threading.Thread):
             frame_info = ' --  File "%s", line %s, in %s\n' % (frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name)
             frame_info += ' --  File "%s", line %s, in %s\n' % (frame.f_back.f_code.co_filename, frame.f_back.f_lineno, frame.f_back.f_code.co_name)
             frame = None
-            sys.stdout.write('Message returned in get_next_message(): %s --  ctx: %s, returned to:\n%s\n' % (msg, context_messag, frame_info))
+            sys.stdout.write('Message returned in get_next_message(): %s --  ctx: %s, returned to:\n%s\n' % (unquote_plus(unquote_plus(msg)), context_messag, frame_info))
         return msg
 
     def run(self):
@@ -367,7 +367,6 @@ class AbstractWriterThread(threading.Thread):
             msg = msg.encode('utf-8')
         self.sock.send(msg)
 
-
     def start_socket(self, port=None):
         from _pydev_bundle.pydev_localhost import get_socket_name
         if SHOW_WRITES_AND_READS:
@@ -384,13 +383,13 @@ class AbstractWriterThread(threading.Thread):
         if SHOW_WRITES_AND_READS:
             print('Waiting in socket.accept()')
         self.server_socket = s
-        newSock, addr = s.accept()
+        new_sock, addr = s.accept()
         if SHOW_WRITES_AND_READS:
-            print('Test Writer Thread Socket:', newSock, addr)
+            print('Test Writer Thread Socket:', new_sock, addr)
 
-        reader_thread = self.reader_thread = ReaderThread(newSock)
+        reader_thread = self.reader_thread = ReaderThread(new_sock)
         reader_thread.start()
-        self.sock = newSock
+        self.sock = new_sock
 
         self._sequence = -1
         # initial command is always the version
@@ -404,7 +403,6 @@ class AbstractWriterThread(threading.Thread):
     def next_seq(self):
         self._sequence += 2
         return self._sequence
-
 
     def wait_for_new_thread(self):
         # wait for hit breakpoint
@@ -556,12 +554,13 @@ class AbstractWriterThread(threading.Thread):
     def get_main_filename(self):
         return self.TEST_FILE
 
-    def write_add_breakpoint(self, line, func):
+    def write_add_breakpoint(self, line, func, filename=None):
         '''
             @param line: starts at 1
         '''
+        filename = self.get_main_filename()
         breakpoint_id = self.next_breakpoint_id()
-        self.write("111\t%s\t%s\t%s\t%s\t%s\t%s\tNone\tNone" % (self.next_seq(), breakpoint_id, 'python-line', self.get_main_filename(), line, func))
+        self.write("111\t%s\t%s\t%s\t%s\t%s\t%s\tNone\tNone" % (self.next_seq(), breakpoint_id, 'python-line', filename, line, func))
         self.log.append('write_add_breakpoint: %s line: %s func: %s' % (breakpoint_id, line, func))
         return breakpoint_id
 
@@ -629,6 +628,10 @@ class AbstractWriterThread(threading.Thread):
     def write_run_thread(self, thread_id):
         self.log.append('write_run_thread')
         self.write("%s\t%s\t%s" % (CMD_THREAD_RUN, self.next_seq(), thread_id,))
+        
+    def write_load_source(self, filename):
+        self.log.append('write_load_source')
+        self.write("%s\t%s\t%s" % (CMD_LOAD_SOURCE, self.next_seq(), filename,))
 
     def write_kill_thread(self, thread_id):
         self.write("%s\t%s\t%s" % (CMD_THREAD_KILL, self.next_seq(), thread_id,))
@@ -669,7 +672,32 @@ class AbstractWriterThread(threading.Thread):
             if last.startswith('502\t%s' % (seq,)):
                 return re.findall(r'\bid=\"(\w+)\"', last)
                 
-
+    def wait_for_message(self, accept_message, unquote_msg=True, expect_xml=True):
+        import untangle
+        from io import StringIO
+        prev = None
+        while True:
+            last = self.reader_thread.get_next_message('wait_for_message')
+            if unquote_msg:
+                last = unquote_plus(unquote_plus(last))
+            if accept_message(last):
+                if expect_xml:
+                    # Extract xml and return untangled.
+                    try:
+                        xml = last[last.index('<xml>'):]
+                        if isinstance(xml, bytes):
+                            xml = xml.decode('utf-8')
+                        xml = untangle.parse(StringIO(xml))
+                    except:
+                        import traceback;traceback.print_exc()
+                        raise AssertionError('Unable to parse:\n%s\nxml:\n%s' % (last, xml))
+                    return xml.xml
+                else:
+                    return last
+            if prev != last:
+                print('Ignored message: %r' % (last,))
+                
+            prev = last
 
 def _get_debugger_test_file(filename):
     try:

--- a/ptvsd/_vendored/pydevd/tests_python/test_convert_utilities.py
+++ b/ptvsd/_vendored/pydevd/tests_python/test_convert_utilities.py
@@ -1,0 +1,127 @@
+import os.path
+
+
+def test_convert_utilities(tmpdir):
+    import pydevd_file_utils
+    import sys
+    
+    test_dir = str(tmpdir.mkdir("Test_Convert_Utilities"))
+    if sys.platform == 'win32':
+        normalized = pydevd_file_utils.normcase(test_dir)
+        assert normalized.lower() == normalized
+         
+        assert '~' not in normalized
+        assert '~' in pydevd_file_utils.convert_to_short_pathname(normalized)
+         
+        real_case = pydevd_file_utils.get_path_with_real_case(normalized)
+        # Note test_dir itself cannot be compared with because pytest may
+        # have passed the case normalized.
+        assert real_case.endswith("Test_Convert_Utilities")
+         
+    else:
+        # On other platforms, nothing should change
+        assert pydevd_file_utils.normcase(test_dir) == test_dir
+        assert pydevd_file_utils.convert_to_short_pathname(test_dir) == test_dir
+        assert pydevd_file_utils.get_path_with_real_case(test_dir) == test_dir
+
+
+def test_to_server_and_to_client(tmpdir):
+    try:
+        import pydevd_file_utils
+        import sys
+        if sys.platform == 'win32':
+            # Check with made-up files
+            
+            # Client and server are on windows. 
+            pydevd_file_utils.set_ide_os('WINDOWS')
+            in_eclipse = 'c:\\foo'
+            in_python = 'c:\\bar'
+            PATHS_FROM_ECLIPSE_TO_PYTHON = [
+                (in_eclipse, in_python)
+            ]
+            pydevd_file_utils.setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+            assert pydevd_file_utils.norm_file_to_server('c:\\foo\\my') == 'c:\\bar\\my'
+            assert pydevd_file_utils.norm_file_to_server('c:\\foo\\my'.upper()) == 'c:\\bar\\my'
+            assert pydevd_file_utils.norm_file_to_client('c:\\bar\\my') == 'c:\\foo\\my'
+            
+            # Client on unix and server on windows
+            pydevd_file_utils.set_ide_os('UNIX')
+            in_eclipse = '/foo'
+            in_python = 'c:\\bar'
+            PATHS_FROM_ECLIPSE_TO_PYTHON = [
+                (in_eclipse, in_python)
+            ]
+            pydevd_file_utils.setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+            assert pydevd_file_utils.norm_file_to_server('/foo/my') == 'c:\\bar\\my'
+            assert pydevd_file_utils.norm_file_to_client('c:\\bar\\my') == '/foo/my'
+            
+            # Test with 'real' files
+            # Client and server are on windows. 
+            pydevd_file_utils.set_ide_os('WINDOWS')
+
+            test_dir = str(tmpdir.mkdir("Foo"))
+            os.makedirs(os.path.join(test_dir, "Another"))
+
+            in_eclipse = os.path.join(os.path.dirname(test_dir), 'Bar')
+            in_python = test_dir
+            PATHS_FROM_ECLIPSE_TO_PYTHON = [
+                (in_eclipse, in_python)
+            ]
+            pydevd_file_utils.setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+            
+            assert pydevd_file_utils.norm_file_to_server(in_eclipse) == in_python.lower()
+            found_in_eclipse = pydevd_file_utils.norm_file_to_client(in_python)
+            assert found_in_eclipse.endswith('Bar')
+            
+            assert pydevd_file_utils.norm_file_to_server(
+                os.path.join(in_eclipse, 'another')) == os.path.join(in_python, 'another').lower()
+            found_in_eclipse = pydevd_file_utils.norm_file_to_client(
+                os.path.join(in_python, 'another'))
+            assert found_in_eclipse.endswith('Bar\\Another')
+            
+            # Client on unix and server on windows
+            pydevd_file_utils.set_ide_os('UNIX')
+            in_eclipse = '/foo'
+            in_python = test_dir
+            PATHS_FROM_ECLIPSE_TO_PYTHON = [
+                (in_eclipse, in_python)
+            ]
+            pydevd_file_utils.setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+            assert pydevd_file_utils.norm_file_to_server('/foo').lower() == in_python.lower()
+            assert pydevd_file_utils.norm_file_to_client(in_python) == in_eclipse
+            
+            # Test without translation in place (still needs to fix case and separators)
+            pydevd_file_utils.set_ide_os('WINDOWS')
+            PATHS_FROM_ECLIPSE_TO_PYTHON = []
+            pydevd_file_utils.setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+            assert pydevd_file_utils.norm_file_to_server(test_dir) == test_dir.lower()
+            assert pydevd_file_utils.norm_file_to_client(test_dir).endswith('\\Foo')
+
+        else:
+            # Client on windows and server on unix
+            pydevd_file_utils.set_ide_os('WINDOWS')
+            in_eclipse = 'c:\\foo'
+            in_python = '/bar'
+            PATHS_FROM_ECLIPSE_TO_PYTHON = [
+                (in_eclipse, in_python)
+            ]
+            pydevd_file_utils.setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+            assert pydevd_file_utils.norm_file_to_server('c:\\foo\\my') == '/bar/my'
+            assert pydevd_file_utils.norm_file_to_client('/bar/my') == 'c:\\foo\\my'
+
+            # Files for which there's no translation have only their separators updated.
+            assert pydevd_file_utils.norm_file_to_client('/usr/bin') == '\\usr\\bin'
+            assert pydevd_file_utils.norm_file_to_server('\\usr\\bin') == '/usr/bin'
+
+            # Client and server on unix
+            pydevd_file_utils.set_ide_os('UNIX')
+            in_eclipse = '/foo'
+            in_python = '/bar'
+            PATHS_FROM_ECLIPSE_TO_PYTHON = [
+                (in_eclipse, in_python)
+            ]
+            pydevd_file_utils.setup_client_server_paths(PATHS_FROM_ECLIPSE_TO_PYTHON)
+            assert pydevd_file_utils.norm_file_to_server('/foo/my') == '/bar/my'
+            assert pydevd_file_utils.norm_file_to_client('/bar/my') == '/foo/my'
+    finally:
+        pydevd_file_utils.setup_client_server_paths([])


### PR DESCRIPTION
This patch makes improvements in the path handling in pydevd.

It doesn't completely fix https://github.com/Microsoft/ptvsd/issues/333 because the behavior there is expected (the path separators are always sent to be compatible with the client), still, it fixes the `CMD_LOAD_SOURCE` so that translation happens there properly and the case of files should now be correct on windows.

Hopefully it also fixes https://github.com/Microsoft/ptvsd/issues/473 (although I haven't actually tested that it does so).