### PR TITLE
Do not wait for settrace() to finish until wait_for_attach().

### DIFF
--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -13,6 +13,7 @@ def _pydevd_settrace(redirect_output=None, _pydevd=pydevd, **kwargs):
     # thread and all future threads.  PyDevd is not enabled for
     # existing threads (other than the current one).  Consequently,
     # pydevd.settrace() must be called ASAP in the current thread.
+    # See issue #509.
     #
     # This is tricky, however, because settrace() will block until
     # it receives a CMD_RUN message.  You can't just call it in a

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -63,6 +63,10 @@ def enable_attach(address,
     t = new_hidden_thread('start-pydevd', start_pydevd)
     t.start()
 
+    def wait(timeout=None):
+        t.join(timeout)
+        return not t.is_alive()
+
     def debug_current_thread(suspend=False, **kwargs):
         # Make sure that pydevd has finished starting before enabling
         # in the current thread.
@@ -81,4 +85,4 @@ def enable_attach(address,
             **kwargs
         )
         debug('pydevd enabled (current thread)')
-    return daemon, t.join, debug_current_thread
+    return daemon, wait, debug_current_thread

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -1,5 +1,6 @@
 import pydevd
 
+from ptvsd._util import debug
 from ptvsd.pydevd_hooks import install, start_server
 from ptvsd.socket import Address
 
@@ -16,6 +17,7 @@ def enable_attach(address,
                   _pydevd=pydevd, _install=install,
                   **kwargs):
     addr = Address.as_server(*address)
+    debug('installing ptvsd as server')
     # pydevd.settrace() forces a "client" connection, so we trick it
     # by setting start_client to start_server..
     daemon = _install(
@@ -26,12 +28,15 @@ def enable_attach(address,
         singlesession=False,
         **kwargs
     )
+    debug('enabling pydevd')
     # Only pass the port so start_server() gets triggered.
+    # As noted above, we also have to trick settrace() because it
+    # *always* forces a client connection.
     _pydevd.settrace(
-        host=addr.host,
         stdoutToServer=redirect_output,
         stderrToServer=redirect_output,
         port=addr.port,
         suspend=False,
     )
+    debug('pydevd enabled')
     return daemon

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -82,6 +82,9 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
     # debugging in the *current* thread.  That is done in
     # wait_for_attach().  Thus this approach is problematic if
     # wait_for_attach() is never called.
+    # TODO: Is there any way to ensure that debug_current_thread()
+    # gets called in the current thread, regardless of if
+    # wait_for_attach() gets called?
     _, wait, debug_current_thread = ptvsd_enable_attach(
         address,
         on_attach=_attached.set,

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -11,6 +11,8 @@ from ptvsd._remote import (
 )
 
 
+WAIT_TIMEOUT = 1.0  # TODO: Use a smaller value during tests?
+
 DEFAULT_HOST = '0.0.0.0'
 DEFAULT_PORT = 5678
 
@@ -78,13 +80,18 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
     # wait_for_attach() is never called.  It also assumes that
     # wait_for_attach() called only once and only in the same thread
     # where enable_attach was called.
-    _, _, debug_current_thread = ptvsd_enable_attach(
+    _, wait, debug_current_thread = ptvsd_enable_attach(
         address,
         on_attach=_attached.set,
         redirect_output=redirect_output,
     )
     global _debug_current_thread
     _debug_current_thread = debug_current_thread
+
+    # Give it a chance to finish starting.  This helps reduce possible
+    # issues due to relying on wait_for_attach().
+    if wait(WAIT_TIMEOUT):
+        debug_current_thread()
 
 
 # TODO: Add disable_attach()?

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -16,6 +16,7 @@ DEFAULT_PORT = 5678
 
 _enabled = False
 _attached = threading.Event()
+_pydevd_wait = None
 
 
 def wait_for_attach(timeout=None):
@@ -29,6 +30,7 @@ def wait_for_attach(timeout=None):
         The timeout for the operation in seconds (or fractions thereof).
     """
     _attached.wait(timeout)
+    _pydevd_wait()
 
 
 def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
@@ -65,11 +67,13 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
     _enabled = True
     _attached.clear()
 
-    ptvsd_enable_attach(
+    _, wait = ptvsd_enable_attach(
         address,
         on_attach=_attached.set,
         redirect_output=redirect_output,
     )
+    global _pydevd_wait
+    _pydevd_wait = wait
 
 
 # TODO: Add disable_attach()?

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -4,11 +4,11 @@
 
 import threading
 
-import pydevd
-
 # TODO: Why import run_module & run_file?
 from ptvsd._local import run_module, run_file  # noqa
-from ptvsd._remote import enable_attach as ptvsd_enable_attach
+from ptvsd._remote import (
+    enable_attach as ptvsd_enable_attach, _pydevd_settrace,
+)
 
 
 DEFAULT_HOST = '0.0.0.0'
@@ -71,6 +71,7 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
         redirect_output=redirect_output,
     )
 
+
 # TODO: Add disable_attach()?
 
 
@@ -87,7 +88,7 @@ def break_into_debugger():
         return
 
     import sys
-    pydevd.settrace(
+    _pydevd_settrace(
         suspend=True,
         trace_only_current_thread=True,
         patch_multiprocessing=False,

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -147,6 +147,7 @@ class DaemonBase(object):
             assert self._sessionlock is None
             assert self.session is None
             self._server = create_server(addr.host, addr.port)
+            debug('server socket created')
             self._sessionlock = threading.Lock()
         sock = self._sock
 

--- a/ptvsd/pydevd_hooks.py
+++ b/ptvsd/pydevd_hooks.py
@@ -31,12 +31,9 @@ def start_server(daemon, host, port, **kwargs):
             debug('failed:', exc, tb=True)
             return None
 
-    while True:
+    def serve_forever():
         debug('waiting on initial connection')
         handle_next()
-        break
-
-    def serve_forever():
         while True:
             debug('waiting on next connection')
             try:

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -416,12 +416,16 @@ class PydevdSocket(object):
 
     def pydevd_notify(self, cmd_id, args):
         # TODO: docstring
+        if self.pipe_w is None:
+            raise EOFError
         seq, s = self.make_packet(cmd_id, args)
         _util.log_pydevd_msg(cmd_id, seq, args, inbound=False)
         os.write(self.pipe_w, s.encode('utf8'))
 
     def pydevd_request(self, loop, cmd_id, args):
         # TODO: docstring
+        if self.pipe_w is None:
+            raise EOFError
         seq, s = self.make_packet(cmd_id, args)
         _util.log_pydevd_msg(cmd_id, seq, args, inbound=False)
         fut = loop.create_future()

--- a/tests/helpers/debugadapter.py
+++ b/tests/helpers/debugadapter.py
@@ -177,9 +177,11 @@ class DebugAdapter(Closeable):
 
     @classmethod
     def start_for_attach(cls, addr, *args, **kwargs):
+        wait = kwargs.pop('waitforserver', False)
         addr = Address.as_server(*addr)
         adapter = cls._start_as(addr, *args, server=True, **kwargs)
-        wait_for_socket_server(addr)
+        if wait:
+            wait_for_socket_server(addr)
         return adapter
 
     @classmethod
@@ -205,6 +207,7 @@ class DebugAdapter(Closeable):
 
     @classmethod
     def start_embedded(cls, addr, filename, argv=[], **kwargs):
+        wait = kwargs.pop('waitforserver', False)
         addr = Address.as_server(*addr)
         with open(filename, 'r+') as scriptfile:
             content = scriptfile.read()
@@ -212,7 +215,8 @@ class DebugAdapter(Closeable):
             assert 'ptvsd.enable_attach' in content
         adapter = cls.start_wrapper_script(
             filename, argv=argv, addr=addr, **kwargs)
-        wait_for_socket_server(addr, **kwargs)
+        if wait:
+            wait_for_socket_server(addr, **kwargs)
         return adapter
 
     @classmethod

--- a/tests/helpers/debugsession.py
+++ b/tests/helpers/debugsession.py
@@ -179,6 +179,9 @@ class DebugSession(Closeable):
 
         wait = args.pop('wait', False)
         req = self._create_request(command, **args)
+        if self.VERBOSE:
+            msg = parse_message(req)
+            print(' <-', msg)
 
         if wait:
             with self.wait_for_response(req) as resp:

--- a/tests/helpers/script.py
+++ b/tests/helpers/script.py
@@ -66,6 +66,13 @@ def find_line(script, label):
 ########################
 # wait points
 
+def _indent(script, line):
+    indent = ' ' * (len(line) - len(line.lstrip(' ')))
+    if not indent:
+        return script
+    return indent + (os.linesep + indent).join(script.splitlines())
+
+
 def insert_release(script, lockfile, label=None):
     """Return (script, wait func) after adding a done script to the original.
 
@@ -85,6 +92,7 @@ def insert_release(script, lockfile, label=None):
         lines = iter(script.splitlines())
         for line, matched in iter_until_label(lines, label):
             if matched:
+                donescript = _indent(donescript, line)
                 leading.extend([
                     donescript,
                     line,
@@ -143,6 +151,7 @@ def insert_lock(script, lockfile, label=None, timeout=5):
         lines = iter(script.splitlines())
         for line, matched in iter_until_label(lines, label):
             if matched:
+                waitscript = _indent(waitscript, line)
                 leading.extend([
                     waitscript,
                     line,

--- a/tests/resources/system_tests/test_forever/attach_forever.py
+++ b/tests/resources/system_tests/test_forever/attach_forever.py
@@ -2,6 +2,7 @@ import ptvsd
 import sys
 import time
 
+
 ptvsd.enable_attach((sys.argv[1], sys.argv[2]))
 ptvsd.wait_for_attach()
 

--- a/tests/resources/system_tests/test_forever/attach_forever.py
+++ b/tests/resources/system_tests/test_forever/attach_forever.py
@@ -10,5 +10,6 @@ ptvsd.wait_for_attach()
 i = 0
 while True:
     time.sleep(0.1)
+    # <bp>
     print(i)
     i += 1

--- a/tests/resources/system_tests/test_forever/attach_forever.py
+++ b/tests/resources/system_tests/test_forever/attach_forever.py
@@ -3,6 +3,8 @@ import sys
 import time
 
 ptvsd.enable_attach((sys.argv[1], sys.argv[2]))
+ptvsd.wait_for_attach()
+
 
 i = 0
 while True:

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -285,12 +285,15 @@ Original Error:
             debug_info.starttype == 'attach' and \
             debug_info.filename is not None:
             argv = debug_info.argv
-            with DebugAdapter.start_embedded(
-                    addr,
-                    debug_info.filename,
-                    argv=argv,
-                    env=env,
-                    cwd=cwd) as adapter:
+            adapter = DebugAdapter.start_embedded(
+                addr,
+                debug_info.filename,
+                argv=argv,
+                env=env,
+                cwd=cwd,
+                waitforserver=True,
+            )
+            with adapter:
                 with DebugClient() as editor:
                     time.sleep(DELAY_WAITING_FOR_SOCKETS)
                     session = editor.attach_socket(addr, adapter)
@@ -307,13 +310,16 @@ Original Error:
                 name = debug_info.modulename
                 kind = 'module'
             argv = debug_info.argv
-            with DebugAdapter.start_for_attach(
-                    addr,
-                    name=name,
-                    extra=argv,
-                    kind=kind,
-                    env=env,
-                    cwd=cwd) as adapter:
+            adapter = DebugAdapter.start_for_attach(
+                addr,
+                name=name,
+                extra=argv,
+                kind=kind,
+                env=env,
+                cwd=cwd,
+                waitforserver=True,
+            )
+            with adapter:
                 with DebugClient() as editor:
                     time.sleep(DELAY_WAITING_FOR_SOCKETS)
                     session = editor.attach_socket(addr, adapter)

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -184,6 +184,19 @@ def _configure(session, breakpoints, excbreakpoints):
     return reqs_bps, reqs_exc, req_done
 
 
+def react_to_stopped(session, tid):
+    req_threads = session.send_request('threads')
+    req_threads.wait()
+
+    req_stacktrace = session.send_request(
+        'stackTrace',
+        threadId=tid,
+    )
+    req_stacktrace.wait()
+
+    return req_threads, req_stacktrace
+
+
 class TestsBase(object):
 
     @property

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -23,8 +23,8 @@ PORT = 9879
 CONNECT_TIMEOUT = 5.0
 DELAY_WAITING_FOR_SOCKETS = 1.0
 
-DebugInfo = namedtuple('DebugInfo', 'host port starttype argv filename modulename env cwd attachtype')  # noqa
-DebugInfo.__new__.__defaults__ = ('localhost', PORT, 'launch', []) + ((None, ) * (len(DebugInfo._fields) - 4))  # noqa
+DebugInfo = namedtuple('DebugInfo', 'host port starttype argv filename modulename env cwd attachtype verbose')  # noqa
+DebugInfo.__new__.__defaults__ = ('localhost', PORT, 'launch', [], None, None, None, None, None, False)  # noqa
 
 
 Debugger = namedtuple('Debugger', 'session adapter')
@@ -293,6 +293,8 @@ Original Error:
             _kill_proc(adapter.pid)
             _wrap_and_reraise(session, ex, exc_type, exc_value, exc_traceback)
 
+        if debug_info.verbose:
+            DebugAdapter.VERBOSE = True
         if debug_info.attachtype == 'import' and \
             debug_info.modulename is not None:
             argv = debug_info.argv

--- a/tests/system_tests/test_enable_attach.py
+++ b/tests/system_tests/test_enable_attach.py
@@ -30,22 +30,41 @@ class EnableAttachTests(LifecycleTestsBase, unittest.TestCase):
             wait(timeout=3)
             adapter.wait()
 
-    @unittest.skip('fails due to "thread" event never happening')
+    @unittest.skip('fails due to "stopped" event never happening')
     def test_never_call_wait_for_attach(self):
         addr = Address('localhost', PORT)
         filename = self.write_script('spam.py', """
             import sys
+            import threading
+            import time
+
             sys.path.insert(0, {!r})
             import ptvsd
             ptvsd.enable_attach({}, redirect_output=False)
             # <ready>
-            # <wait>
+            print('== ready ==')
+
+            # Allow tracing to be triggered.
+            def wait():
+                # <wait>
+                pass
+            t = threading.Thread(target=wait)
+            t.start()
+            for _ in range(100):  # 10 seconds
+                print('-----')
+                t.join(0.1)
+                if not t.is_alive():
+                    break
+            t.join()
+
+            print('== starting ==')
             # <bp>
+            print('== done ==')
             """.format(PROJECT_ROOT, tuple(addr)),
         )
-        lockfile1 = self.workspace.lockfile()
+        lockfile1 = self.workspace.lockfile('ready.lock')
         _, wait = set_release(filename, lockfile1, 'ready')
-        lockfile2 = self.workspace.lockfile()
+        lockfile2 = self.workspace.lockfile('wait.log')
         done, script = set_lock(filename, lockfile2, 'wait')
 
         bp = find_line(script, 'bp')
@@ -57,22 +76,31 @@ class EnableAttachTests(LifecycleTestsBase, unittest.TestCase):
         }]
 
         #DebugAdapter.VERBOSE = True
+        #DebugClient.SESSION.VERBOSE = True
         adapter = DebugAdapter.start_embedded(addr, filename)
         with adapter:
-            wait(timeout=3)
+            # Wait longer that WAIT_TIMEOUT, so that debugging isn't
+            # immediately enabled in the script's thread.
+            wait(timeout=3.0)
+
             with DebugClient() as editor:
                 session = editor.attach_socket(addr, adapter, timeout=1)
                 with session.wait_for_event('thread') as result:
                     lifecycle_handshake(session, 'attach',
-                                        breakpoints=breakpoints)
+                                        breakpoints=breakpoints,
+                                        threads=True)
                 event = result['msg']
                 tid = event.body['threadId']
-                wait(timeout=1)
+
                 with session.wait_for_event('stopped'):
                     done()
                 session.send_request('continue', threadId=tid)
 
                 adapter.wait()
+        out = str(adapter.output)
+
+        self.assertIn('== ready ==', out)
+        self.assertIn('== starting ==', out)
 
     def test_wait_for_attach(self):
         addr = Address('localhost', PORT)

--- a/tests/system_tests/test_enable_attach.py
+++ b/tests/system_tests/test_enable_attach.py
@@ -1,0 +1,62 @@
+import unittest
+
+from ptvsd.socket import Address
+from tests import PROJECT_ROOT
+from tests.helpers.debugadapter import DebugAdapter
+from tests.helpers.debugclient import EasyDebugClient as DebugClient
+from tests.helpers.lock import LockTimeoutError
+from tests.helpers.script import set_lock, set_release
+from . import LifecycleTestsBase, PORT, lifecycle_handshake
+
+
+class EnableAttachTests(LifecycleTestsBase, unittest.TestCase):
+
+    def test_does_not_block(self):
+        addr = Address('localhost', PORT)
+        filename = self.write_script('spam.py', """
+            import sys
+            sys.path.insert(0, {!r})
+            import ptvsd
+            ptvsd.enable_attach({}, redirect_output=False)
+            # <ready>
+            """.format(PROJECT_ROOT, tuple(addr)),
+        )
+        lockfile = self.workspace.lockfile()
+        _, wait = set_release(filename, lockfile, 'ready')
+
+        #DebugAdapter.VERBOSE = True
+        adapter = DebugAdapter.start_embedded(addr, filename)
+        with adapter:
+            wait(timeout=1)
+            adapter.wait()
+
+    def test_wait_for_attach(self):
+        addr = Address('localhost', PORT)
+        filename = self.write_script('spam.py', """
+            import sys
+            sys.path.insert(0, {!r})
+            import ptvsd
+            ptvsd.enable_attach({}, redirect_output=False)
+
+            ptvsd.wait_for_attach()
+            # <ready>
+            # <wait>
+            """.format(PROJECT_ROOT, tuple(addr)),
+        )
+        lockfile1 = self.workspace.lockfile()
+        _, wait = set_release(filename, lockfile1, 'ready')
+        lockfile2 = self.workspace.lockfile()
+        done, _ = set_lock(filename, lockfile2, 'wait')
+
+        adapter = DebugAdapter.start_embedded(addr, filename)
+        with adapter:
+            with DebugClient() as editor:
+                session = editor.attach_socket(addr, adapter, timeout=1)
+                # Ensure that it really does wait.
+                with self.assertRaises(LockTimeoutError):
+                    wait(timeout=0.5)
+
+                lifecycle_handshake(session, 'attach')
+                wait(timeout=1)
+                done()
+                adapter.wait()

--- a/tests/system_tests/test_enable_attach.py
+++ b/tests/system_tests/test_enable_attach.py
@@ -30,6 +30,7 @@ class EnableAttachTests(LifecycleTestsBase, unittest.TestCase):
             wait(timeout=3)
             adapter.wait()
 
+    @unittest.skip('fails due to "thread" event never happening')
     def test_never_call_wait_for_attach(self):
         addr = Address('localhost', PORT)
         filename = self.write_script('spam.py', """

--- a/tests/system_tests/test_enable_attach.py
+++ b/tests/system_tests/test_enable_attach.py
@@ -27,7 +27,7 @@ class EnableAttachTests(LifecycleTestsBase, unittest.TestCase):
         #DebugAdapter.VERBOSE = True
         adapter = DebugAdapter.start_embedded(addr, filename)
         with adapter:
-            wait(timeout=1)
+            wait(timeout=3)
             adapter.wait()
 
     def test_wait_for_attach(self):

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -15,7 +15,7 @@ from tests.helpers.debugsession import Awaitable
 from . import (
     _strip_newline_output_events, lifecycle_handshake, TestsBase,
     LifecycleTestsBase, _strip_output_event, _strip_exit, _find_events,
-    PORT,
+    PORT, react_to_stopped,
 )
 
 
@@ -645,11 +645,7 @@ class LifecycleTests(LifecycleTestsBase):
                             done1()
                     event = result['msg']
                     tid = event.body['threadId']
-                req_threads2 = session.send_request('threads')
-                req_stacktrace1 = session.send_request(
-                    'stackTrace',
-                    threadId=tid,
-                )
+                req_threads2, req_stacktrace1 = react_to_stopped(session, tid)
                 out2 = str(adapter.output)
 
                 # Tell the script to proceed (at "# <bp 2>").  This
@@ -662,11 +658,7 @@ class LifecycleTests(LifecycleTestsBase):
                             'continue',
                             threadId=tid,
                         )
-                req_threads3 = session.send_request('threads')
-                req_stacktrace2 = session.send_request(
-                    'stackTrace',
-                    threadId=tid,
-                )
+                req_threads3, req_stacktrace2 = react_to_stopped(session, tid)
                 out3 = str(adapter.output)
 
                 with session.wait_for_event('continued'):

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -631,6 +631,7 @@ class LifecycleTests(LifecycleTestsBase):
                                                      breakpoints=breakpoints,
                                                      options=options,
                                                      threads=True)
+                            req_bps, = reqs_bps  # There should only be one.
 
                             # Grab the initial output.
                             out1 = next(adapter.output)  # 'waiting for attach'
@@ -638,8 +639,10 @@ class LifecycleTests(LifecycleTestsBase):
                             while line:
                                 out1 += line
                                 line = adapter.output.readline()
+
+                            # Tell the script to proceed (at "# <waiting>").
+                            # This leads to the first breakpoint.
                             done1()
-                        req_bps, = reqs_bps  # There should only be one.
                     event = result['msg']
                     tid = event.body['threadId']
                 req_threads2 = session.send_request('threads')
@@ -649,6 +652,9 @@ class LifecycleTests(LifecycleTestsBase):
                 )
                 out2 = str(adapter.output)
 
+                # Tell the script to proceed (at "# <bp 2>").  This
+                # leads to the second breakpoint.  At this point
+                # execution is still stopped at the first breakpoint.
                 done2()
                 with session.wait_for_event('stopped'):
                     with session.wait_for_event('continued'):

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -15,7 +15,9 @@ from tests.helpers.debugsession import Awaitable
 from . import (
     _strip_newline_output_events, lifecycle_handshake, TestsBase,
     LifecycleTestsBase, _strip_output_event, _strip_exit, _find_events,
-    PORT)
+    PORT,
+)
+
 
 ROOT = os.path.dirname(os.path.dirname(ptvsd.__file__))
 

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -658,6 +658,7 @@ class LifecycleTests(LifecycleTestsBase):
                             'continue',
                             threadId=tid,
                         )
+                        req_continue1.wait()
                 req_threads3, req_stacktrace2 = react_to_stopped(session, tid)
                 out3 = str(adapter.output)  # "attached!"
 
@@ -666,6 +667,7 @@ class LifecycleTests(LifecycleTestsBase):
                         'continue',
                         threadId=tid,
                     )
+                    req_continue2.wait()
 
                 adapter.wait()
             out4 = str(adapter.output)  # "done waiting"

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -577,13 +577,13 @@ class LifecycleTests(LifecycleTestsBase):
 
             addr = {}
             ptvsd.enable_attach(addr)
-            print('waiting for attach')
+            print('== waiting for attach ==')
             # <waiting>
             ptvsd.wait_for_attach()
             # <attached>
-            print('attached!')
+            print('== attached! ==')
             # <bp 2>
-            print('done waiting')
+            print('== done waiting ==')
             """.format(ROOT, tuple(addr)))
         lockfile1 = self.workspace.lockfile()
         done1, _ = set_lock(filename, lockfile1, 'waiting')
@@ -635,7 +635,7 @@ class LifecycleTests(LifecycleTestsBase):
                 tid = event.body['threadId']
 
                 # Grab the initial output.
-                out1 = next(adapter.output)  # 'waiting for attach'
+                out1 = next(adapter.output)  # "waiting for attach"
                 line = adapter.output.readline()
                 while line:
                     out1 += line
@@ -646,7 +646,7 @@ class LifecycleTests(LifecycleTestsBase):
                     # This leads to the first breakpoint.
                     done1()
                 req_threads2, req_stacktrace1 = react_to_stopped(session, tid)
-                out2 = str(adapter.output)
+                out2 = str(adapter.output)  # ""
 
                 # Tell the script to proceed (at "# <bp 2>").  This
                 # leads to the second breakpoint.  At this point
@@ -659,7 +659,7 @@ class LifecycleTests(LifecycleTestsBase):
                             threadId=tid,
                         )
                 req_threads3, req_stacktrace2 = react_to_stopped(session, tid)
-                out3 = str(adapter.output)
+                out3 = str(adapter.output)  # "attached!"
 
                 with session.wait_for_event('continued'):
                     req_continue2 = session.send_request(
@@ -668,13 +668,13 @@ class LifecycleTests(LifecycleTestsBase):
                     )
 
                 adapter.wait()
-            out4 = str(adapter.output)
+            out4 = str(adapter.output)  # "done waiting"
 
         # Output between enable_attach() and wait_for_attach() may
         # be sent at a relatively arbitrary time (or not at all).
         # So we ignore it by removing it from the message list.
         received = list(_strip_output_event(session.received,
-                                            u'waiting for attach'))
+                                            u'== waiting for attach =='))
         received = list(_strip_newline_output_events(received))
         # There's an ordering race with continue/continued that pops
         # up occasionally.  We work around that by manually fixing the
@@ -762,7 +762,7 @@ class LifecycleTests(LifecycleTestsBase):
             self.new_event(
                 'output',
                 category='stdout',
-                output='attached!',
+                output='== attached! ==',
             ),
             self.new_event(
                 'stopped',
@@ -795,7 +795,7 @@ class LifecycleTests(LifecycleTestsBase):
             self.new_event(
                 'output',
                 category='stdout',
-                output='done waiting',
+                output='== done waiting ==',
             ),
             #self.new_event(
             #    'thread',

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -225,6 +225,7 @@ class LifecycleTests(LifecycleTestsBase):
             sys.path.insert(0, {!r})
             import ptvsd
             ptvsd.enable_attach({}, redirect_output={})
+            ptvsd.wait_for_attach()
 
             print('success!', end='')
 
@@ -345,6 +346,7 @@ class LifecycleTests(LifecycleTestsBase):
 
             addr = {}
             ptvsd.enable_attach(addr)
+            ptvsd.wait_for_attach()
 
             # <before>
             print('==before==')

--- a/tests/system_tests/test_remote.py
+++ b/tests/system_tests/test_remote.py
@@ -192,6 +192,7 @@ class AttachFileTests(RemoteTests):
                 cwd=cwd,
                 starttype='attach',
                 argv=argv,
+                #verbose=True,
             ),
             expected_stacktrace,
             path_mappings,

--- a/tests/system_tests/test_remote.py
+++ b/tests/system_tests/test_remote.py
@@ -54,11 +54,10 @@ class RemoteTests(LifecycleTestsBase):
         }
 
         with self.start_debugging(debug_info) as dbg:
-            (_, req_attach, _, _, _, req_threads) = lifecycle_handshake(
-                dbg.session,
-                debug_info.starttype,
-                options=options,
-                threads=True)
+            (_, req_attach, _, _, _, req_threads,
+             ) = lifecycle_handshake(dbg.session, debug_info.starttype,
+                                     options=options,
+                                     threads=True)
 
             # wait till we enter the for loop.
             time.sleep(1)
@@ -143,7 +142,9 @@ class AttachFileTests(RemoteTests):
                 host=ip,
                 cwd=cwd,
                 starttype='attach',
-                argv=argv))
+                argv=argv,
+            ),
+        )
 
     def test_source_references_should_be_returned_without_path_mappings(self):
         filename = WITH_TEST_FORVER.resolve('attach_forever.py')
