### PR TITLE
Refactor test classes

### DIFF
--- a/tests/system_tests/test_basic.py
+++ b/tests/system_tests/test_basic.py
@@ -14,7 +14,7 @@ TEST_TERMINATION_FILES_DIR = os.path.join(ROOT, 'tests', 'resources',
                                           'system_tests', 'test_terminate')
 
 
-class LaunchLifecycleTests(LifecycleTestsBase):
+class BasicTests(LifecycleTestsBase):
     def run_test_output(self, debug_info):
         options = {"debugOptions": ["RedirectOutput"]}
 
@@ -30,11 +30,6 @@ class LaunchLifecycleTests(LifecycleTestsBase):
                 self.new_event("output", category="stderr", output="no"),
             ],
         )
-
-    def test_with_output(self):
-        filename = os.path.join(TEST_FILES_DIR, 'test_output', 'output.py')
-        cwd = os.path.dirname(filename)
-        self.run_test_output(DebugInfo(filename=filename, cwd=cwd))
 
     def run_test_arguments(self, debug_info, expected_args):
         options = {"debugOptions": ["RedirectOutput"]}
@@ -53,15 +48,6 @@ class LaunchLifecycleTests(LifecycleTestsBase):
             ],
         )
 
-    def test_arguments(self):
-        filename = os.path.join(TEST_FILES_DIR, 'test_args',
-                                'launch_with_args.py')
-        cwd = os.path.dirname(filename)
-        argv = ['arg1', 'arg2']
-        self.run_test_arguments(
-            DebugInfo(filename=filename, cwd=cwd, argv=argv),
-            [filename] + argv)
-
     def run_test_termination(self, debug_info):
         with self.start_debugging(debug_info) as dbg:
             session = dbg.session
@@ -77,12 +63,6 @@ class LaunchLifecycleTests(LifecycleTestsBase):
             disconnect = session.send_request("disconnect")
 
             Awaitable.wait_all(exited, terminated, disconnect)
-
-    @unittest.skip('Broken')
-    def test_termination(self):
-        filename = os.path.join(TEST_TERMINATION_FILES_DIR, 'simple.py')
-        cwd = os.path.dirname(filename)
-        self.run_test_termination(DebugInfo(filename=filename, cwd=cwd))
 
     def run_test_without_output(self, debug_info):
         options = {"debugOptions": ["RedirectOutput"]}
@@ -100,6 +80,28 @@ class LaunchLifecycleTests(LifecycleTestsBase):
         err = self.find_events(received, 'output', {'category': 'stderr'})
         self.assertEqual(len(out + err), 0)
 
+
+class LaunchFileTests(BasicTests):
+    def test_with_output(self):
+        filename = os.path.join(TEST_FILES_DIR, 'test_output', 'output.py')
+        cwd = os.path.dirname(filename)
+        self.run_test_output(DebugInfo(filename=filename, cwd=cwd))
+
+    def test_arguments(self):
+        filename = os.path.join(TEST_FILES_DIR, 'test_args',
+                                'launch_with_args.py')
+        cwd = os.path.dirname(filename)
+        argv = ['arg1', 'arg2']
+        self.run_test_arguments(
+            DebugInfo(filename=filename, cwd=cwd, argv=argv),
+            [filename] + argv)
+
+    @unittest.skip('Broken')
+    def test_termination(self):
+        filename = os.path.join(TEST_TERMINATION_FILES_DIR, 'simple.py')
+        cwd = os.path.dirname(filename)
+        self.run_test_termination(DebugInfo(filename=filename, cwd=cwd))
+
     def test_without_output(self):
         filename = os.path.join(TEST_FILES_DIR, 'test_without_output',
                                 'output.py')
@@ -107,7 +109,7 @@ class LaunchLifecycleTests(LifecycleTestsBase):
         self.run_test_without_output(DebugInfo(filename=filename, cwd=cwd))
 
 
-class LaunchModuleLifecycleTests(LaunchLifecycleTests):
+class LaunchModuleTests(BasicTests):
     def test_with_output(self):
         module_name = 'mymod_launch1'
         cwd = os.path.join(TEST_FILES_DIR, 'test_output')
@@ -142,7 +144,7 @@ class LaunchModuleLifecycleTests(LaunchLifecycleTests):
             ['-m'] + argv)
 
 
-class ServerAttachLifecycleTests(LaunchLifecycleTests):
+class ServerAttachTests(BasicTests):
     def test_with_output(self):
         filename = os.path.join(TEST_FILES_DIR, 'test_output', 'output.py')
         cwd = os.path.dirname(filename)
