### PR TITLE
Turning suspend all policy and using get stack trace command

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2082,7 +2082,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
                 self.bp_map.remove(pyd_bpid, vsc_bpid)
 
         cmd = pydevd_comm.CMD_SET_BREAK
-        msgfmt = '{}\t{}\t{}\t{}\tNone\t{}\t{}\t{}\t{}'
+        msgfmt = '{}\t{}\t{}\t{}\tNone\t{}\t{}\t{}\t{}\tALL'
         if needs_unicode(path):
             msgfmt = unicode(msgfmt)   # noqa
         for src_bp in src_bps:

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2138,14 +2138,15 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
             self.send_response(request)
 
     def _get_exception_description(self, pyd_tid, pyd_fid):
-            cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
-            cmdid = pydevd_comm.CMD_GET_VARIABLE
-            _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
-            xml = self.parse_xml_response(resp_args)
+        cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
+        cmdid = pydevd_comm.CMD_GET_VARIABLE
+        _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
+        xml = self.parse_xml_response(resp_args)
 
-            name = unquote(xml.var[1]['type'])
-            description = unquote(xml.var[1]['value'])
-            return name, description
+        name = unquote(xml.var[1]['type'])
+        description = unquote(xml.var[1]['value'])
+        yield name, description
+        return
 
     @async_handler
     def on_exceptionInfo(self, request, args):

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2146,7 +2146,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
             name = unquote(xml.var[1]['type'])
             description = unquote(xml.var[1]['value'])
-            return (name, description)
+            return name, description
 
     @async_handler
     def on_exceptionInfo(self, request, args):

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2137,17 +2137,6 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         if request is not None:
             self.send_response(request)
 
-    def _get_exception_description(self, pyd_tid, pyd_fid):
-        cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
-        cmdid = pydevd_comm.CMD_GET_VARIABLE
-        _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
-        xml = self.parse_xml_response(resp_args)
-
-        name = unquote(xml.var[1]['type'])
-        description = unquote(xml.var[1]['value'])
-        yield name, description
-        return
-
     @async_handler
     def on_exceptionInfo(self, request, args):
         # TODO: docstring
@@ -2165,9 +2154,14 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
             xframe = xframes[0]
             pyd_fid = xframe['id']
-            name, description = self._get_exception_description(
-                                    pyd_tid,
-                                    pyd_fid)
+
+            cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
+            cmdid = pydevd_comm.CMD_GET_VARIABLE
+            _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
+            xml = self.parse_xml_response(resp_args)
+
+            name = unquote(xml.var[1]['type'])
+            description = unquote(xml.var[1]['value'])
 
             frame_data = []
             for f in xframes:
@@ -2378,9 +2372,13 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         if reason == 'exception':
             try:
                 pyd_fid = xframe['id']
-                text, description = self._get_exception_description(
-                                        pyd_tid,
-                                        pyd_fid)
+                cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
+                cmdid = pydevd_comm.CMD_GET_VARIABLE
+                _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
+                xml = self.parse_xml_response(resp_args)
+
+                text = unquote(xml.var[1]['type'])
+                description = unquote(xml.var[1]['value'])
             except Exception:
                 pass
 

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2146,7 +2146,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
             name = unquote(xml.var[1]['type'])
             description = unquote(xml.var[1]['value'])
-            return name, description
+            return (name, description)
 
     @async_handler
     def on_exceptionInfo(self, request, args):
@@ -2165,13 +2165,10 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
             xframe = xframes[0]
             pyd_fid = xframe['id']
-            cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
-            cmdid = pydevd_comm.CMD_GET_VARIABLE
-            _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
-            xml = self.parse_xml_response(resp_args)
+            name, description = self._get_exception_description(
+                                    pyd_tid,
+                                    pyd_fid)
 
-            name = unquote(xml.var[1]['type'])
-            description = unquote(xml.var[1]['value'])
             frame_data = []
             for f in xframes:
                 file_path = unquote(f['file'])

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1478,6 +1478,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         # TODO: Wait until the last request has been handled?
 
     def _resume_all_threads(self):
