### PR TITLE
Switch from Awaitable to SentRequest.

### DIFF
--- a/tests/helpers/debugsession.py
+++ b/tests/helpers/debugsession.py
@@ -220,11 +220,6 @@ class DebugSession(Closeable):
         self._add_pending_handler(match, pending, handlername)
         return pending
 
-    # TODO: Drop get_awaiter_for_event().
-
-    def get_awaiter_for_event(self, event, condition=lambda msg: True, **kwargs): # noqa
-        return self.add_pending_event(event, match_body=condition)
-
     # internal methods
 
     def _close(self):
@@ -461,12 +456,3 @@ class SentRequest(dict):
         if self._pending is None:
             return False
         return self._pending.wait(timeout)
-
-
-# TODO: Drop Awaitable.
-
-class Awaitable(object):
-
-    @classmethod
-    def wait_all(cls, *awaitables):
-        wait_all(awaitables)

--- a/tests/system_tests/test_basic.py
+++ b/tests/system_tests/test_basic.py
@@ -60,9 +60,9 @@ class BasicTests(LifecycleTestsBase):
 
             Awaitable.wait_all(req_launch,
                                session.get_awaiter_for_event('thread'))
-            disconnect = session.send_request('disconnect')
+            session.send_request_and_wait('disconnect')
 
-            Awaitable.wait_all(exited, terminated, disconnect)
+            Awaitable.wait_all(exited, terminated)
 
     def run_test_without_output(self, debug_info):
         options = {'debugOptions': ['RedirectOutput']}

--- a/tests/system_tests/test_breakpoints.py
+++ b/tests/system_tests/test_breakpoints.py
@@ -134,25 +134,25 @@ class BreakpointTests(LifecycleTestsBase):
                                     breakpoints=breakpoints)
             tid = event.body['threadId']
 