@@ -160,20 +162,8 @@ class ServerAttachLifecycleTests(LaunchLifecycleTests):
             DebugInfo(
                 filename=filename, cwd=cwd, starttype='attach', argv=argv))
 
-    @unittest.skip('Needs to be fixed')
-    def test_not_breaking_into_handled_exceptions(self):
-        pass
 
-    @unittest.skip('No need to test')
-    def test_termination(self):
-        pass
-
-    @unittest.skip('No need to test')
-    def test_arguments(self):
-        pass
-
-
-class PTVSDAttachLifecycleTests(LaunchLifecycleTests):
+class PTVSDAttachTests(BasicTests):
     def test_with_output(self):
         filename = os.path.join(TEST_FILES_DIR, 'test_output',
                                 'attach_output.py')
@@ -200,16 +190,8 @@ class PTVSDAttachLifecycleTests(LaunchLifecycleTests):
                 starttype='attach',
                 argv=argv))
 
-    @unittest.skip('No need to test')
-    def test_termination(self):
-        pass
 
-    @unittest.skip('No need to test')
-    def test_arguments(self):
-        pass
-
-
-class ServerAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
+class ServerAttachModuleTests(BasicTests):  # noqa
     def test_with_output(self):
         module_name = 'mymod_launch1'
         cwd = os.path.join(TEST_FILES_DIR, 'test_output')
@@ -236,17 +218,9 @@ class ServerAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
                 argv=argv,
                 starttype='attach'))
 
-    @unittest.skip('No need to test')
-    def test_termination(self):
-        pass
 
-    @unittest.skip('No need to test')
-    def test_arguments(self):
-        pass
-
-
-@unittest.skip('Needs fixing')
-class PTVSDAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
+@unittest.skip('Needs fixing #545')
+class PTVSDAttachModuleTests(BasicTests):  # noqa
     def test_with_output(self):
         module_name = 'mymod_attach1'
         cwd = os.path.join(TEST_FILES_DIR, 'test_output')
@@ -274,11 +248,3 @@ class PTVSDAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
                 argv=argv,
                 attachtype='import',
                 starttype='attach'))
-
-    @unittest.skip('No need to test')
-    def test_termination(self):
-        pass
-
-    @unittest.skip('No need to test')
-    def test_arguments(self):
-        pass

--- a/tests/system_tests/test_breakpoints.py
+++ b/tests/system_tests/test_breakpoints.py
@@ -11,13 +11,7 @@ TEST_FILES_DIR = os.path.join(ROOT, 'tests', 'resources', 'system_tests',
                               'test_breakpoints')
 
 
-class LaunchLifecycleTests(LifecycleTestsBase):
-    def test_with_break_points(self):
-        filename = os.path.join(TEST_FILES_DIR, 'output.py')
-        cwd = os.path.dirname(filename)
-        self.run_test_with_break_points(
-            DebugInfo(filename=filename, cwd=cwd), filename, bp_line=3)
-
+class BreakpointTests(LifecycleTestsBase):
     def run_test_with_break_points(self, debug_info, bp_filename, bp_line):
         options = {"debugOptions": ["RedirectOutput"]}
         breakpoints = [{
@@ -90,55 +84,6 @@ class LaunchLifecycleTests(LifecycleTestsBase):
             ],
         )
 
-    def test_with_break_points_across_files(self):
-        first_file = os.path.join(TEST_FILES_DIR, 'foo.py')
-        second_file = os.path.join(TEST_FILES_DIR, 'bar.py')
-        cwd = os.path.dirname(first_file)
-        expected_modules = [{
-            "reason": "new",
-            "module": {
-                "path": second_file,
-                "name": "bar"
-            }
-        }, {
-            "reason": "new",
-            "module": {
-                "path": first_file,
-                "name": "__main__"
-            }
-        }]
-        expected_stacktrace = {
-            "stackFrames": [{
-                "name": "do_bar",
-                "source": {
-                    "path": second_file,
-                    "sourceReference": 0
-                },
-                "line": 2,
-                "column": 1
-            }, {
-                "name": "do_foo",
-                "source": {
-                    "path": first_file,
-                    "sourceReference": 0
-                },
-                "line": 5,
-                "column": 1
-            }, {
-                "id": 3,
-                "name": "<module>",
-                "source": {
-                    "path": first_file,
-                    "sourceReference": 0
-                },
-                "line": 8,
-                "column": 1
-            }],
-        }
-        self.run_test_with_break_points_across_files(
-            DebugInfo(filename=first_file, cwd=cwd), first_file, second_file,
-            2, expected_modules, expected_stacktrace)
-
     def run_test_with_break_points_across_files(
             self, debug_info, first_file, second_file, second_file_line,
             expected_modules, expected_stacktrace):