+        # TODO: Replace this with resume all command after #732 is fixed
         for pyd_tid in self.thread_map.pydevd_ids():
             self.pydevd_notify(pydevd_comm.CMD_THREAD_RUN, pyd_tid)
 
@@ -1582,6 +1583,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         try:
             pyd_tid = self.thread_map.to_pydevd(vsc_tid)
         except KeyError:
+            # Unknown thread, nothing much we cna do about it here
             self.send_error_response(request)
             return
 
@@ -1985,6 +1987,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
                 return
 
         # Always suspend all threads.
+        # TODO: Replace this with suspend all command after #732 is fixed
         for pyd_tid in self.thread_map.pydevd_ids():
             self.pydevd_notify(pydevd_comm.CMD_THREAD_SUSPEND, pyd_tid)
         self.send_response(request)
@@ -1993,6 +1996,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     def on_continue(self, request, args):
         # TODO: docstring
         # Always continue all threads.
+        # TODO: Replace this with resume all command after #732 is fixed
         for pyd_tid in self.thread_map.pydevd_ids():
             self.pydevd_notify(pydevd_comm.CMD_THREAD_RUN, pyd_tid)
         self.send_response(request, allThreadsContinued=True)

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1995,9 +1995,10 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     @async_handler
     def on_continue(self, request, args):
         # TODO: docstring
-        tid = self.thread_map.to_pydevd(int(args['threadId']))
-        self.pydevd_notify(pydevd_comm.CMD_THREAD_RUN, tid)
-        self.send_response(request)
+        # Always suspend all threads.
+        for pyd_tid in self.thread_map.pydevd_ids():
+            self.pydevd_notify(pydevd_comm.CMD_THREAD_RUN, pyd_tid)
+        self.send_response(request, allThreadsContinued=True)
 
     @async_handler
     def on_next(self, request, args):

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2165,10 +2165,13 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
             xframe = xframes[0]
             pyd_fid = xframe['id']
-            name, description = self._get_exception_description(
-                                    pyd_tid,
-                                    pyd_fid)
+            cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
+            cmdid = pydevd_comm.CMD_GET_VARIABLE
+            _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
+            xml = self.parse_xml_response(resp_args)
 
+            name = unquote(xml.var[1]['type'])
+            description = unquote(xml.var[1]['value'])
             frame_data = []
             for f in xframes:
                 file_path = unquote(f['file'])

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2372,7 +2372,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         if reason == 'exception':
             try:
                 pyd_fid = xframe['id']
-                cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
+                cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid,
+                                                                pyd_fid)
                 cmdid = pydevd_comm.CMD_GET_VARIABLE
                 _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
                 xml = self.parse_xml_response(resp_args)

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -2381,7 +2381,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
                 text = unquote(xml.var[1]['type'])
                 description = unquote(xml.var[1]['value'])
             except Exception:
-                pass
+                text = 'BaseException'
+                description = 'exception: no description'
 
         self.send_event(
             'stopped',

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1581,6 +1581,11 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
         try:
             pyd_tid = self.thread_map.to_pydevd(vsc_tid)
+        except KeyError:
+            self.send_error_response(request)
+            return
+
+        try:
             cmd = pydevd_comm.CMD_GET_THREAD_STACK
             _, _, resp_args = yield self.pydevd_request(cmd, pyd_tid)
             xml = self.parse_xml_response(resp_args)

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1579,9 +1579,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         levels = int(args.get('levels', 0))
         fmt = args.get('format', {})
 
-        pyd_tid = self.thread_map.to_pydevd(vsc_tid)
-
         try:
+            pyd_tid = self.thread_map.to_pydevd(vsc_tid)
             cmd = pydevd_comm.CMD_GET_THREAD_STACK
             _, _, resp_args = yield self.pydevd_request(cmd, pyd_tid)
             xml = self.parse_xml_response(resp_args)

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -563,16 +563,12 @@ class VariablesSorter(object):
         if var_name.startswith('__'):
             if var_name.endswith('__'):
                 self.dunder.append(var)
-                #print('Apended dunder: %s' % var_name)
             else:
                 self.double_underscore.append(var)
-                #print('Apended double under: %s' % var_name)
         elif var_name.startswith('_'):
             self.single_underscore.append(var)
-            #print('Apended single under: %s' % var_name)
         else:
             self.variables.append(var)
-            #print('Apended variable: %s' % var_name)
 
     def get_sorted_variables(self):
         def get_sort_key(o):
@@ -581,7 +577,6 @@ class VariablesSorter(object):
         self.single_underscore.sort(key=get_sort_key)
         self.double_underscore.sort(key=get_sort_key)
         self.dunder.sort(key=get_sort_key)
-        #print('sorted')
         return self.variables + self.single_underscore + self.double_underscore + self.dunder  # noqa
 
 
@@ -1218,10 +1213,6 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         # debugger state
         self.is_process_created = False
         self.is_process_created_lock = threading.Lock()
-        self.stack_traces = {}
-        self.stack_traces_lock = threading.Lock()
-        self.active_exceptions = {}
-        self.active_exceptions_lock = threading.Lock()
         self.thread_map = IDMap()
         self.frame_map = IDMap()
         self.var_map = IDMap()
@@ -1487,8 +1478,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         # TODO: Wait until the last request has been handled?
 
     def _resume_all_threads(self):
-        for tid in self.stack_traces:
-            self.pydevd_notify(pydevd_comm.CMD_THREAD_RUN, tid)
+        for pyd_tid in self.thread_map.pydevd_ids():
+            self.pydevd_notify(pydevd_comm.CMD_THREAD_RUN, pyd_tid)
 
     def send_process_event(self, start_method):
         # TODO: docstring
@@ -1589,15 +1580,17 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         fmt = args.get('format', {})
 
         pyd_tid = self.thread_map.to_pydevd(vsc_tid)
-        with self.stack_traces_lock:
-            try:
-                xframes = self.stack_traces[pyd_tid]
-            except KeyError:
-                # This means the stack was requested before the
-                # thread was suspended
-                xframes = []
-        totalFrames = len(xframes)
 
+        try:
+            cmd = pydevd_comm.CMD_GET_THREAD_STACK
+            _, _, resp_args = yield self.pydevd_request(cmd, pyd_tid)
+            xml = self.parse_xml_response(resp_args)
+            xframes = list(xml.thread.frame)
+        except Exception:
+            self.send_error_response(request, 'Stack unavailable')
+            return
+
+        totalFrames = len(xframes)
         if levels == 0:
             levels = totalFrames
 
@@ -1641,8 +1634,9 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
 
         user_frames = []
         for frame in stackFrames:
-            if not self.internals_filter.is_internal_path(
-                frame['source']['path']):
+            path = frame['source']['path']
+            if not self.internals_filter.is_internal_path(path) and \
+                self._should_debug(path):
                 user_frames.append(frame)
 
         totalFrames = len(user_frames)
@@ -2148,13 +2142,57 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     def on_exceptionInfo(self, request, args):
         # TODO: docstring
         pyd_tid = self.thread_map.to_pydevd(args['threadId'])
-        with self.active_exceptions_lock:
-            try:
-                exc = self.active_exceptions[pyd_tid]
-            except KeyError:
-                exc = ExceptionInfo('BaseException',
-                                    'exception: no description',
-                                    None, None)
+
+        # For exception cases both raise and uncaught, pydevd adds a
+        # __exception__ object to the top most frame. Extracting the
+        # exception name and description from that frame gives accurate
+        # exception information. Get exception info from frame
+        try:
+            cmd = pydevd_comm.CMD_GET_THREAD_STACK
+            _, _, resp_args = yield self.pydevd_request(cmd, pyd_tid)
+            xml = self.parse_xml_response(resp_args)
+            xframes = list(xml.thread.frame)
+
+            xframe = xframes[0]
+            pyd_fid = xframe['id']
+            cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid, pyd_fid)
+            cmdid = pydevd_comm.CMD_GET_VARIABLE
+            _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
+            xml = self.parse_xml_response(resp_args)
+
+            name = unquote(xml.var[1]['type'])
+            description = unquote(xml.var[1]['value'])
+            frame_data = []
+            for f in xframes:
+                file_path = unquote(f['file'])
+                if not self.internals_filter.is_internal_path(file_path) and \
+                    self._should_debug(file_path):
+                    line_no = int(f['line'])
+                    func_name = unquote(f['name'])
+                    if _util.is_py34():
+                        # NOTE: In 3.4.* format_list requires the text
+                        # to be passed in the tuple list.
+                        line_text = _util.get_line_for_traceback(file_path,
+                                                                 line_no)
+                        frame_data.append((file_path, line_no,
+                                           func_name, line_text))
+                    else:
+                        frame_data.append((file_path, line_no,
+                                           func_name, None))
+
+            stack = ''.join(traceback.format_list(frame_data))
+
+            source = unquote(xframe['file'])
+            if self.internals_filter.is_internal_path(source) or \
+                not self._should_debug(source):
+                source = None
+        except Exception:
+            name = 'BaseException'
+            description = 'exception: no description'
+            stack = None
+            source = None
+
+        exc = ExceptionInfo(name, description, stack, source)
         self.send_response(
             request,
             exceptionId=exc.name,
@@ -2319,9 +2357,6 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         autogen = self.start_reason == 'attach'
         vsc_tid = self.thread_map.to_vscode(pyd_tid, autogen=autogen)
 
-        with self.stack_traces_lock:
-            self.stack_traces[pyd_tid] = list(xml.thread.frame)
-
         description = None
         text = None
         if reason in STEP_REASONS:
@@ -2332,53 +2367,6 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
             reason = 'breakpoint'
         else:
             reason = 'pause'
-
-        # For exception cases both raise and uncaught, pydevd adds a
-        # __exception__ object to the top most frame. Extracting the
-        # exception name and description from that frame gives accurate
-        # exception information.
-        if reason == 'exception':
-            # Get exception info from frame
-            try:
-                pyd_fid = xframe['id']
-                cmdargs = '{}\t{}\tFRAME\t__exception__'.format(pyd_tid,
-                                                                pyd_fid)
-                cmdid = pydevd_comm.CMD_GET_VARIABLE
-                _, _, resp_args = yield self.pydevd_request(cmdid, cmdargs)
-                xml = self.parse_xml_response(resp_args)
-                text = unquote(xml.var[1]['type'])
-                description = unquote(xml.var[1]['value'])
-                frame_data = []
-                for f in xframes:
-                    file_path = unquote(f['file'])
-                    if not self.internals_filter.is_internal_path(file_path):
-                        line_no = int(f['line'])
-                        func_name = unquote(f['name'])
-                        if _util.is_py34():
-                            # NOTE: In 3.4.* format_list requires the text
-                            # to be passed in the tuple list.
-                            line_text = _util.get_line_for_traceback(file_path,
-                                                                     line_no)
-                            frame_data.append((file_path, line_no,
-                                               func_name, line_text))
-                        else:
-                            frame_data.append((file_path, line_no,
-                                               func_name, None))
-                stack = ''.join(traceback.format_list(frame_data))
-                source = unquote(xframe['file'])
-                if self.internals_filter.is_internal_path(source):
-                    source = None
-            except Exception:
-                text = 'BaseException'
-                description = 'exception: no description'
-                stack = None
-                source = None
-
-            with self.active_exceptions_lock:
-                self.active_exceptions[pyd_tid] = ExceptionInfo(text,
-                                                                description,
-                                                                stack,
-                                                                source)
 
         self.send_event(
             'stopped',
@@ -2393,20 +2381,8 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
         pyd_tid, _ = args.split('\t')
         pyd_tid = pyd_tid.strip()
 
-        # Stack trace, active exception, all frames, and variables for
+        # All frames, and variables for
         # this thread are now invalid; clear their IDs.
-        with self.stack_traces_lock:
-            try:
-                del self.stack_traces[pyd_tid]
-            except KeyError:
-                pass
-
-        with self.active_exceptions_lock:
-            try:
-                del self.active_exceptions[pyd_tid]
-            except KeyError:
-                pass
-
         for pyd_fid, vsc_fid in self.frame_map.pairs():
             if pyd_fid[0] == pyd_tid:
                 self.frame_map.remove(pyd_fid, vsc_fid)
@@ -2430,12 +2406,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     @pydevd_events.handler(pydevd_comm.CMD_SEND_CURR_EXCEPTION_TRACE_PROCEEDED)
     def on_pydevd_send_curr_exception_trace_proceeded(self, seq, args):
         # TODO: docstring
-        pyd_tid = args.strip()
-        with self.active_exceptions_lock:
-            try:
-                del self.active_exceptions[pyd_tid]
-            except KeyError:
-                pass
+        pass
 
     @pydevd_events.handler(pydevd_comm.CMD_WRITE_TO_CONSOLE)
     def on_pydevd_cmd_write_to_console2(self, seq, args):

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1586,8 +1586,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
             xml = self.parse_xml_response(resp_args)
             xframes = list(xml.thread.frame)
         except Exception:
-            self.send_error_response(request, 'Stack unavailable')
-            return
+            xframes = []
 
         totalFrames = len(xframes)
         if levels == 0:
@@ -1988,7 +1987,7 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     @async_handler
     def on_continue(self, request, args):
         # TODO: docstring
-        # Always suspend all threads.
+        # Always continue all threads.
         for pyd_tid in self.thread_map.pydevd_ids():
             self.pydevd_notify(pydevd_comm.CMD_THREAD_RUN, pyd_tid)
         self.send_response(request, allThreadsContinued=True)

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -17,6 +17,7 @@ from _pydevd_bundle.pydevd_comm import (
     CMD_THREAD_CREATE,
     CMD_GET_VARIABLE,
     CMD_SET_PROJECT_ROOTS,
+    CMD_GET_THREAD_STACK,
 )
 
 from ptvsd._util import new_hidden_thread
@@ -833,6 +834,8 @@ class HighlevelFixture(object):
         self._pydevd.send_pause_event(thread, *stack)
         if self._vsc._hidden:
             self._vsc.msgs.next_event()
+        payload = self.debugger_msgs.format_frames(thread.id, 'pause', *stack)
+        self.set_debugger_response(CMD_GET_THREAD_STACK, payload)
         self.send_request('stackTrace', {'threadId': tid})
         self.send_request('scopes', {'frameId': 1})
         return tid, thread

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -923,10 +923,11 @@ class VSCTest(object):
         expected = list(daemon.protocol.parse_each(expected))
         self.assertEqual(received, expected)
 
-    def assert_contains(self, received, expected):
+    def assert_contains(self, received, expected, parser='vsc'):
+        parser = self.vsc.protocol if parser == 'vsc' else parser
         from tests.helpers.message import assert_contains_messages
-        received = list(self.vsc.protocol.parse_each(received))
-        expected = list(self.vsc.protocol.parse_each(expected))
+        received = list(parser.parse_each(received))
+        expected = list(parser.parse_each(expected))
         assert_contains_messages(received, expected)
 
     def assert_received_unordered_payload(self, daemon, expected):

--- a/tests/highlevel/__init__.py
+++ b/tests/highlevel/__init__.py
@@ -909,8 +909,9 @@ class VSCTest(object):
         self.assertEqual(received[:-1], expected)
 
         failure = received[-1] if len(received) > 0 else []
-        expected = self.vsc.protocol.parse(
-            self.fix.vsc_msgs.new_failure(req, failure.message))
+        if failure:
+            expected = self.vsc.protocol.parse(
+                self.fix.vsc_msgs.new_failure(req, failure.message))
         self.assertEqual(failure, expected)
 
     def assert_received(self, daemon, expected):

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -249,46 +249,6 @@ class BreakpointTests(VSCFlowTest, unittest.TestCase):
         raise MyError('ka-boom')
         """)
 
-    def assert_vsc_received_fixing_events(self, received, specs):
-        '''
-        Assert that the received messages match the spec but considering that
-        some events may be unordered.
-        '''
-        iter_specs = iter(specs)
-        expected_msgs = []
-        new_received = []
-        for msg in received:
-            if msg.type == 'event':
-                if msg.event == 'process':
-                    # Just check that 'process' is correct, don't add to the
-                    # check list later on.
-                    self.assertEqual(msg.body['name'], sys.argv[0])
-                    self.assertEqual(msg.body['systemProcessId'], os.getpid())
-                    self.assertEqual(msg.body['isLocalProcess'], True)
-                    self.assertEqual(msg.body['startMethod'], 'launch')
-                    continue
-
-                if msg.event == 'thread':
-                    # When thread is found, just consider it ok, no
-                    # matter where it was found.
-                    continue
-
-            new_received.append(msg)
-
-            try:
-                spec = next(iter_specs)
-            except StopIteration:
-                continue
-
-            if isinstance(spec, tuple):
-                event, body = spec
-                expected = self.new_event(event, seq=msg.seq, **body)
-            else:
-                expected = self.new_response(spec, seq=msg.seq)
-            expected_msgs.append(expected)
-
-        self.assert_vsc_received(new_received, expected_msgs)
-
     def _set_lock(self, label=None, script=None):
         if script is None:
             if not os.path.exists(self.filename):
@@ -370,34 +330,31 @@ class BreakpointTests(VSCFlowTest, unittest.TestCase):
             self.assertNotEqual(req['command'], 'setExceptionBreakpoints')
         self.assertEqual(got, config['breakpoints'])
 
-        self.assert_vsc_received_fixing_events(received, [
-            ('stopped',
-             dict(
-                 reason='breakpoint',
-                 threadId=tid,
-                 text=None,
-                 description=None,
-             )),
-            req_continue1,
-            ('continued', dict(threadId=tid, )),
-            ('stopped',
-             dict(
-                 reason='breakpoint',
-                 threadId=tid,
-                 text=None,
-                 description=None,
-             )),
-            req_continue2,
-            ('continued', dict(threadId=tid, )),
-            ('stopped',
-             dict(
-                 reason='breakpoint',
-                 threadId=tid,
-                 text=None,
-                 description=None,
-             )),
-            req_continue_last,
-            ('continued', dict(threadId=tid, )),
+        self.assert_contains(received, [
+            self.new_event('stopped',
+                           reason='breakpoint',
+                           threadId=tid,
+                           text=None,
+                           description=None,
+                           ),
+            self.new_response(req_continue1, allThreadsContinued=True),
+            self.new_event('continued', threadId=tid),
+            self.new_event('stopped',
+                           reason='breakpoint',
+                           threadId=tid,
+                           text=None,
+                           description=None,
+                           ),
+            self.new_response(req_continue2, allThreadsContinued=True),
+            self.new_event('continued', threadId=tid),
+            self.new_event('stopped',
+                           reason='breakpoint',
+                           threadId=tid,
+                           text=None,
+                           description=None,
+                           ),
+            self.new_response(req_continue_last, allThreadsContinued=True),
+            self.new_event('continued', threadId=tid),
         ])
         self.assertIn('2 4 4', out)
         self.assertIn('ka-boom', err)

--- a/tests/highlevel/test_live_pydevd.py
+++ b/tests/highlevel/test_live_pydevd.py
@@ -401,7 +401,7 @@ class BreakpointTests(VSCFlowTest, unittest.TestCase):
                  threadId=tid,
                  text='MyError',
                  description=description)),
-            self.new_response(req_continue_last),
+            self.new_response(req_continue_last, allThreadsContinued=True),
             self.new_event('continued', **dict(threadId=tid, )),
         ])
         self.assertIn('2 4 4', out)

--- a/tests/highlevel/test_messages.py
+++ b/tests/highlevel/test_messages.py
@@ -873,11 +873,11 @@ class ContinueTests(NormalRequestTest, unittest.TestCase):
             # no events
         ])
         thread_ids = list(t.id for t in self._known_threads)
-        thread_ids.sort()
         expected = list(self.debugger_msgs.new_request(
                         self.PYDEVD_CMD, str(t))
                         for t in thread_ids)
-        self.assert_received(self.debugger, expected)
+        self.assert_contains(self.debugger.received, expected,
+                             parser=self.debugger.protocol)
 
 
 class NextTests(NormalRequestTest, unittest.TestCase):

--- a/tests/highlevel/test_messages.py
+++ b/tests/highlevel/test_messages.py
@@ -1045,9 +1045,9 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone'),
+                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.expected_pydevd_request(
-                '2\tpython-line\tspam.py\t15\tNone\ti == 3\tNone\tNone\tNone'),
+                '2\tpython-line\tspam.py\t15\tNone\ti == 3\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1095,15 +1095,15 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\t@HIT@ == 5\tNone'), # noqa
+                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\t@HIT@ == 5\tNone\tALL'), # noqa
             self.expected_pydevd_request(
-                '2\tpython-line\tspam.py\t15\tNone\tNone\tNone\t@HIT@ ==5\tNone'), # noqa
+                '2\tpython-line\tspam.py\t15\tNone\tNone\tNone\t@HIT@ ==5\tNone\tALL'), # noqa
             self.expected_pydevd_request(
-                '3\tpython-line\tspam.py\t20\tNone\tNone\tNone\t@HIT@ > 5\tNone'), # noqa
+                '3\tpython-line\tspam.py\t20\tNone\tNone\tNone\t@HIT@ > 5\tNone\tALL'), # noqa
             self.expected_pydevd_request(
-             '4\tpython-line\tspam.py\t25\tNone\tNone\tNone\t@HIT@ % 5 == 0\tNone'), # noqa
+             '4\tpython-line\tspam.py\t25\tNone\tNone\tNone\t@HIT@ % 5 == 0\tNone\tALL'), # noqa
             self.expected_pydevd_request(
-                '5\tpython-line\tspam.py\t30\tNone\tNone\tNone\tx\tNone'),
+                '5\tpython-line\tspam.py\t30\tNone\tNone\tNone\tx\tNone\tALL'),
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1146,13 +1146,13 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\t' + repr("5") + '\tNone\tTrue'), # noqa
+                '1\tpython-line\tspam.py\t10\tNone\tNone\t' + repr("5") + '\tNone\tTrue\tALL'), # noqa
             self.expected_pydevd_request(
-                '2\tpython-line\tspam.py\t15\tNone\tNone\t' + repr("Hello World") + '\tNone\tTrue'), # noqa
+                '2\tpython-line\tspam.py\t15\tNone\tNone\t' + repr("Hello World") + '\tNone\tTrue\tALL'), # noqa
             self.expected_pydevd_request(
-                '3\tpython-line\tspam.py\t20\tNone\tNone\t"{}".format(a)\tNone\tTrue'), # noqa
+                '3\tpython-line\tspam.py\t20\tNone\tNone\t"{}".format(a)\tNone\tTrue\tALL'), # noqa
             self.expected_pydevd_request(
-             '4\tpython-line\tspam.py\t25\tNone\tNone\t"{}+{}=Something".format(a, b)\tNone\tTrue'), # noqa
+             '4\tpython-line\tspam.py\t25\tNone\tNone\t"{}+{}=Something".format(a, b)\tNone\tTrue\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1161,9 +1161,9 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
             with self.hidden():
                 self.PYDEVD_CMD = CMD_SET_BREAK
                 p1 = self.expected_pydevd_request(
-                    '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone') # noqa
+                    '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL') # noqa
                 p2 = self.expected_pydevd_request(
-                    '2\tpython-line\tspam.py\t17\tNone\tNone\tNone\tNone\tNone') # noqa
+                    '2\tpython-line\tspam.py\t17\tNone\tNone\tNone\tNone\tNone\tALL') # noqa
                 with self.expect_debugger_command(CMD_VERSION):
                     self.fix.send_request('setBreakpoints', dict(
                         source={'path': 'spam.py'},
@@ -1213,11 +1213,11 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, removed + [
             self.expected_pydevd_request(
-                '3\tpython-line\tspam.py\t113\tNone\tNone\tNone\tNone\tNone'),
+                '3\tpython-line\tspam.py\t113\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.expected_pydevd_request(
-                '4\tpython-line\tspam.py\t2\tNone\tNone\tNone\tNone\tNone'),
+                '4\tpython-line\tspam.py\t2\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.expected_pydevd_request(
-                '5\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone'),
+                '5\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1254,10 +1254,10 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone'),
+                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
             self.expected_pydevd_request(
-                '2\tpython-line\teggs.py\t17\tNone\tNone\tNone\tNone\tNone'),
+                '2\tpython-line\teggs.py\t17\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1293,10 +1293,10 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone'),
+                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
             self.expected_pydevd_request(
-                '2\tdjango-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone'), # noqa
+                '2\tdjango-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1332,10 +1332,10 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\t' + repr("Hello World") + '\tNone\tTrue'), # noqa
+                '1\tpython-line\tspam.py\t10\tNone\tNone\t' + repr("Hello World") + '\tNone\tTrue\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
             self.expected_pydevd_request(
-                '2\tdjango-line\teggs.html\t17\tNone\tNone\t' + repr("Hello Django World") + '\tNone\tTrue'), # noqa
+                '2\tdjango-line\teggs.html\t17\tNone\tNone\t' + repr("Hello Django World") + '\tNone\tTrue\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1371,10 +1371,10 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone'),
+                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
             self.expected_pydevd_request(
-                '2\tjinja2-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone'), # noqa
+                '2\tjinja2-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1410,10 +1410,10 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\t' + repr("Hello World") + '\tNone\tTrue'), # noqa
+                '1\tpython-line\tspam.py\t10\tNone\tNone\t' + repr("Hello World") + '\tNone\tTrue\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
             self.expected_pydevd_request(
-                '2\tjinja2-line\teggs.html\t17\tNone\tNone\t' + repr("Hello Jinja World") + '\tNone\tTrue'), # noqa
+                '2\tjinja2-line\teggs.html\t17\tNone\tNone\t' + repr("Hello Jinja World") + '\tNone\tTrue\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1449,10 +1449,10 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone'),
+                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
             self.expected_pydevd_request(
-                '2\tjinja2-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone'), # noqa
+                '2\tjinja2-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 
@@ -1488,10 +1488,10 @@ class SetBreakpointsTests(NormalRequestTest, unittest.TestCase):
         self.PYDEVD_CMD = CMD_SET_BREAK
         self.assert_received(self.debugger, [
             self.expected_pydevd_request(
-                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone'),
+                '1\tpython-line\tspam.py\t10\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
             self.expected_pydevd_request(
-                '2\tjinja2-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone'), # noqa
+                '2\tjinja2-line\teggs.html\t17\tNone\tNone\tNone\tNone\tNone\tALL'), # noqa
             self.debugger_msgs.new_request(CMD_VERSION, _get_cmd_version()),
         ])
 

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -791,7 +791,7 @@ class LifecycleTests(LifecycleTestsBase):
                     'column': 1,
                 }],
             }),
-            self.new_response(req_continue2.req **{
+            self.new_response(req_continue2.req, **{
                 'allThreadsContinued': True
             }),
             self.new_event('continued', threadId=tid),

--- a/tests/system_tests/test_main.py
+++ b/tests/system_tests/test_main.py
@@ -756,7 +756,9 @@ class LifecycleTests(LifecycleTestsBase):
                     'column': 1,
                 }],
             }),
-            self.new_response(req_continue1.req),
+            self.new_response(req_continue1.req, **{
+                'allThreadsContinued': True
+            }),
             self.new_event('continued', threadId=tid),
             self.new_event(
                 'output',
@@ -789,7 +791,9 @@ class LifecycleTests(LifecycleTestsBase):
                     'column': 1,
                 }],
             }),
-            self.new_response(req_continue2.req),
+            self.new_response(req_continue2.req **{
+                'allThreadsContinued': True
+            }),
             self.new_event('continued', threadId=tid),
             self.new_event(
                 'output',


### PR DESCRIPTION
This change does the following:
1. Enables the suspend all policy
2. Pause/continue will always suspend or resume all threads
3. Stack trace request uses CMD_GET_THREAD_STACK
4. exception info is extracted on request.

This should address most of the concerns with #72. 
