### PR TITLE
Handle multi-line console commands.

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1858,7 +1858,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         """Handles DAP EvaluateRequest."""
 
         # pydevd message format doesn't permit tabs in expressions
-        expr = args['expression'].replace('\t', ' ')
+        expr = args['expression'].replace('\n', '@LINE@').replace('\t', ' ')
         fmt = args.get('format', {})
 
         vsc_fid = int(args['frameId'])


### PR DESCRIPTION
Fixes #518

Previously:
![image](https://user-images.githubusercontent.com/3840081/42186342-25f9ef96-7e01-11e8-8efe-f93732e33be3.png)

With the fix:
![image](https://user-images.githubusercontent.com/3840081/42186361-40122880-7e01-11e8-8194-30fdbbc0c867.png)