@@ -179,12 +124,6 @@ class LaunchLifecycleTests(LifecycleTestsBase):
                 len(found_mod), 1, 'Modul not found {}'.format(mod))
 
         self.assert_is_subset(stacktrace.resp, expected_stacktrace)
-
-    def test_conditional_break_points(self):
-        filename = os.path.join(TEST_FILES_DIR, 'loopy.py')
-        cwd = os.path.dirname(filename)
-        self.run_test_conditional_break_points(
-            DebugInfo(filename=filename, cwd=cwd))
 
     def run_test_conditional_break_points(self, debug_info):
         breakpoints = [{
@@ -248,11 +187,6 @@ class LaunchLifecycleTests(LifecycleTestsBase):
                                   "evaluateName": "i"
                               }])
 
-    def test_logpoints(self):
-        filename = os.path.join(TEST_FILES_DIR, 'loopy.py')
-        cwd = os.path.dirname(filename)
-        self.run_test_logpoints(DebugInfo(filename=filename, cwd=cwd))
-
     def run_test_logpoints(self, debug_info):
         options = {"debugOptions": ["RedirectOutput"]}
         breakpoints = [{
@@ -293,7 +227,75 @@ class LaunchLifecycleTests(LifecycleTestsBase):
         self.assert_contains(received, expected_events)
 
 
-class LaunchModuleLifecycleTests(LaunchLifecycleTests):
+class LaunchFileTests(BreakpointTests):
+    def test_with_break_points(self):
+        filename = os.path.join(TEST_FILES_DIR, 'output.py')
+        cwd = os.path.dirname(filename)
+        self.run_test_with_break_points(
+            DebugInfo(filename=filename, cwd=cwd), filename, bp_line=3)
+
+    def test_with_break_points_across_files(self):
+        first_file = os.path.join(TEST_FILES_DIR, 'foo.py')
+        second_file = os.path.join(TEST_FILES_DIR, 'bar.py')
+        cwd = os.path.dirname(first_file)
+        expected_modules = [{
+            "reason": "new",
+            "module": {
+                "path": second_file,
+                "name": "bar"
+            }
+        }, {
+            "reason": "new",
+            "module": {
+                "path": first_file,
+                "name": "__main__"
+            }
+        }]
+        expected_stacktrace = {
+            "stackFrames": [{
+                "name": "do_bar",
+                "source": {
+                    "path": second_file,
+                    "sourceReference": 0
+                },
+                "line": 2,
+                "column": 1
+            }, {
+                "name": "do_foo",
+                "source": {
+                    "path": first_file,
+                    "sourceReference": 0
+                },
+                "line": 5,
+                "column": 1
+            }, {
+                "id": 3,
+                "name": "<module>",
+                "source": {
+                    "path": first_file,
+                    "sourceReference": 0
+                },
+                "line": 8,
+                "column": 1
+            }],
+        }
+        self.run_test_with_break_points_across_files(
+            DebugInfo(filename=first_file, cwd=cwd), first_file, second_file,
+            2, expected_modules, expected_stacktrace)
+
+    def test_conditional_break_points(self):
+        filename = os.path.join(TEST_FILES_DIR, 'loopy.py')
+        cwd = os.path.dirname(filename)
+        self.run_test_conditional_break_points(
+            DebugInfo(filename=filename, cwd=cwd))
+
+    def test_logpoints(self):
+        filename = os.path.join(TEST_FILES_DIR, 'loopy.py')
+        cwd = os.path.dirname(filename)
+        self.run_test_logpoints(DebugInfo(filename=filename, cwd=cwd))
+
+
+class LaunchModuleTests(BreakpointTests):
     def test_with_break_points(self):
         module_name = 'mymod_launch1'
         cwd = os.path.join(TEST_FILES_DIR)
@@ -356,16 +358,8 @@ class LaunchModuleLifecycleTests(LaunchLifecycleTests):
             DebugInfo(modulename=module_name, cwd=cwd, env=env), first_file,
             second_file, 2, expected_modules, expected_stacktrace)
 
-    @unittest.skip('Not required')
-    def test_conditional_break_points(self):
-        pass
 
-    @unittest.skip('Not required')
-    def test_logpoints(self):
-        pass
-
-
-class ServerAttachLifecycleTests(LaunchLifecycleTests):
+class ServerAttachTests(BreakpointTests):
     def test_with_break_points(self):
         filename = os.path.join(TEST_FILES_DIR, 'output.py')
         cwd = os.path.dirname(filename)
@@ -376,20 +370,8 @@ class ServerAttachLifecycleTests(LaunchLifecycleTests):
             filename,
             bp_line=3)
 
