### PR TITLE
Revert "Use sys.exit() instead of os.kill(). (#538)"

### DIFF
--- a/tests/helpers/pydevd/_binder.py
+++ b/tests/helpers/pydevd/_binder.py
@@ -30,8 +30,7 @@ class PTVSD(ptvsd.daemon.Daemon):
             singlesession=singlesession,
         )
         self.start()
-        session = self.start_session(client, 'ptvsd.Server')
-        session._msgprocessor._kill_current_proc = (lambda: None)
+        self.start_session(client, 'ptvsd.Server')
         self.server = server
         return self
 


### PR DESCRIPTION
This reverts commit bd390322a8e31dcdb318da95e108c82f7f3a4f97.

Fixes #633 
Fixes #618 

@ericsnowcurrently 
I'm revering the above commit, as it didn't fix anything and it was introduced with an assumption that it was the right way to do things. There was no change to any tests, hence there was no difference, the original bug #530 was not resolved, and we have a two new issues as a result. Hence reverting it.