### PR TITLE
Update verbosity when we create junit-style output report files

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -190,9 +190,12 @@ def run_tests(argv, env, coverage, junit_xml):
     elif junit_xml:
         from xmlrunner import XMLTestRunner  # noqa
         os.environ.update(env)
+        verbosity = 1
+        if '-v' in argv or '--verbose' in argv:
+            verbosity = 2
         with open(junit_xml, 'wb') as output:
             unittest.main(
-                testRunner=XMLTestRunner(output=output),
+                testRunner=XMLTestRunner(output=output, verbosity=verbosity),
                 module=None,
                 argv=argv,
             )


### PR DESCRIPTION
The -v verbosity switch is not being respected on VSTS when we run tests.

The XMLTestRunner we are using to produce VSTS-compatible JUnit test output logs doesn't respect the -v switch being sent into the unittest process.

When junit report file is being generated, detect if the -v or --verbose switch is being applied. If it is, set the verbosity to '2' in the XMLTestRunner.