-    @unittest.skip('Not required')
-    def test_with_break_points_across_files(self):
-        pass
 
-    @unittest.skip('Not required')
-    def test_conditional_break_points(self):
-        pass
-
-    @unittest.skip('Not required')
-    def test_logpoints(self):
-        pass
-
-
-class PTVSDAttachLifecycleTests(LaunchLifecycleTests):
+class PTVSDAttachTests(BreakpointTests):
     def test_with_break_points(self):
         filename = os.path.join(TEST_FILES_DIR, 'attach_output.py')
         cwd = os.path.dirname(filename)
@@ -404,20 +386,8 @@ class PTVSDAttachLifecycleTests(LaunchLifecycleTests):
             filename,
             bp_line=6)
 
-    @unittest.skip('Not required')
-    def test_with_break_points_across_files(self):
-        pass
 
-    @unittest.skip('Not required')
-    def test_conditional_break_points(self):
-        pass
-
-    @unittest.skip('Not required')
-    def test_logpoints(self):
-        pass
-
-
-class ServerAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
+class ServerAttachModuleTests(BreakpointTests):  # noqa
     def test_with_break_points(self):
         module_name = 'mymod_launch1'
         cwd = os.path.join(TEST_FILES_DIR)
@@ -434,21 +404,9 @@ class ServerAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
             bp_filename,
             bp_line=3)
 
-    @unittest.skip('Not required')
-    def test_with_break_points_across_files(self):
-        pass
-
-    @unittest.skip('Not required')
-    def test_conditional_break_points(self):
-        pass
-
-    @unittest.skip('Not required')
-    def test_logpoints(self):
-        pass
-
 
 @unittest.skip('Needs fixing')
-class PTVSDAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
+class PTVSDAttachModuleTests(BreakpointTests):  # noqa
     def test_with_break_points(self):
         module_name = 'mymod_attach1'
         cwd = os.path.join(TEST_FILES_DIR)
@@ -465,15 +423,3 @@ class PTVSDAttachModuleLifecycleTests(LaunchLifecycleTests):  # noqa
                 starttype='attach'),
             bp_filename,
             bp_line=6)
-
-    @unittest.skip('Not required')
-    def test_with_break_points_across_files(self):
-        pass
-
-    @unittest.skip('Not required')
-    def test_conditional_break_points(self):
-        pass
-
-    @unittest.skip('Not required')
-    def test_logpoints(self):
-        pass

--- a/tests/system_tests/test_exceptions.py
+++ b/tests/system_tests/test_exceptions.py
@@ -12,7 +12,7 @@ TEST_FILES_DIR = os.path.join(ROOT, 'tests', 'resources', 'system_tests',
                               'test_exceptions')
 
 
-class LaunchExceptionLifecycleTests(LifecycleTestsBase):
+class ExceptionTests(LifecycleTestsBase):
     def run_test_not_breaking_into_handled_exceptions(self, debug_info):
         excbreakpoints = [{"filters": ["uncaught"]}]
         options = {"debugOptions": ["RedirectOutput"]}
@@ -33,12 +33,6 @@ class LaunchExceptionLifecycleTests(LifecycleTestsBase):
                 self.new_event("terminated"),
             ],
         )
-
-    def test_not_breaking_into_handled_exceptions(self):
-        filename = os.path.join(TEST_FILES_DIR, 'handled_exceptions_launch.py')
-        cwd = os.path.dirname(filename)
-        self.run_test_not_breaking_into_handled_exceptions(
-            DebugInfo(filename=filename, cwd=cwd))
 
     def run_test_breaking_into_handled_exceptions(self, debug_info):
         excbreakpoints = [{"filters": ["raised", "uncaught"]}]
@@ -90,6 +84,14 @@ class LaunchExceptionLifecycleTests(LifecycleTestsBase):
             ],
         )
 
