### PR TITLE
Add timeouts for thread.joins to ensure it does not block indefinitely

### DIFF
--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -219,9 +219,8 @@ class EasyDebugClient(DebugClient):
                         'unable to connect after {} secs'.format(
                             self._connecttimeout))
                 else:
-                    # This happens when using py27.
                     message = message + os.linesep + self._run_server_formatted_ex # noqa
-                    exec("raise Exception(message)", globals(), locals())
+                    raise Exception(message)
 
             # The adapter will close when the connection does.
 

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -193,14 +193,12 @@ class EasyDebugClient(DebugClient):
         assert self._session is None
         addr = ('localhost', self._addr.port)
 
-        self._run_server_ex = None
         self._run_server_formatted_ex = None
 
         def run():
             try:
                 self._session = self.SESSION.create_server(addr, **kwargs)
             except Exception as ex:
-                self._run_server_ex = ex
                 self._run_server_formatted_ex = traceback.format_exc()
 
         t = new_hidden_thread(
@@ -221,15 +219,9 @@ class EasyDebugClient(DebugClient):
                         'unable to connect after {} secs'.format(
                             self._connecttimeout))
                 else:
-                    try:
-                        # Chain the original exception for py3.
-                        exec(
-                            'raise Exception(message) from self._run_server_formatted_ex', # noqa
-                            globals(), locals())
-                    except SyntaxError:
-                        # This happens when using py27.
-                        message = message + os.linesep + self._run_server_formatted_ex # noqa
-                        exec("raise Exception(message)", globals(), locals())
+                    # This happens when using py27.
+                    message = message + os.linesep + self._run_server_formatted_ex # noqa
+                    exec("raise Exception(message)", globals(), locals())
 
             # The adapter will close when the connection does.
 

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -216,7 +216,7 @@ class EasyDebugClient(DebugClient):
             if self._session is None:
                 message = 'unable to connect after {} secs'.format(  # noqa
                     self._connecttimeout)
-                if self._run_server_formatted_ex is not None:
+                if self._run_server_formatted_ex is None:
                     raise RuntimeError(
                         'unable to connect after {} secs'.format(
                             self._connecttimeout))

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import os
+import traceback
 import warnings
 
 from ptvsd.socket import Address
@@ -15,12 +17,13 @@ class _LifecycleClient(Closeable):
 
     SESSION = DebugSession
 
-    def __init__(self,
-                 addr=None,
-                 port=8888,
-                 breakpoints=None,
-                 connecttimeout=1.0,
-                 ):
+    def __init__(
+            self,
+            addr=None,
+            port=8888,
+            breakpoints=None,
+            connecttimeout=1.0,
+    ):
         super(_LifecycleClient, self).__init__()
         self._addr = Address.from_raw(addr, defaultport=port)
         self._connecttimeout = connecttimeout
@@ -165,7 +168,6 @@ class DebugClient(_LifecycleClient):
 
 
 class EasyDebugClient(DebugClient):
-
     def start_detached(self, argv):
         """Start an adapter in a background process."""
         if self.closed:
@@ -191,8 +193,16 @@ class EasyDebugClient(DebugClient):
         assert self._session is None
         addr = ('localhost', self._addr.port)
 
+        self._run_server_ex = None
+        self._run_server_formatted_ex = None
+
         def run():
