### PR TITLE
Do not check __main__.__file__ under -m.

### DIFF
--- a/ptvsd/pydevd_hooks.py
+++ b/ptvsd/pydevd_hooks.py
@@ -92,7 +92,8 @@ def install(pydevd, address,
     pydevd.start_server = _start_server
     pydevd.start_client = _start_client
     __main__ = sys.modules['__main__']
-    if __main__ is not pydevd and __main__.__file__ == pydevd.__file__:
-        __main__.start_server = _start_server
-        __main__.start_client = _start_client
+    if __main__ is not pydevd:
+        if getattr(__main__, '__file__', None) == pydevd.__file__:
+            __main__.start_server = _start_server
+            __main__.start_client = _start_client
     return daemon

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -188,6 +188,9 @@ class TestsBase(object):
             self._pathentry.install()
             return self._pathentry
 
+    def enable_verbose(self):
+        DebugAdapter.VERBOSE = True
+
     def write_script(self, name, content):
         return self.workspace.write_python_script(name, content=content)
 

--- a/tests/system_tests/test_basic.py
+++ b/tests/system_tests/test_basic.py
@@ -219,8 +219,8 @@ class ServerAttachModuleTests(BasicTests):  # noqa
                 starttype='attach'))
 
 
-@unittest.skip('Needs fixing #545')
-class PTVSDAttachModuleTests(BasicTests):  # noqa
+class PTVSDAttachModuleTests(BasicTests):
+
     def test_with_output(self):
         module_name = 'mymod_attach1'
         cwd = os.path.join(TEST_FILES_DIR, 'test_output')

--- a/tests/system_tests/test_basic.py
+++ b/tests/system_tests/test_basic.py
@@ -222,6 +222,7 @@ class ServerAttachModuleTests(BasicTests):  # noqa
 class PTVSDAttachModuleTests(BasicTests):
 
     def test_with_output(self):
+        #self.enable_verbose()
         module_name = 'mymod_attach1'
         cwd = os.path.join(TEST_FILES_DIR, 'test_output')
         env = {"PYTHONPATH": cwd}


### PR DESCRIPTION
(fixes #592)

Under certain circumstances, `__main__` is a "builtin" module.  Such modules do not have a `__file__` attribute.  Consequently, this caused the pydevd injection code to fail.  This PR fixes that.