+
+class LaunchFileTests(ExceptionTests):
+    def test_not_breaking_into_handled_exceptions(self):
+        filename = os.path.join(TEST_FILES_DIR, 'handled_exceptions_launch.py')
+        cwd = os.path.dirname(filename)
+        self.run_test_not_breaking_into_handled_exceptions(
+            DebugInfo(filename=filename, cwd=cwd))
+
     def test_breaking_into_handled_exceptions(self):
         filename = os.path.join(TEST_FILES_DIR, 'handled_exceptions_launch.py')
         cwd = os.path.dirname(filename)
@@ -97,7 +99,7 @@ class LaunchExceptionLifecycleTests(LifecycleTestsBase):
             DebugInfo(filename=filename, cwd=cwd))
 
 
-class LaunchModuleExceptionLifecycleTests(LaunchExceptionLifecycleTests):
+class LaunchModuleExceptionLifecycleTests(ExceptionTests):
     def test_breaking_into_handled_exceptions(self):
         module_name = 'mymod_launch1'
         env = {"PYTHONPATH": TEST_FILES_DIR}
@@ -113,7 +115,7 @@ class LaunchModuleExceptionLifecycleTests(LaunchExceptionLifecycleTests):
             DebugInfo(modulename=module_name, env=env, cwd=cwd))
 
 
-class ServerAttachExceptionLifecycleTests(LaunchExceptionLifecycleTests):
+class ServerAttachExceptionLifecycleTests(ExceptionTests):
     def test_breaking_into_handled_exceptions(self):
         filename = os.path.join(TEST_FILES_DIR, 'handled_exceptions_launch.py')
         cwd = os.path.dirname(filename)
@@ -131,7 +133,7 @@ class ServerAttachExceptionLifecycleTests(LaunchExceptionLifecycleTests):
                 filename=filename, cwd=cwd, starttype='attach', argv=argv))
 
 
-class PTVSDAttachExceptionLifecycleTests(LaunchExceptionLifecycleTests):
+class PTVSDAttachExceptionLifecycleTests(ExceptionTests):
     def test_breaking_into_handled_exceptions(self):
         filename = os.path.join(TEST_FILES_DIR, 'handled_exceptions_attach.py')
         cwd = os.path.dirname(filename)
@@ -144,7 +146,7 @@ class PTVSDAttachExceptionLifecycleTests(LaunchExceptionLifecycleTests):
                 starttype='attach',
                 argv=argv))
 
-    @unittest.skip('broken')
+    @unittest.skip('Needs fixing in #609')
     def test_not_breaking_into_handled_exceptions(self):
         filename = os.path.join(TEST_FILES_DIR, 'handled_exceptions_attach.py')
         cwd = os.path.dirname(filename)
@@ -158,8 +160,7 @@ class PTVSDAttachExceptionLifecycleTests(LaunchExceptionLifecycleTests):
                 argv=argv))
 
 
-class ServerAttachModuleExceptionLifecycleTests(
-        LaunchExceptionLifecycleTests):  # noqa
+class ServerAttachModuleExceptionLifecycleTests(ExceptionTests):  # noqa
     def test_breaking_into_handled_exceptions(self):
         module_name = 'mymod_launch1'
         env = {"PYTHONPATH": TEST_FILES_DIR}
@@ -188,8 +189,7 @@ class ServerAttachModuleExceptionLifecycleTests(
 
 
 @unittest.skip('Needs fixing')
-class PTVSDAttachModuleExceptionLifecycleTests(
-        LaunchExceptionLifecycleTests):  # noqa
+class PTVSDAttachModuleExceptionLifecycleTests(ExceptionTests):  # noqa
     def test_breaking_into_handled_exceptions(self):
         module_name = 'mymod_attach1'
         env = {"PYTHONPATH": TEST_FILES_DIR}

--- a/tests/system_tests/test_variables.py
+++ b/tests/system_tests/test_variables.py
@@ -10,7 +10,7 @@ TEST_FILES_DIR = os.path.join(ROOT, 'tests', 'resources', 'system_tests',
                               'test_variables')
 
 
-class VariableLifecycleTests(LifecycleTestsBase):
+class VariableTests(LifecycleTestsBase):
     def test_variables(self):
         filename = os.path.join(TEST_FILES_DIR, 'simple.py')
         cwd = os.path.dirname(filename)


### PR DESCRIPTION
Purpose: Avoid having to use `@unittest.skip`

* Create base classes for tests
* Move test methods into test classes