-            req_stacktrace = session.send_request_and_request(
+            req_stacktrace = session.send_request_and_wait(
                 'stackTrace',
                 threadId=tid,
             )
             frames = req_stacktrace.resp.body['stackFrames']
             frame_id = frames[0]['id']
-            req_scopes = session.send_request_and_request(
+            req_scopes = session.send_request_and_wait(
                 'scopes',
                 frameId=frame_id,
             )
             scopes = req_scopes.resp.body['scopes']
             variables_reference = scopes[0]['variablesReference']
-            req_variables = session.send_request_and_request(
+            req_variables = session.send_request_and_wait(
                 'variables',
                 variablesReference=variables_reference,
             )
             variables = req_variables.resp.body['variables']
 
-            session.send_request_and_request('continue', threadId=tid)
+            session.send_request_and_wait('continue', threadId=tid)
 
         self.assert_is_subset(variables, [{
             'name': 'a',

--- a/tests/system_tests/test_breakpoints.py
+++ b/tests/system_tests/test_breakpoints.py
@@ -27,13 +27,12 @@ class BreakpointTests(LifecycleTestsBase):
 
         with self.start_debugging(debug_info) as dbg:
             session = dbg.session
-            with session.wait_for_event('stopped') as result:
+            with session.wait_for_event('stopped') as event:
                 (_, req_launch_attach, _, _, _, _,
                  ) = lifecycle_handshake(session, debug_info.starttype,
                                          options=options,
                                          breakpoints=breakpoints)
                 req_launch_attach.wait()
-            event = result['msg']
             tid = event.body['threadId']
 
             req_stacktrace = session.send_request(
@@ -94,12 +93,11 @@ class BreakpointTests(LifecycleTestsBase):
 
         with self.start_debugging(debug_info) as dbg:
             session = dbg.session
-            with session.wait_for_event('stopped') as result:
+            with session.wait_for_event('stopped') as event:
                 (_, req_launch_attach, _, _, _, _,
                  ) = lifecycle_handshake(session, debug_info.starttype,
                                          breakpoints=breakpoints)
                 req_launch_attach.wait()
-            event = result['msg']
             tid = event.body['threadId']
 
             req_stacktrace = session.send_request(
@@ -135,10 +133,9 @@ class BreakpointTests(LifecycleTestsBase):
 
         with self.start_debugging(debug_info) as dbg:
             session = dbg.session
-            with session.wait_for_event('stopped') as result:
+            with session.wait_for_event('stopped') as event:
                 lifecycle_handshake(session, debug_info.starttype,
                                     breakpoints=breakpoints)
-            event = result['msg']
             tid = event.body['threadId']
 
             req_stacktrace = session.send_request(
@@ -205,10 +202,9 @@ class BreakpointTests(LifecycleTestsBase):
             count = 0
             while count < hits:
                 if count == 0:
-                    with session.wait_for_event('stopped') as result:
+                    with session.wait_for_event('stopped') as event:
                         lifecycle_handshake(session, debug_info.starttype,
                                             breakpoints=breakpoints)
-                event = result['msg']
                 tid = event.body['threadId']
 
                 req_stacktrace = session.send_request(
@@ -237,7 +233,7 @@ class BreakpointTests(LifecycleTestsBase):
                 i_values.append(i_value[0] if len(i_value) > 0 else None)
                 count = count + 1
                 if count < hits:
-                    with session.wait_for_event('stopped') as result:
+                    with session.wait_for_event('stopped') as event:
                         session.send_request('continue', threadId=tid)
                 else:
                     session.send_request('continue', threadId=tid)

--- a/tests/system_tests/test_exceptions.py
+++ b/tests/system_tests/test_exceptions.py
@@ -2,7 +2,6 @@ import os
 import os.path
 import unittest
 
-from tests.helpers.debugsession import Awaitable
 from tests.helpers.resource import TestResources
 from . import (
     _strip_newline_output_events, lifecycle_handshake,
@@ -37,19 +36,13 @@ class ExceptionTests(LifecycleTestsBase):
         options = {'debugOptions': ['RedirectOutput']}
 
         with self.start_debugging(debug_info) as dbg:
-            stopped = dbg.session.get_awaiter_for_event('stopped')
-            (_, req_launch_attach, _, _, _, _
-             ) = lifecycle_handshake(dbg.session, debug_info.starttype,
-                                     excbreakpoints=excbreakpoints,
-                                     options=options,
-                                     threads=True)
+            with dbg.session.wait_for_event('stopped') as event:
+                lifecycle_handshake(dbg.session, debug_info.starttype,
+                                    excbreakpoints=excbreakpoints,
+                                    options=options,
+                                    threads=True)
+            thread_id = event.body["threadId"]
 
-            Awaitable.wait_all(req_launch_attach, stopped)
-            self.assertEqual(stopped.event.body['text'], 'ArithmeticError')
-            self.assertIn("ArithmeticError('Hello'",
-                          stopped.event.body['description'])
-
-            thread_id = stopped.event.body['threadId']
             req_exc_info = dbg.session.send_request_and_wait(
                 'exceptionInfo',
                 threadId=thread_id,
@@ -65,14 +58,27 @@ class ExceptionTests(LifecycleTestsBase):
                 }
             })
 
-            continued = dbg.session.get_awaiter_for_event('continued')
-            dbg.session.send_request_and_wait(
-                'continue',
-                threadId=thread_id,
-            )
-            Awaitable.wait_all(continued)
+            with dbg.session.wait_for_event('continued'):
+                dbg.session.send_request_and_wait(
+                    'continue',
+                    threadId=thread_id,
+                )
 
         received = list(_strip_newline_output_events(dbg.session.received))
+
+        self.assertEqual(event.body["text"], "ArithmeticError")
+        self.assertIn("ArithmeticError('Hello'",
+                      event.body["description"])
+
+        self.assert_is_subset(exc_info, {
+            "exceptionId": "ArithmeticError",
+            "breakMode": "always",
+            "details": {
+                "typeName": "ArithmeticError",
+                # "source": debug_info.filename
+            }
+        })
+
         self.assert_contains(received, [
             self.new_event('continued', threadId=thread_id),
             self.new_event('output', category='stdout', output='end'),

--- a/tests/system_tests/test_exceptions.py
+++ b/tests/system_tests/test_exceptions.py
@@ -50,11 +50,10 @@ class ExceptionTests(LifecycleTestsBase):
                           stopped.event.body['description'])
 
             thread_id = stopped.event.body['threadId']
-            req_exc_info = dbg.session.send_request(
+            req_exc_info = dbg.session.send_request_and_wait(
                 'exceptionInfo',
                 threadId=thread_id,
             )
-            req_exc_info.wait()
             exc_info = req_exc_info.resp.body
 
             self.assert_is_subset(exc_info, {
@@ -67,10 +66,10 @@ class ExceptionTests(LifecycleTestsBase):
             })
 
             continued = dbg.session.get_awaiter_for_event('continued')
-            dbg.session.send_request(
+            dbg.session.send_request_and_wait(
                 'continue',
                 threadId=thread_id,
-            ).wait()
+            )
             Awaitable.wait_all(continued)
 
         received = list(_strip_newline_output_events(dbg.session.received))

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -370,13 +370,12 @@ class LifecycleTests(LifecycleTestsBase):
             with DebugClient() as editor:
                 session1 = editor.attach_socket(addr, adapter, timeout=1)
                 #session1.VERBOSE = True
-                with session1.wait_for_event('thread') as result:
+                with session1.wait_for_event('thread') as event:
                     with session1.wait_for_event('process'):
                         (req_init1, req_attach1, req_config1,
                          _, _, req_threads1,
                          ) = lifecycle_handshake(session1, 'attach',
                                                  threads=True)
-                event = result['msg']
                 tid1 = event.body['threadId']
 
                 stopped_event = session1.get_awaiter_for_event('stopped')
@@ -413,13 +412,12 @@ class LifecycleTests(LifecycleTestsBase):
 
                 session2 = editor.attach_socket(addr, adapter, timeout=1)
                 #session2.VERBOSE = True
-                with session2.wait_for_event('thread') as result:
+                with session2.wait_for_event('thread') as event:
                     with session2.wait_for_event('process'):
                         (req_init2, req_attach2, req_config2,
                          _, _, req_threads3,
                          ) = lifecycle_handshake(session2, 'attach',
                                                  threads=True)
-                event = result['msg']
                 tid2 = event.body['threadId']
 
                 done2()
@@ -643,7 +641,7 @@ class LifecycleTests(LifecycleTestsBase):
                 # TODO: There appears to be a small race that may
                 # cause the test to fail here.
                 with session.wait_for_event('stopped'):
-                    with session.wait_for_event('thread') as result:
+                    with session.wait_for_event('thread') as event:
                         with session.wait_for_event('process'):
                             (req_init, req_attach, req_config,
                              reqs_bps, _, req_threads1,
@@ -660,7 +658,6 @@ class LifecycleTests(LifecycleTestsBase):
                                 line = adapter.output.readline()
                             done1()
                         req_bps, = reqs_bps  # There should only be one.
-                    event = result['msg']
                     tid = event.body['threadId']
                 req_threads2 = session.send_request('threads')
                 req_stacktrace1 = session.send_request(

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -374,7 +374,7 @@ class LifecycleTests(LifecycleTestsBase):
                                                  threads=True)
                 tid1 = event.body['threadId']
 
-                with self.wait_for_event('stopped'):
+                with session1.wait_for_event('stopped'):
                     req_bps = session1.send_request_and_wait(
                         'setBreakpoints',
                         source={'path': filename},

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -128,10 +128,10 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_newline_output_events(session.received))
         self.assert_received(received[:7], [
             self.new_version_event(session.received),
-            self.new_response(req_initialize.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_launch.req),
-            self.new_response(req_config.req),
+            self.new_response(req_launch),
+            self.new_response(req_config),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -161,10 +161,10 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_newline_output_events(session.received))
         self.assert_received(received[:7], [
             self.new_version_event(session.received),
-            self.new_response(req_initialize.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_launch.req),
-            self.new_response(req_config.req),
+            self.new_response(req_launch),
+            self.new_response(req_config),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -196,10 +196,10 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_newline_output_events(session.received))
         self.assert_received(received[:7], [
             self.new_version_event(session.received),
-            self.new_response(req_initialize.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_launch.req),
-            self.new_response(req_config.req),
+            self.new_response(req_launch),
+            self.new_response(req_config),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -250,10 +250,10 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_newline_output_events(session.received))
         self.assert_received(received, [
             self.new_version_event(session.received),
-            self.new_response(req_initialize.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_launch.req),
-            self.new_response(req_config.req),
+            self.new_response(req_launch),
+            self.new_response(req_config),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -299,10 +299,10 @@ class LifecycleTests(LifecycleTestsBase):
 
         self.assert_contains(received, [
             self.new_version_event(session1.received),
-            self.new_response(reqs[0].req, **INITIALIZE_RESPONSE),
+            self.new_response(reqs[0], **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(reqs[1].req),
-            self.new_response(reqs[2].req),
+            self.new_response(reqs[1]),
+            self.new_response(reqs[2]),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -310,17 +310,17 @@ class LifecycleTests(LifecycleTestsBase):
                 'name': filename,
             }),
             self.new_event('thread', reason='started', threadId=1),
-            self.new_response(req_disconnect.req),
+            self.new_response(req_disconnect),
         ])
         self.messages.reset_all()
         received = list(_strip_newline_output_events(session2.received))
 
         self.assert_contains(received, [
             self.new_version_event(session2.received),
-            self.new_response(req_initialize.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_launch.req),
-            self.new_response(req_config.req),
+            self.new_response(req_launch),
+            self.new_response(req_config),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -429,28 +429,28 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_newline_output_events(session1.received))
         self.assert_contains(received, [
             self.new_version_event(session1.received),
-            self.new_response(req_init1.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_init1, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_attach1.req),
+            self.new_response(req_attach1),
             self.new_event(
                 'thread',
                 threadId=tid1,
                 reason='started',
             ),
-            self.new_response(req_threads1.req, **{
+            self.new_response(req_threads1, **{
                 'threads': [{
                     'id': 1,
                     'name': 'MainThread',
                 }],
             }),
-            self.new_response(req_config1.req),
+            self.new_response(req_config1),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
                 'startMethod': 'attach',
                 'name': filename,
             }),
-            self.new_response(req_bps.req, **{
+            self.new_response(req_bps, **{
                 'breakpoints': [{
                     'id': 1,
                     'line': bp1,
@@ -468,7 +468,7 @@ class LifecycleTests(LifecycleTestsBase):
                 description=None,
                 text=None,
             ),
-            self.new_response(req_threads2.req, **{
+            self.new_response(req_threads2, **{
                 'threads': [{
                     'id': 1,
                     'name': 'MainThread',
@@ -484,7 +484,7 @@ class LifecycleTests(LifecycleTestsBase):
                 },
                 reason='new',
             ),
-            self.new_response(req_stacktrace1.req, **{
+            self.new_response(req_stacktrace1, **{
                 'totalFrames': 1,
                 'stackFrames': [{
                     'id': 1,
@@ -497,7 +497,7 @@ class LifecycleTests(LifecycleTestsBase):
                     'column': 1,
                 }],
             }),
-            self.new_response(req_disconnect.req),
+            self.new_response(req_disconnect),
         ])
         self.messages.reset_all()
         received = list(_strip_newline_output_events(session2.received))
@@ -506,21 +506,21 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_exit(received))
         self.assert_contains(received, [
             self.new_version_event(session2.received),
-            self.new_response(req_init2.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_init2, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_attach2.req),
+            self.new_response(req_attach2),
             self.new_event(
                 'thread',
                 threadId=tid2,
                 reason='started',
             ),
-            self.new_response(req_threads3.req, **{
+            self.new_response(req_threads3, **{
                 'threads': [{
                     'id': 1,
                     'name': 'MainThread',
                 }],
             }),
-            self.new_response(req_config2.req),
+            self.new_response(req_config2),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -577,10 +577,10 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_newline_output_events(session.received))
         self.assert_received(received, [
             self.new_version_event(session.received),
-            self.new_response(req_initialize.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_launch.req),
-            self.new_response(req_config.req),
+            self.new_response(req_launch),
+            self.new_response(req_config),
             self.new_event('exited', exitCode=0),
             self.new_event('terminated'),
         ])
@@ -711,21 +711,21 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_exit(received))
         self.assert_contains(received, [
             self.new_version_event(session.received),
-            self.new_response(req_init.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_init, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_attach.req),
+            self.new_response(req_attach),
             self.new_event(
                 'thread',
                 threadId=tid,
                 reason='started',
             ),
-            self.new_response(req_threads1.req, **{
+            self.new_response(req_threads1, **{
                 'threads': [{
                     'id': 1,
                     'name': 'MainThread',
                 }],
             }),
-            self.new_response(req_bps.req, **{
+            self.new_response(req_bps, **{
                 'breakpoints': [{
                     'id': 1,
                     'line': bp1,
@@ -736,7 +736,7 @@ class LifecycleTests(LifecycleTestsBase):
                     'verified': True,
                 }],
             }),
-            self.new_response(req_config.req),
+            self.new_response(req_config),
             self.new_event('process', **{
                 'isLocalProcess': True,
                 'systemProcessId': adapter.pid,
@@ -750,7 +750,7 @@ class LifecycleTests(LifecycleTestsBase):
                 description=None,
                 text=None,
             ),
-            self.new_response(req_threads2.req, **{
+            self.new_response(req_threads2, **{
                 'threads': [{
                     'id': 1,
                     'name': 'MainThread',
@@ -766,7 +766,7 @@ class LifecycleTests(LifecycleTestsBase):
                 },
                 reason='new',
             ),
-            self.new_response(req_stacktrace1.req, **{
+            self.new_response(req_stacktrace1, **{
                 'totalFrames': 1,
                 'stackFrames': [{
                     'id': 1,
@@ -779,7 +779,7 @@ class LifecycleTests(LifecycleTestsBase):
                     'column': 1,
                 }],
             }),
-            self.new_response(req_continue1.req),
+            self.new_response(req_continue1),
             self.new_event('continued', threadId=tid),
             self.new_event(
                 'output',
@@ -793,13 +793,13 @@ class LifecycleTests(LifecycleTestsBase):
                 description=None,
                 text=None,
             ),
-            self.new_response(req_threads3.req, **{
+            self.new_response(req_threads3, **{
                 'threads': [{
                     'id': 1,
                     'name': 'MainThread',
                 }],
             }),
-            self.new_response(req_stacktrace2.req, **{
+            self.new_response(req_stacktrace2, **{
                 'totalFrames': 1,
                 'stackFrames': [{
                     'id': 2,  # TODO: Isn't this the same frame as before?
@@ -812,7 +812,7 @@ class LifecycleTests(LifecycleTestsBase):
                     'column': 1,
                 }],
             }),
-            self.new_response(req_continue2.req),
+            self.new_response(req_continue2),
             self.new_event('continued', threadId=tid),
             self.new_event(
                 'output',
@@ -865,10 +865,10 @@ class LifecycleTests(LifecycleTestsBase):
         received = list(_strip_newline_output_events(session.received))
         self.assert_contains(received[:9], [
             self.new_version_event(session.received),
-            self.new_response(req_initialize.req, **INITIALIZE_RESPONSE),
+            self.new_response(req_initialize, **INITIALIZE_RESPONSE),
             self.new_event('initialized'),
-            self.new_response(req_launch.req),
-            self.new_response(req_config.req),
+            self.new_response(req_launch),
+            self.new_response(req_config),
             self.new_event('output',
                            output='+ before',
                            category='stdout'),

--- a/tests/system_tests/test_restart_vsc.py
+++ b/tests/system_tests/test_restart_vsc.py
@@ -21,11 +21,8 @@ class RestartVSCTests(LifecycleTestsBase):
         debug_info = DebugInfo(filename=filename, cwd=cwd)
 
         with self.start_debugging(debug_info) as dbg:
-            (_, req_launch, _, _, _, _
-             ) = lifecycle_handshake(dbg.session, debug_info.starttype)
-            req_launch.wait()
-
-            dbg.session.send_request('disconnect', restart=False)
+            lifecycle_handshake(dbg.session, debug_info.starttype)
+            dbg.session.send_request_and_wait('disconnect', restart=False)
 
         received = list(_strip_newline_output_events(dbg.session.received))
         evts = self.find_events(received, 'terminated')
@@ -37,10 +34,7 @@ class RestartVSCTests(LifecycleTestsBase):
         debug_info = DebugInfo(filename=filename, cwd=cwd)
 
         with self.start_debugging(debug_info) as dbg:
-            (_, req_launch, _, _, _, _
-             ) = lifecycle_handshake(dbg.session, debug_info.starttype)
-            req_launch.wait()
-
+            lifecycle_handshake(dbg.session, debug_info.starttype)
             dbg.session.send_request('disconnect', restart=True)
 
         received = list(_strip_newline_output_events(dbg.session.received))

--- a/tests/system_tests/test_variables.py
+++ b/tests/system_tests/test_variables.py
@@ -31,12 +31,11 @@ class VariableTests(LifecycleTestsBase):
 
         with self.start_debugging(debug_info) as dbg:
             session = dbg.session
-            with session.wait_for_event('stopped') as result:
+            with session.wait_for_event('stopped') as event:
                 (_, req_launch_attach, _, _, _, _,
                  ) = lifecycle_handshake(session, debug_info.starttype,
                                          breakpoints=breakpoints)
                 req_launch_attach.wait()
-            event = result['msg']
             tid = event.body['threadId']
 
             req_stacktrace = session.send_request(
@@ -184,13 +183,11 @@ class VariableTests(LifecycleTestsBase):
 
         with self.start_debugging(debug_info) as dbg:
             session = dbg.session
-            with session.wait_for_event('stopped') as result:
+            with session.wait_for_event('stopped') as event:
                 (_, req_launch_attach, _, _, _, _,
                  ) = lifecycle_handshake(session, debug_info.starttype,
                                          breakpoints=breakpoints)
                 req_launch_attach.wait()
-
-            event = result['msg']
             tid = event.body['threadId']
 
             req_stacktrace = session.send_request(


### PR DESCRIPTION
In tests we often need to wait for events and responses.  Recently we switch from using context managers for this to a new Awaitable class.  However, this makes the code a bit harder to follow.  This PR brings things back to a middle ground by:

* returning a new SentRequest object from `DebugSession.send_request()` instead of a dedicated "awaitable"
* adding `DebugSession.send_request_and_wait()`
* adding `t.h.debugsession.wait_all()` to replace Awaitable.wait_all()
* fixing up the tests to use `send_request_and_wait()`