-            self._session = self.SESSION.create_server(addr, **kwargs)
+            try:
+                self._session = self.SESSION.create_server(addr, **kwargs)
+            except Exception as ex:
+                self._run_server_ex = ex
+                self._run_server_formatted_ex = traceback.format_exc()
+
         t = new_hidden_thread(
             target=run,
             name='test.client',
@@ -204,8 +214,23 @@ class EasyDebugClient(DebugClient):
             if t.is_alive():
                 warnings.warn('timed out waiting for connection')
             if self._session is None:
-                raise RuntimeError('unable to connect after {} secs'.format(
-                    self._connecttimeout))
+                message = 'unable to connect after {} secs'.format(  # noqa
+                    self._connecttimeout)
+                if self._run_server_formatted_ex is None:
+                    raise RuntimeError(
+                        'unable to connect after {} secs'.format(
+                            self._connecttimeout))
+                else:
+                    try:
+                        # Chain the original exception for py3.
+                        exec(
+                            'raise Exception(message) from self._run_server_formatted_ex', # noqa
+                            globals(), locals())
+                    except SyntaxError:
+                        # This happens when using py27.
+                        message = message + os.linesep + self._run_server_formatted_ex # noqa
+                        exec("raise Exception(message)", globals(), locals())
+
             # The adapter will close when the connection does.
 
         self._launch(

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -216,7 +216,7 @@ class EasyDebugClient(DebugClient):
             if self._session is None:
                 message = 'unable to connect after {} secs'.format(  # noqa
                     self._connecttimeout)
-                if self._run_server_formatted_ex is None:
+                if self._run_server_formatted_ex is not None:
                     raise RuntimeError(
                         'unable to connect after {} secs'.format(
                             self._connecttimeout))

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -193,13 +193,13 @@ class EasyDebugClient(DebugClient):
         assert self._session is None
         addr = ('localhost', self._addr.port)
 
-        self._run_server_formatted_ex = None
+        self._run_server_ex = None
 
         def run():
             try:
                 self._session = self.SESSION.create_server(addr, **kwargs)
             except Exception as ex:
-                self._run_server_formatted_ex = traceback.format_exc()
+                self._run_server_ex = traceback.format_exc()
 
         t = new_hidden_thread(
             target=run,
@@ -214,10 +214,10 @@ class EasyDebugClient(DebugClient):
             if self._session is None:
                 message = 'unable to connect after {} secs'.format(  # noqa
                     self._connecttimeout)
-                if self._run_server_formatted_ex is None:
+                if self._run_server_ex is None:
                     raise RuntimeError(message)
                 else:
-                    message = message + os.linesep + self._run_server_formatted_ex # noqa
+                    message = message + os.linesep + self._run_server_ex # noqa
                     raise Exception(message)
 
             # The adapter will close when the connection does.

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -215,7 +215,7 @@ class EasyDebugClient(DebugClient):
                 message = 'unable to connect after {} secs'.format(  # noqa
                     self._connecttimeout)
                 if self._run_server_ex is None:
-                    raise RuntimeError(message)
+                    raise Exception(message)
                 else:
                     message = message + os.linesep + self._run_server_ex # noqa
                     raise Exception(message)

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -215,9 +215,7 @@ class EasyDebugClient(DebugClient):
                 message = 'unable to connect after {} secs'.format(  # noqa
                     self._connecttimeout)
                 if self._run_server_formatted_ex is None:
-                    raise RuntimeError(
-                        'unable to connect after {} secs'.format(
-                            self._connecttimeout))
+                    raise RuntimeError(message)
                 else:
                     message = message + os.linesep + self._run_server_formatted_ex # noqa
                     raise Exception(message)

--- a/tests/helpers/proc.py
+++ b/tests/helpers/proc.py
@@ -168,7 +168,6 @@ class Proc(Closeable):
             stdout = subprocess.PIPE
         if stderr is _NOT_SET:
             stderr = subprocess.STDOUT
-        print('here')
         proc = subprocess.Popen(
             argv,
             stdout=stdout,

--- a/tests/helpers/proc.py
+++ b/tests/helpers/proc.py
@@ -168,6 +168,7 @@ class Proc(Closeable):
             stdout = subprocess.PIPE
         if stderr is _NOT_SET:
             stderr = subprocess.STDOUT
+        print('here')
         proc = subprocess.Popen(
             argv,
             stdout=stdout,

--- a/tests/helpers/pydevd/_binder.py
+++ b/tests/helpers/pydevd/_binder.py
@@ -142,7 +142,7 @@ class BinderBase(object):
         self._thread.join(timeout)
         if self._thread.isAlive():
             raise RuntimeError(
-                'wait_until_done timed out after {} s'.format(timeout))
+                'wait_until_done timed out after {} secs'.format(timeout))
 
     ####################
     # for subclassing

--- a/tests/helpers/pydevd/_binder.py
+++ b/tests/helpers/pydevd/_binder.py
@@ -132,13 +132,17 @@ class BinderBase(object):
             else:
                 raise RuntimeError('timed out')
             return self._wrap_sock()
+
         return connect, remote
 
-    def wait_until_done(self):
+    def wait_until_done(self, timeout=10.0):
         """Wait for the started debugger operation to finish."""
         if self._thread is None:
             return
-        self._thread.join()
+        self._thread.join(timeout)
+        if self._thread.isAlive():
+            raise RuntimeError(
+                'wait_until_done timed out after {} s'.format(timeout))
 
     ####################
     # for subclassing
@@ -187,8 +191,10 @@ class Binder(BinderBase):
 
     def __init__(self, do_debugging=None, **kwargs):
         if do_debugging is None:
+
             def do_debugging(external, internal):
                 time.sleep(5)
+
         super(Binder, self).__init__(**kwargs)
         self._do_debugging = do_debugging
 

--- a/tests/helpers/pydevd/_binder.py
+++ b/tests/helpers/pydevd/_binder.py
@@ -141,7 +141,7 @@ class BinderBase(object):
             return
         self._thread.join(timeout)
         if self._thread.isAlive():
-            raise RuntimeError(
+            raise Exception(
                 'wait_until_done timed out after {} secs'.format(timeout))
 
     ####################

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -234,7 +234,7 @@ class VSCLifecycle(object):
                 daemon.wait_until_connected()
         return daemon
 
-    def _stop_daemon(self, daemon, disconnect=True):
+    def _stop_daemon(self, daemon, disconnect=True, timeout=10.0):
         # We must close ptvsd directly (rather than closing the external
         # socket (i.e. "daemon").  This is because cloing ptvsd blocks,
         # keeping us from sending the disconnect request we need to send
@@ -251,7 +251,10 @@ class VSCLifecycle(object):
             t.start()
         if disconnect:
             self.disconnect()
-        t.join()
+        t.join(timeout)
+        if t.isAlive():
+            raise RuntimeError(
+                '_stop_daemon timed out after {} s'.format(timeout))
         daemon.close()
 
     def _handshake(self, command, threadnames=None, config=None, requests=None,

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -170,6 +170,7 @@ class VSCLifecycle(object):
         with self._fix.hidden() if hide else noop_cm():
             daemon = self._start_daemon(port)
         try:
+            print('daemon is running')
             yield
         finally:
             with self._fix.hidden() if hide else noop_cm():
@@ -189,8 +190,12 @@ class VSCLifecycle(object):
 
     def launch(self, **kwargs):
         """Initialize the debugger protocol and then launch."""
+        print('before hidden')
         with self._hidden():
+            print('inside hidden')
             self._handshake('launch', **kwargs)
+            print('after handshake in hidden')
+        print('after hidden')
 
     def attach(self, **kwargs):
         """Initialize the debugger protocol and then attach."""
@@ -230,8 +235,11 @@ class VSCLifecycle(object):
             # must be waited for here.
             # TODO: Is this necessary any more since we added the "readylock"?
             with self._fix.wait_for_event('output'):
+                print('start')
                 daemon = self._fix.fake.start(addr)
+                print('start2')
                 daemon.wait_until_connected()
+                print('start3')
         return daemon
 
     def _stop_daemon(self, daemon, disconnect=True, timeout=10.0):
@@ -544,6 +552,7 @@ class VSCFixture(FixtureBase):
 
     @property
     def lifecycle(self):
+        print('tw')
         try:
             return self._lifecycle
         except AttributeError:
@@ -689,6 +698,7 @@ class HighlevelFixture(object):
 
     @property
     def lifecycle(self):
+        print('one')
         return self._vsc.lifecycle
 
     @property

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -170,7 +170,6 @@ class VSCLifecycle(object):
         with self._fix.hidden() if hide else noop_cm():
             daemon = self._start_daemon(port)
         try:
-            print('daemon is running')
             yield
         finally:
             with self._fix.hidden() if hide else noop_cm():
@@ -190,12 +189,8 @@ class VSCLifecycle(object):
 
     def launch(self, **kwargs):
         """Initialize the debugger protocol and then launch."""
-        print('before hidden')
         with self._hidden():
-            print('inside hidden')
             self._handshake('launch', **kwargs)
-            print('after handshake in hidden')
-        print('after hidden')
 
     def attach(self, **kwargs):
         """Initialize the debugger protocol and then attach."""
@@ -235,11 +230,8 @@ class VSCLifecycle(object):
             # must be waited for here.
             # TODO: Is this necessary any more since we added the "readylock"?
             with self._fix.wait_for_event('output'):
-                print('start')
                 daemon = self._fix.fake.start(addr)
-                print('start2')
                 daemon.wait_until_connected()
-                print('start3')
         return daemon
 
     def _stop_daemon(self, daemon, disconnect=True, timeout=10.0):
@@ -552,7 +544,6 @@ class VSCFixture(FixtureBase):
 
     @property
     def lifecycle(self):
-        print('tw')
         try:
             return self._lifecycle
         except AttributeError:
@@ -698,7 +689,6 @@ class HighlevelFixture(object):
 
     @property
     def lifecycle(self):
-        print('one')
         return self._vsc.lifecycle
 
     @property

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -254,7 +254,7 @@ class VSCLifecycle(object):
         t.join(timeout)
         if t.isAlive():
             raise RuntimeError(
-                '_stop_daemon timed out after {} s'.format(timeout))
+                '_stop_daemon timed out after {} secs'.format(timeout))
         daemon.close()
 
     def _handshake(self, command, threadnames=None, config=None, requests=None,

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -253,7 +253,7 @@ class VSCLifecycle(object):
             self.disconnect()
         t.join(timeout)
         if t.isAlive():
-            raise RuntimeError(
+            raise Exception(
                 '_stop_daemon timed out after {} secs'.format(timeout))
         daemon.close()
 

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -201,14 +201,7 @@ class VSCFlowTest(TestBase):
     Original Error:
     ---------------
     %(error)s""" % fmt
-                try:
-                    # Chain the original exception for py3.
-                    exec('raise Exception(message) from ex', globals(),
-                         locals())
-                except SyntaxError:
-                    # This happens when using py27.
-                    message = message + os.linesep + formatted_ex
-                    exec("raise Exception(message)", globals(), locals())
+                exec("raise Exception(message)", globals(), locals())
             else:
                 raise
 
@@ -313,19 +306,19 @@ class BreakpointTests(VSCFlowTest, unittest.TestCase):
             'breakpoints': [],
             'excbreakpoints': [],
         }
-        with captured_stdio() as (stdout, _):
-            with self.launched(config=config):
-                # Allow the script to run to completion.
-                received = self.vsc.received
-        out = stdout.getvalue()
+        # with captured_stdio() as (stdout, _):
+        with self.launched(config=config):
+            # Allow the script to run to completion.
+            received = self.vsc.received
+        # out = stdout.getvalue()
 
         for req, _ in self.lifecycle.requests:
             self.assertNotEqual(req['command'], 'setBreakpoints')
             self.assertNotEqual(req['command'], 'setExceptionBreakpoints')
         self.assert_received(self.vsc, [])
         self.assert_vsc_received(received, [])
-        self.assertIn('2 4 4', out)
-        self.assertIn('ka-boom', out)
+        # self.assertIn('2 4 4', out)
+        # self.assertIn('ka-boom', out)
 
     def test_breakpoints_single_file(self):
         done1, _ = self._set_lock('d')

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -201,7 +201,7 @@ class VSCFlowTest(TestBase):
     Original Error:
     ---------------
     %(error)s""" % fmt
-                exec("raise Exception(message)", globals(), locals())
+                raise Exception(message)
             else:
                 raise
 

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -189,7 +189,6 @@ class VSCFlowTest(TestBase):
             formatted_ex = traceback.format_exc()
             if hasattr(self, 'vsc') and hasattr(self.vsc, 'received'):
                 fmt = {
-                    "sep": os.linesep,
                     "messages": os.linesep.join(self.vsc.received),
                     "error": formatted_ex
                 }

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -378,49 +378,49 @@ class BreakpointTests(VSCFlowTest, unittest.TestCase):
         self.assertIn('2 4 4', out)
         self.assertIn('ka-boom', err)
 
-    # @unittest.skip('not working right #614')
-    # def test_exception_breakpoints(self):
-    #     self.vsc.PRINT_RECEIVED_MESSAGES = True
-    #     done, script = self._set_lock('h')
-    #     self.lifecycle.requests = []  # Trigger capture.
-    #     config = {
-    #         'breakpoints': [],
-    #         'excbreakpoints': [
-    #             {'filters': ['raised']},
-    #         ],
-    #     }
-    #     with captured_stdio() as (stdout, _):
-    #         with self.launched(config=config):
-    #             with self.fix.hidden():
-    #                 _, tid = self.get_threads(self.thread.name)
-    #             with self.wait_for_event('stopped'):
-    #                 done()
+    @unittest.skip('not working right #614')
+    def test_exception_breakpoints(self):
+        self.vsc.PRINT_RECEIVED_MESSAGES = True
+        done, script = self._set_lock('h')
+        self.lifecycle.requests = []  # Trigger capture.
+        config = {
+            'breakpoints': [],
+            'excbreakpoints': [
+                {'filters': ['raised']},
+            ],
+        }
+        with captured_stdio() as (stdout, _):
+            with self.launched(config=config):
+                with self.fix.hidden():
+                    _, tid = self.get_threads(self.thread.name)
+                with self.wait_for_event('stopped'):
+                    done()
 
-    #             # Allow the script to run to completion.
-    #             received = self.vsc.received
-    #     out = stdout.getvalue()
-    #     #print(' + ' + '\n + '.join(out.splitlines()))
+                # Allow the script to run to completion.
+                received = self.vsc.received
+        out = stdout.getvalue()
+        #print(' + ' + '\n + '.join(out.splitlines()))
 
-    #     got = []
-    #     for req, resp in self.lifecycle.requests:
-    #         if req['command'] == 'setExceptionBreakpoints':
-    #             got.append(req['arguments'])
-    #         self.assertNotEqual(req['command'], 'setBreakpoints')
-    #     self.assertEqual(got, config['excbreakpoints'])
-    #     if sys.version_info >= (3, 7):
-    #         description = "MyError('ka-boom')"
-    #     else:
-    #         description = "MyError('ka-boom',)"
-    #     self.assert_vsc_received_fixing_events(received, [
-    #         ('stopped', dict(
-    #             reason='exception',
-    #             threadId=tid,
-    #             text='MyError',
-    #             description=description
-    #         )),
-    #     ])
-    #     self.assertIn('2 4 4', out)
-    #     self.assertIn('ka-boom', out)
+        got = []
+        for req, resp in self.lifecycle.requests:
+            if req['command'] == 'setExceptionBreakpoints':
+                got.append(req['arguments'])
+            self.assertNotEqual(req['command'], 'setBreakpoints')
+        self.assertEqual(got, config['excbreakpoints'])
+        if sys.version_info >= (3, 7):
+            description = "MyError('ka-boom')"
+        else:
+            description = "MyError('ka-boom',)"
+        self.assert_vsc_received_fixing_events(received, [
+            ('stopped', dict(
+                reason='exception',
+                threadId=tid,
+                text='MyError',
+                description=description
+            )),
+        ])
+        self.assertIn('2 4 4', out)
+        self.assertIn('ka-boom', out)
 
 
 @unittest.skip('Needs fixing when running with code coverage')

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -188,19 +188,14 @@ class VSCFlowTest(TestBase):
         except Exception as ex:
             formatted_ex = traceback.format_exc()
             if hasattr(self, 'vsc') and hasattr(self.vsc, 'received'):
-                fmt = {
-                    "messages": os.linesep.join(self.vsc.received),
-                    "error": formatted_ex
-                }
                 message = """
-
     Session Messages:
     -----------------
-    %(messages)s
+    {}
 
     Original Error:
     ---------------
-    %(error)s""" % fmt
+    {}""".format(os.linesep.join(self.vsc.received), formatted_ex)
                 raise Exception(message)
             else:
                 raise
@@ -306,19 +301,19 @@ class BreakpointTests(VSCFlowTest, unittest.TestCase):
             'breakpoints': [],
             'excbreakpoints': [],
         }
-        # with captured_stdio() as (stdout, _):
-        with self.launched(config=config):
-            # Allow the script to run to completion.
-            received = self.vsc.received
-        # out = stdout.getvalue()
+        with captured_stdio() as (stdout, _):
+            with self.launched(config=config):
+                # Allow the script to run to completion.
+                received = self.vsc.received
+        out = stdout.getvalue()
 
         for req, _ in self.lifecycle.requests:
             self.assertNotEqual(req['command'], 'setBreakpoints')
             self.assertNotEqual(req['command'], 'setExceptionBreakpoints')
         self.assert_received(self.vsc, [])
         self.assert_vsc_received(received, [])
-        # self.assertIn('2 4 4', out)
-        # self.assertIn('ka-boom', out)
+        self.assertIn('2 4 4', out)
+        self.assertIn('ka-boom', out)
 
     def test_breakpoints_single_file(self):
         done1, _ = self._set_lock('d')

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -177,7 +177,13 @@ class VSCFlowTest(TestBase):
         with self.lifecycle.launched(port=port, hide=True, **kwargs):
             yield
             self.fix.binder.done(close=False)
-        self.fix.binder.wait_until_done()
+        
+        try:
+            self.fix.binder.wait_until_done()
+        except Exception:
+            if hasattr(self, 'vsc') and hasattr(self.vsc, 'received'):
+                print(self.vsc.received)
+            raise
 
 
 class BreakpointTests(VSCFlowTest, unittest.TestCase):

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -378,49 +378,49 @@ class BreakpointTests(VSCFlowTest, unittest.TestCase):
         self.assertIn('2 4 4', out)
         self.assertIn('ka-boom', err)
 
-    @unittest.skip('not working right #614')
-    def test_exception_breakpoints(self):
-        self.vsc.PRINT_RECEIVED_MESSAGES = True
-        done, script = self._set_lock('h')
-        self.lifecycle.requests = []  # Trigger capture.
-        config = {
-            'breakpoints': [],
-            'excbreakpoints': [
-                {'filters': ['raised']},
-            ],
-        }
-        with captured_stdio() as (stdout, _):
-            with self.launched(config=config):
-                with self.fix.hidden():
-                    _, tid = self.get_threads(self.thread.name)
-                with self.wait_for_event('stopped'):
-                    done()
+    # @unittest.skip('not working right #614')
+    # def test_exception_breakpoints(self):
+    #     self.vsc.PRINT_RECEIVED_MESSAGES = True
+    #     done, script = self._set_lock('h')
+    #     self.lifecycle.requests = []  # Trigger capture.
+    #     config = {
+    #         'breakpoints': [],
+    #         'excbreakpoints': [
+    #             {'filters': ['raised']},
+    #         ],
+    #     }
+    #     with captured_stdio() as (stdout, _):
+    #         with self.launched(config=config):
+    #             with self.fix.hidden():
+    #                 _, tid = self.get_threads(self.thread.name)
+    #             with self.wait_for_event('stopped'):
+    #                 done()
 
-                # Allow the script to run to completion.
-                received = self.vsc.received
-        out = stdout.getvalue()
-        #print(' + ' + '\n + '.join(out.splitlines()))
+    #             # Allow the script to run to completion.
+    #             received = self.vsc.received
+    #     out = stdout.getvalue()
+    #     #print(' + ' + '\n + '.join(out.splitlines()))
 
-        got = []
-        for req, resp in self.lifecycle.requests:
-            if req['command'] == 'setExceptionBreakpoints':
-                got.append(req['arguments'])
-            self.assertNotEqual(req['command'], 'setBreakpoints')
-        self.assertEqual(got, config['excbreakpoints'])
-        if sys.version_info >= (3, 7):
-            description = "MyError('ka-boom')"
-        else:
-            description = "MyError('ka-boom',)"
-        self.assert_vsc_received_fixing_events(received, [
-            ('stopped', dict(
-                reason='exception',
-                threadId=tid,
-                text='MyError',
-                description=description
-            )),
-        ])
-        self.assertIn('2 4 4', out)
-        self.assertIn('ka-boom', out)
+    #     got = []
+    #     for req, resp in self.lifecycle.requests:
+    #         if req['command'] == 'setExceptionBreakpoints':
+    #             got.append(req['arguments'])
+    #         self.assertNotEqual(req['command'], 'setBreakpoints')
+    #     self.assertEqual(got, config['excbreakpoints'])
+    #     if sys.version_info >= (3, 7):
+    #         description = "MyError('ka-boom')"
+    #     else:
+    #         description = "MyError('ka-boom',)"
+    #     self.assert_vsc_received_fixing_events(received, [
+    #         ('stopped', dict(
+    #             reason='exception',
+    #             threadId=tid,
+    #             text='MyError',
+    #             description=description
+    #         )),
+    #     ])
+    #     self.assertIn('2 4 4', out)
+    #     self.assertIn('ka-boom', out)
 
 
 @unittest.skip('Needs fixing when running with code coverage')

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -251,7 +251,7 @@ class LifecycleTestsBase(TestsBase, unittest.TestCase):
 
             fmt = {
                 "messages": os.linesep.join(messages),
-                "error": ''.join(traceback.format_exception_only(exc_type, exc_value)) # noqa
+                "error": formatted_ex
             }
             message = """
 
@@ -263,13 +263,7 @@ Original Error:
 ---------------
 %(error)s""" % fmt
 
-            try:
-                # Chain the original exception for py3.
-                exec('raise Exception(message) from ex', globals(), locals())
-            except SyntaxError:
-                # This happens when using py27.
-                message = message + os.linesep + formatted_ex
-                exec("raise Exception(message)", globals(), locals())
+            exec("raise Exception(message)", globals(), locals())
 
         def _handle_exception(ex, adapter, session):
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -263,7 +263,7 @@ Original Error:
 ---------------
 %(error)s""" % fmt
 
-            exec("raise Exception(message)", globals(), locals())
+            raise Exception(message)
 
         def _handle_exception(ex, adapter, session):
             exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -249,19 +249,14 @@ class LifecycleTestsBase(TestsBase, unittest.TestCase):
             except Exception:
                 pass
 
-            fmt = {
-                "messages": os.linesep.join(messages),
-                "error": formatted_ex
-            }
             message = """
-
 Session Messages:
 -----------------
-%(messages)s
+{}
 
 Original Error:
 ---------------
-%(error)s""" % fmt
+{}""".format(os.linesep.join(messages), formatted_ex)
 
             raise Exception(message)
 

--- a/tests/system_tests/__init__.py
+++ b/tests/system_tests/__init__.py
@@ -250,7 +250,6 @@ class LifecycleTestsBase(TestsBase, unittest.TestCase):
                 pass
 
             fmt = {
-                "sep": os.linesep,
                 "messages": os.linesep.join(messages),
                 "error": ''.join(traceback.format_exception_only(exc_type, exc_value)) # noqa
             }


### PR DESCRIPTION
* Add timeouts for thread.joins (**this is the main change**)
* Format errors captured and displayed (for py27 and 3 compatibility)
* Format code (this accounts for 95% of the changes, was tired of linter errors, hence formatted code using autpep8)