@@ -153,7 +154,7 @@ class AttachFileTests(RemoteTests):
             'stackFrames': [{
                 'source': {
                     'path': filename,
-                    'sourceReference': 1
+                    'sourceReference': 1,
                 }
             }],
         }
@@ -163,7 +164,10 @@ class AttachFileTests(RemoteTests):
                 attachtype='import',
                 cwd=cwd,
                 starttype='attach',
-                argv=argv), expected_stacktrace)
+                argv=argv,
+            ),
+            expected_stacktrace,
+        )
 
     def test_source_references_should_not_be_returned_with_path_mappings(self):
         filename = WITH_TEST_FORVER.resolve('attach_forever.py')
@@ -177,7 +181,7 @@ class AttachFileTests(RemoteTests):
             'stackFrames': [{
                 'source': {
                     'path': filename,
-                    'sourceReference': 0
+                    'sourceReference': 0,
                 }
             }],
         }
@@ -187,7 +191,11 @@ class AttachFileTests(RemoteTests):
                 attachtype='import',
                 cwd=cwd,
                 starttype='attach',
-                argv=argv), expected_stacktrace, path_mappings)
+                argv=argv,
+            ),
+            expected_stacktrace,
+            path_mappings,
+        )
 
     def test_source_references_should_be_returned_with_invalid_path_mappings(
             self):
