### PR TITLE
WIP - Try unique port

### DIFF
--- a/tests/resources/system_tests/test_exceptions/handled_exceptions_attach.py
+++ b/tests/resources/system_tests/test_exceptions/handled_exceptions_attach.py
@@ -1,6 +1,6 @@
 import sys
 import ptvsd
-ptvsd.enable_attach((('localhost', 9876)))
+ptvsd.enable_attach((('localhost', 9879)))
 ptvsd.wait_for_attach()
 
 try:

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -19,12 +19,12 @@ from tests.helpers.vsc import parse_message, VSCMessages, Response, Event
 
 
 ROOT = os.path.dirname(os.path.dirname(ptvsd.__file__))
-PORT = 9876
+PORT = 9879
 CONNECT_TIMEOUT = 3.0
 DELAY_WAITING_FOR_SOCKETS = 1.0
 
 DebugInfo = namedtuple('DebugInfo', 'host port starttype argv filename modulename env cwd attachtype')  # noqa
-DebugInfo.__new__.__defaults__ = ('localhost', 9876, 'launch', []) + ((None, ) * (len(DebugInfo._fields) - 4))  # noqa
+DebugInfo.__new__.__defaults__ = ('localhost', PORT, 'launch', []) + ((None, ) * (len(DebugInfo._fields) - 4))  # noqa
 
 
 Debugger = namedtuple('Debugger', 'session adapter')

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -14,7 +14,8 @@ from tests.helpers.debugsession import Awaitable
 
 from . import (
     _strip_newline_output_events, lifecycle_handshake, TestsBase,
-    LifecycleTestsBase, _strip_output_event, _strip_exit, _find_events)
+    LifecycleTestsBase, _strip_output_event, _strip_exit, _find_events,
+    PORT)
 
 ROOT = os.path.dirname(os.path.dirname(ptvsd.__file__))
 
@@ -88,8 +89,8 @@ class DebugTests(TestsBase, unittest.TestCase):
             print('done')
             sys.stdout.flush()
             """)
-        script = self.write_debugger_script(filename, 9876, run_as='script')
-        with DebugClient(port=9876) as editor:
+        script = self.write_debugger_script(filename, PORT, run_as='script')
+        with DebugClient(port=PORT) as editor:
             adapter, session = editor.host_local_debugger(argv, script)
             lifecycle_handshake(session, 'launch')
             adapter.wait()
@@ -109,8 +110,8 @@ class LifecycleTests(LifecycleTestsBase):
         lockfile = self.workspace.lockfile()
         done, waitscript = lockfile.wait_in_script()
         filename = self.write_script('spam.py', waitscript)
-        script = self.write_debugger_script(filename, 9876, run_as='script')
-        with DebugClient(port=9876) as editor:
+        script = self.write_debugger_script(filename, PORT, run_as='script')
+        with DebugClient(port=PORT) as editor:
             adapter, session = editor.host_local_debugger(
                 argv,
                 script,
@@ -825,7 +826,7 @@ class LifecycleTests(LifecycleTestsBase):
 
             print('+ after')
             """).format(waitscript))
-        with DebugClient(port=9876) as editor:
+        with DebugClient(port=PORT) as editor:
             adapter, session = editor.host_local_debugger(
                 argv=[
                     '--nodebug',


### PR DESCRIPTION
We have tests that seem to be holding on to port 9876.

I created this PR just to test whether we get any connection timeouts when using a different port (other than 9876). If we do not get any timeouts, then this proves the hypothesis that a process is created for testing is still holding onto port 9876.

Note: Previously the test framework for system tests, didn't properly dispose the resources that create socket servers, I have resolved that since then. It is most likely we have similar un-disposed resources in other tests (non-system tests).

Right now, its much easier to just use another port than identify what test is causing this issue, i know it isn't a system test.