@@ -202,7 +210,7 @@ class AttachFileTests(RemoteTests):
             'stackFrames': [{
                 'source': {
                     'path': filename,
-                    'sourceReference': 1
+                    'sourceReference': 1,
                 }
             }],
         }
@@ -212,7 +220,11 @@ class AttachFileTests(RemoteTests):
                 attachtype='import',
                 cwd=cwd,
                 starttype='attach',
-                argv=argv), expected_stacktrace, path_mappings)
+                argv=argv,
+            ),
+            expected_stacktrace,
+            path_mappings,
+        )
 
     def test_source_references_should_be_returned_with_win_client(self):
         filename = WITH_TEST_FORVER.resolve('attach_forever.py')
@@ -227,7 +239,7 @@ class AttachFileTests(RemoteTests):
             'stackFrames': [{
                 'source': {
                     'path': client_dir + '\\' + os.path.basename(filename),
-                    'sourceReference': 0
+                    'sourceReference': 0,
                 }
             }],
         }
@@ -237,10 +249,12 @@ class AttachFileTests(RemoteTests):
                 attachtype='import',
                 cwd=cwd,
                 starttype='attach',
-                argv=argv),
+                argv=argv,
+            ),
             expected_stacktrace,
             path_mappings=path_mappings,
-            debug_options=['WindowsClient'])
+            debug_options=['WindowsClient'],
+        )
 
     def test_source_references_should_be_returned_with_unix_client(self):
         filename = WITH_TEST_FORVER.resolve('attach_forever.py')
@@ -255,7 +269,7 @@ class AttachFileTests(RemoteTests):
             'stackFrames': [{
                 'source': {
                     'path': client_dir + '/' + os.path.basename(filename),
-                    'sourceReference': 0
+                    'sourceReference': 0,
                 }
             }],
         }
@@ -265,7 +279,9 @@ class AttachFileTests(RemoteTests):
                 attachtype='import',
                 cwd=cwd,
                 starttype='attach',
-                argv=argv),
+                argv=argv,
+            ),
             expected_stacktrace,
             path_mappings=path_mappings,
-            debug_options=['UnixClient'])
+            debug_options=['UnixClient'],
+        )


### PR DESCRIPTION
(helps #545)

We move the settrace() into a thread, but make sure to wait for the thread to finish in wait_for_attach().

My only concern with the solution is that the current thread will not get debugged if `enable_attach()` is called but `wait_for_attach()` is not (and no attach happens right away).  I'm going to address this in a follow-up PR by monkey-patching `sys.settrace` temporarily.