### PR TITLE
Properly add __exception__ on all frames on caught exceptions (fixes #679)

### DIFF
--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_breakpoints.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_breakpoints.py
@@ -104,8 +104,9 @@ def get_exception_breakpoint(exctype, exceptions):
     return exc
 
 
-def stop_on_unhandled_exception(py_db, thread, additional_info, exctype, value, tb):
+def stop_on_unhandled_exception(py_db, thread, additional_info, arg):
     from _pydevd_bundle.pydevd_frame import handle_breakpoint_condition, handle_breakpoint_expression
+    exctype, value, tb = arg
     break_on_uncaught_exceptions = py_db.break_on_uncaught_exceptions
     if break_on_uncaught_exceptions:
         exception_breakpoint = get_exception_breakpoint(exctype, break_on_uncaught_exceptions)
@@ -136,8 +137,7 @@ def stop_on_unhandled_exception(py_db, thread, additional_info, exctype, value, 
         frame = user_frame
     else:
         frame = frames[-1]
-    exception = (exctype, value, tb)
-    add_exception_to_frame(frame, exception)
+    add_exception_to_frame(frame, arg)
     if exception_breakpoint.condition is not None:
         eval_result = handle_breakpoint_condition(py_db, additional_info, exception_breakpoint, frame)
         if not eval_result:
@@ -153,7 +153,7 @@ def stop_on_unhandled_exception(py_db, thread, additional_info, exctype, value, 
 
     pydev_log.debug('Handling post-mortem stop on exception breakpoint %s' % (exception_breakpoint.qname,))
 
-    py_db.stop_on_unhandled_exception(thread, frame, frames_byid, exception)
+    py_db.stop_on_unhandled_exception(thread, frame, frames_byid, arg)
 
 
 def _get_class(kls):

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -175,8 +175,15 @@ CMD_SHOW_CYTHON_WARNING = 150
 CMD_LOAD_FULL_VALUE = 151
 
 CMD_GET_THREAD_STACK = 152
-CMD_THREAD_DUMP_TO_STDERR = 153  # This is mostly for unit-tests to diagnose errors on ci.
+
+# This is mostly for unit-tests to diagnose errors on ci.
+CMD_THREAD_DUMP_TO_STDERR = 153  
+
+# Sent from the client to signal that we should stop when we start executing user code.
 CMD_STOP_ON_START = 154
+
+# When the debugger is stopped in an exception, this command will provide the details of the current exception (in the current thread).
+CMD_GET_EXCEPTION_DETAILS = 155
 
 CMD_REDIRECT_OUTPUT = 200
 CMD_GET_NEXT_STATEMENT_TARGETS = 201
@@ -243,6 +250,7 @@ ID_TO_MEANING = {
     '152': 'CMD_GET_THREAD_STACK',
     '153': 'CMD_THREAD_DUMP_TO_STDERR',
     '154': 'CMD_STOP_ON_START',
+    '155': 'CMD_GET_EXCEPTION_DETAILS',
 
     '200': 'CMD_REDIRECT_OUTPUT',
     '201': 'CMD_GET_NEXT_STATEMENT_TARGETS',
@@ -872,21 +880,55 @@ class NetCommandFactory:
         except Exception:
             return self.make_error_message(seq, get_exception_traceback_str())
 
+    def _make_send_curr_exception_trace_str(self, thread_id, exc_type, exc_desc, trace_obj):
+        while trace_obj.tb_next is not None:
+            trace_obj = trace_obj.tb_next
+            
+        exc_type = pydevd_xml.make_valid_xml_value(str(exc_type)).replace('\t', '  ') or 'exception: type unknown'
+        exc_desc = pydevd_xml.make_valid_xml_value(str(exc_desc)).replace('\t', '  ') or 'exception: no description'
+        
+        thread_suspend_str, thread_stack_str = self.make_thread_suspend_str(
+            thread_id, trace_obj.tb_frame, CMD_SEND_CURR_EXCEPTION_TRACE, '')
+        return exc_type, exc_desc, thread_suspend_str, thread_stack_str
+
     def make_send_curr_exception_trace_message(self, seq, thread_id, curr_frame_id, exc_type, exc_desc, trace_obj):
         try:
-            while trace_obj.tb_next is not None:
-                trace_obj = trace_obj.tb_next
-
-            exc_type = pydevd_xml.make_valid_xml_value(str(exc_type)).replace('\t', '  ') or 'exception: type unknown'
-            exc_desc = pydevd_xml.make_valid_xml_value(str(exc_desc)).replace('\t', '  ') or 'exception: no description'
-            
-            thread_suspend_str, _thread_stack_str = self.make_thread_suspend_str(
-                thread_id, trace_obj.tb_frame, CMD_SEND_CURR_EXCEPTION_TRACE, '')
-
+            exc_type, exc_desc, thread_suspend_str, _thread_stack_str = self._make_send_curr_exception_trace_str(
+                thread_id, exc_type, exc_desc, trace_obj)
             payload = str(curr_frame_id) + '\t' + exc_type + "\t" + exc_desc + "\t" + thread_suspend_str
-
             return NetCommand(CMD_SEND_CURR_EXCEPTION_TRACE, seq, payload)
         except Exception:
+            return self.make_error_message(seq, get_exception_traceback_str())
+        
+    def make_get_exception_details_message(self, seq, thread_id, topmost_frame):
+        """Returns exception details as XML """
+        try:
+            # If the debugger is not suspended, just return the thread and its id.
+            cmd_text = ['<xml><thread id="%s" ' % (thread_id,)]
+
+            if topmost_frame is not None:
+                try:
+                    frame = topmost_frame
+                    topmost_frame = None
+                    while frame is not None:
+                        if frame.f_code.co_name == 'do_wait_suspend' and frame.f_code.co_filename.endswith('pydevd.py'):
+                            arg = frame.f_locals.get('arg', None)
+                            if arg is not None:
+                                exc_type, exc_desc, _thread_suspend_str, thread_stack_str = self._make_send_curr_exception_trace_str(
+                                    thread_id, *arg)
+                                cmd_text.append('exc_type="%s" ' % (exc_type,))
+                                cmd_text.append('exc_desc="%s" ' % (exc_desc,))
+                                cmd_text.append('>')
+                                cmd_text.append(thread_stack_str)
+                                break
+                        frame = frame.f_back
+                    else:
+                        cmd_text.append('>')
+                finally:
+                    frame = None
+            cmd_text.append('</thread></xml>')
+            return NetCommand(CMD_GET_EXCEPTION_DETAILS, seq, ''.join(cmd_text))
+        except:
             return self.make_error_message(seq, get_exception_traceback_str())
 
     def make_send_curr_exception_trace_proceeded_message(self, seq, thread_id):

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_frame.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_frame.py
@@ -193,20 +193,17 @@ class PyDBFrame:
                     
                     was_just_raised = just_raised(trace)
                     if was_just_raised:
-                        add_exception_to_frame(frame, (exception, value, trace))
-                    
-                    if was_just_raised:
         
-                        if main_debugger.break_on_exceptions_thrown_in_same_context:
+                        if main_debugger.skip_on_exceptions_thrown_in_same_context:
                             # Option: Don't break if an exception is caught in the same function from which it is thrown
                             return False, frame
 
                     if exception_breakpoint.notify_on_first_raise_only:
-                        if main_debugger.break_on_exceptions_thrown_in_same_context:
+                        if main_debugger.skip_on_exceptions_thrown_in_same_context:
                             # In this case we never stop if it was just raised, so, to know if it was the first we
                             # need to check if we're in the 2nd method.
                             if not was_just_raised and not just_raised(trace.tb_next):
-                                return False, frame  # I.e.: we stop only when we'r
+                                return False, frame  # I.e.: we stop only when we're at the caller of a method that throws an exception
                                 
                         else:
                             if not was_just_raised:
@@ -218,6 +215,9 @@ class PyDBFrame:
                         info.pydev_message = exception_breakpoint.qname
                     except:
                         info.pydev_message = exception_breakpoint.qname.encode('utf-8')
+                        
+                    # Always add exception to frame (must remove later after we proceed).
+                    add_exception_to_frame(frame, (exception, value, trace))
 
                 else:
                     # No regular exception breakpoint, let's see if some plugin handles it.
@@ -341,7 +341,10 @@ class PyDBFrame:
 
             main_debugger.set_trace_for_frame_and_parents(frame)
         finally:
+            # Make sure the user cannot see the '__exception__' we added after we leave the suspend state.
+            remove_exception_from_frame(frame)
             #Clear some local variables...
+            frame = None
             trace_obj = None
             initial_trace_obj = None
             check_trace_obj = None

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
@@ -20,7 +20,7 @@ from _pydevd_bundle.pydevd_comm import CMD_RUN, CMD_VERSION, CMD_LIST_THREADS, C
     CMD_RUN_CUSTOM_OPERATION, InternalRunCustomOperation, CMD_IGNORE_THROWN_EXCEPTION_AT, CMD_ENABLE_DONT_TRACE, \
     CMD_SHOW_RETURN_VALUES, ID_TO_MEANING, CMD_GET_DESCRIPTION, InternalGetDescription, InternalLoadFullValue, \
     CMD_LOAD_FULL_VALUE, CMD_REDIRECT_OUTPUT, CMD_GET_NEXT_STATEMENT_TARGETS, InternalGetNextStatementTargets, CMD_SET_PROJECT_ROOTS, \
-    CMD_GET_THREAD_STACK, CMD_THREAD_DUMP_TO_STDERR, CMD_STOP_ON_START
+    CMD_GET_THREAD_STACK, CMD_THREAD_DUMP_TO_STDERR, CMD_STOP_ON_START, CMD_GET_EXCEPTION_DETAILS
 from _pydevd_bundle.pydevd_constants import get_thread_id, IS_PY3K, DebugInfoHolder, dict_keys, STATE_RUN, \
     NEXT_VALUE_SEPARATOR, IS_WINDOWS
 from _pydevd_bundle.pydevd_additional_thread_info import set_additional_thread_info
@@ -793,6 +793,19 @@ def process_net_command(py_db, cmd_id, seq, text):
                 
             elif cmd_id == CMD_STOP_ON_START:
                 py_db.stop_on_start = text.strip() in ('True', 'true', '1')
+                
+            elif cmd_id == CMD_GET_EXCEPTION_DETAILS:
+                thread_id = text
+                t = pydevd_find_thread_by_id(thread_id)
+                frame = None
+                if t and not getattr(t, 'pydev_do_not_trace', None):
+                    additional_info = set_additional_thread_info(t)
+                    frame = additional_info.get_topmost_frame(t)
+                try:
+                    cmd = py_db.cmd_factory.make_get_exception_details_message(seq, thread_id, frame)
+                finally:
+                    frame = None
+                    t = None
                 
             else:
                 #I have no idea what this is all about

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
@@ -445,7 +445,7 @@ def process_net_command(py_db, cmd_id, seq, text):
                 #
                 # break_on_uncaught;
                 # break_on_caught;
-                # break_on_exceptions_thrown_in_same_context;
+                # skip_on_exceptions_thrown_in_same_context;
                 # ignore_exceptions_thrown_in_lines_with_ignore_exception;
                 # ignore_libraries;
                 # TypeError;ImportError;zipimport.ZipImportError;
@@ -471,9 +471,9 @@ def process_net_command(py_db, cmd_id, seq, text):
                         break_on_caught = False
 
                     if splitted[2] == 'true':
-                        py_db.break_on_exceptions_thrown_in_same_context = True
+                        py_db.skip_on_exceptions_thrown_in_same_context = True
                     else:
-                        py_db.break_on_exceptions_thrown_in_same_context = False
+                        py_db.skip_on_exceptions_thrown_in_same_context = False
 
                     if splitted[3] == 'true':
                         py_db.ignore_exceptions_thrown_in_lines_with_ignore_exception = True
@@ -566,7 +566,7 @@ def process_net_command(py_db, cmd_id, seq, text):
                 #
                 # There are 2 global settings which can only be set in CMD_SET_PY_EXCEPTION. Namely:
                 #
-                # py_db.break_on_exceptions_thrown_in_same_context
+                # py_db.skip_on_exceptions_thrown_in_same_context
                 # - If True, we should only show the exception in a caller, not where it was first raised.
                 #
                 # py_db.ignore_exceptions_thrown_in_lines_with_ignore_exception

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
@@ -186,8 +186,7 @@ class ThreadTracer:
                     if frame.f_back is not None:
                         additional_info.suspended_at_unhandled = True
                     
-                    exctype, value, tb = arg
-                    stop_on_unhandled_exception(py_db, t, additional_info, exctype, value, tb)        
+                    stop_on_unhandled_exception(py_db, t, additional_info, arg)
         # IFDEF CYTHON
         # return SafeCallWrapper(self.trace_unhandled_exceptions)
         # ELSE

--- a/ptvsd/_vendored/pydevd/pydevd.py
+++ b/ptvsd/_vendored/pydevd/pydevd.py
@@ -36,7 +36,7 @@ from _pydevd_bundle.pydevd_comm import CMD_SET_BREAK, CMD_SET_NEXT_STATEMENT, CM
     start_client, start_server, InternalGetBreakpointException, InternalSendCurrExceptionTrace, \
     InternalSendCurrExceptionTraceProceeded
 from _pydevd_bundle.pydevd_custom_frames import CustomFramesContainer, custom_frames_container_init
-from _pydevd_bundle.pydevd_frame_utils import add_exception_to_frame
+from _pydevd_bundle.pydevd_frame_utils import add_exception_to_frame, remove_exception_from_frame
 from _pydevd_bundle.pydevd_kill_all_pydevd_threads import kill_all_pydev_threads
 from _pydevd_bundle.pydevd_trace_dispatch import trace_dispatch as _trace_dispatch, global_cache_skips, global_cache_frame_skips
 from _pydevd_frame_eval.pydevd_frame_eval_main import frame_eval_func, stop_frame_eval, enable_cache_frames_without_breaks, dummy_trace_dispatch
@@ -882,19 +882,21 @@ class PyDB:
         finally:
             CustomFramesContainer.custom_frames_lock.release()  # @UndefinedVariable
 
-    def stop_on_unhandled_exception(self, thread, frame, frames_byid, exception):
+    def stop_on_unhandled_exception(self, thread, frame, frames_byid, arg):
         pydev_log.debug("We are stopping in post-mortem\n")
         thread_id = get_thread_id(thread)
         pydevd_vars.add_additional_frame_by_id(thread_id, frames_byid)
         try:
             try:
-                add_exception_to_frame(frame, exception)
+                add_exception_to_frame(frame, arg)
                 self.set_suspend(thread, CMD_ADD_EXCEPTION_BREAK)
-                self.do_wait_suspend(thread, frame, 'exception', None, "trace")
+                self.do_wait_suspend(thread, frame, 'exception', arg, "trace")
             except:
-                pydev_log.error("We've got an error while stopping in post-mortem: %s\n"%sys.exc_info()[0])
+                pydev_log.error("We've got an error while stopping in post-mortem: %s\n" % (arg[0],))
         finally:
+            remove_exception_from_frame(frame)
             pydevd_vars.remove_additional_frame_by_id(thread_id)
+            frame = None
 
 
     def set_trace_for_frame_and_parents(self, frame, also_add_to_passed_frame=True, overwrite_prev_trace=False, dispatch_func=None):

--- a/ptvsd/_vendored/pydevd/pydevd.py
+++ b/ptvsd/_vendored/pydevd/pydevd.py
@@ -215,7 +215,7 @@ class PyDB:
         self._termination_event_set = False
         self.signature_factory = None
         self.SetTrace = pydevd_tracing.SetTrace
-        self.break_on_exceptions_thrown_in_same_context = False
+        self.skip_on_exceptions_thrown_in_same_context = False
         self.ignore_exceptions_thrown_in_lines_with_ignore_exception = True
 
         # Suspend debugger even if breakpoint condition raises an exception

--- a/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -75,6 +75,7 @@ CMD_GET_CONCURRENCY_EVENT = 145
 CMD_GET_THREAD_STACK = 152
 CMD_THREAD_DUMP_TO_STDERR = 153  # This is mostly for unit-tests to diagnose errors on ci.
 CMD_STOP_ON_START = 154
+CMD_GET_EXCEPTION_DETAILS = 155
 
 CMD_REDIRECT_OUTPUT = 200
 CMD_GET_NEXT_STATEMENT_TARGETS = 201
@@ -709,6 +710,9 @@ class AbstractWriterThread(threading.Thread):
     def write_add_exception_breakpoint(self, exception):
         self.write("%s\t%s\t%s" % (CMD_ADD_EXCEPTION_BREAK, self.next_seq(), exception))
         self.log.append('write_add_exception_breakpoint: %s' % (exception,))
+        
+    def write_get_current_exception(self, thread_id):
+        self.write("%s\t%s\t%s" % (CMD_GET_EXCEPTION_DETAILS, self.next_seq(), thread_id))
 
     def write_set_py_exception_globals(
             self, 

--- a/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -714,7 +714,7 @@ class AbstractWriterThread(threading.Thread):
             self, 
             break_on_uncaught,
             break_on_caught,
-            break_on_exceptions_thrown_in_same_context, 
+            skip_on_exceptions_thrown_in_same_context, 
             ignore_exceptions_thrown_in_lines_with_ignore_exception,
             ignore_libraries,
             exceptions=()
@@ -723,7 +723,7 @@ class AbstractWriterThread(threading.Thread):
         self.write("131\t%s\t%s" % (self.next_seq(), '%s;%s;%s;%s;%s;%s' % (
             'true' if break_on_uncaught else 'false', 
             'true' if break_on_caught else 'false', 
-            'true' if break_on_exceptions_thrown_in_same_context else 'false', 
+            'true' if skip_on_exceptions_thrown_in_same_context else 'false', 
             'true' if ignore_exceptions_thrown_in_lines_with_ignore_exception else 'false',
             'true' if ignore_libraries else 'false',
             ';'.join(exceptions)

--- a/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_exceptions.py
+++ b/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_exceptions.py
@@ -1,3 +1,4 @@
+import sys
 def method3():
     raise IndexError('foo')
 
@@ -9,6 +10,7 @@ def method1():
         method2()
     except:
         pass  # Ok, handled
+    assert '__exception__' not in sys._getframe().f_locals
         
 if __name__ == '__main__':
     method1()

--- a/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_unhandled_exceptions.py
+++ b/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_unhandled_exceptions.py
@@ -18,7 +18,7 @@ atexit.register(_atexit)
 
 
 def thread_func(n):
-    raise Exception('argh')
+    raise Exception('in thread 1')
 
 
 th = threading.Thread(target=lambda: thread_func(1))
@@ -30,7 +30,7 @@ event = threading.Event()
 
 def thread_func2():
     event.set()
-    raise Exception('argh')
+    raise ValueError('in thread 2')
     
 
 start_new_thread(thread_func2, ())
@@ -44,4 +44,4 @@ th.join()
 import time
 time.sleep(.3) 
 
-raise Exception('argh')
+raise IndexError('in main')

--- a/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
+++ b/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
@@ -18,8 +18,12 @@ import pytest
 from tests_python import debugger_unittest
 from tests_python.debugger_unittest import (get_free_port, CMD_SET_PROPERTY_TRACE, REASON_CAUGHT_EXCEPTION, 
     REASON_UNCAUGHT_EXCEPTION, REASON_STOP_ON_BREAKPOINT, REASON_THREAD_SUSPEND, overrides, CMD_THREAD_CREATE,
-    CMD_GET_THREAD_STACK, REASON_STEP_INTO_MY_CODE)
+    CMD_GET_THREAD_STACK, REASON_STEP_INTO_MY_CODE, CMD_GET_EXCEPTION_DETAILS)
 from _pydevd_bundle.pydevd_constants import IS_WINDOWS
+try:
+    from urllib import unquote
+except ImportError:
+    from urllib.parse import unquote
 
 IS_CPYTHON = platform.python_implementation() == 'CPython'
 IS_IRONPYTHON = platform.python_implementation() == 'IronPython'
@@ -678,6 +682,14 @@ class WriterThreadCase9(debugger_unittest.AbstractWriterThread):
 
         hit = self.wait_for_breakpoint_hit('111')
 
+        # Note: no active exception (should not give an error and should return no
+        # exception details as there's no exception).        
+        self.write_get_current_exception(hit.thread_id)
+
+        msg = self.wait_for_message(accept_message=lambda msg:msg.strip().startswith(str(CMD_GET_EXCEPTION_DETAILS)))
+        assert msg.thread['id'] == hit.thread_id
+        assert not hasattr(msg.thread, 'frames')  # No frames should be found.
+
         self.write_step_over(hit.thread_id)
 
         hit = self.wait_for_breakpoint_hit('108', line=11)
@@ -688,7 +700,7 @@ class WriterThreadCase9(debugger_unittest.AbstractWriterThread):
 
         self.write_run_thread(hit.thread_id)
 
-        assert 11 == self._sequence, 'Expected 11. Had: %s' % self._sequence
+        assert 13 == self._sequence, 'Expected 13. Had: %s' % self._sequence
 
         self.finished_ok = True
 
@@ -944,12 +956,34 @@ class WriterThreadCaseUnhandledExceptionsBasic(debugger_unittest.AbstractWriterT
         self.start_socket()
         self.write_add_exception_breakpoint_with_policy('Exception', "0", "1", "0")
         self.write_make_initial_run()
+        
+        def check(hit, exc_type, exc_desc):        
+            self.write_get_current_exception(hit.thread_id)
+            msg = self.wait_for_message(accept_message=lambda msg:exc_type in msg and 'exc_type="' in msg and 'exc_desc="' in msg, unquote_msg=False)
+            assert unquote(msg.thread['exc_desc']) == exc_desc
+            assert unquote(msg.thread['exc_type']) in (
+                "&lt;type 'exceptions.%s'&gt;" % (exc_type,),  # py2 
+                "&lt;class '%s'&gt;" % (exc_type,)  # py3
+            )
+            if len(msg.thread.frame) == 0:
+                assert unquote(unquote(msg.thread.frame['file'])).endswith('_debugger_case_unhandled_exceptions.py')
+            else:
+                assert unquote(unquote(msg.thread.frame[0]['file'])).endswith('_debugger_case_unhandled_exceptions.py')
+            self.write_run_thread(hit.thread_id)
 
         # Will stop in 2 background threads
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-        thread_id1 = hit.thread_id
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-        thread_id2 = hit.thread_id
+        hit0 = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        thread_id1 = hit0.thread_id
+        
+        hit1 = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        thread_id2 = hit1.thread_id
+        
+        if hit0.name == 'thread_func2':
+            check(hit0, 'ValueError', 'in thread 2')
+            check(hit1, 'Exception', 'in thread 1')
+        else:
+            check(hit0, 'Exception', 'in thread 1')
+            check(hit1, 'ValueError', 'in thread 2')
 
         self.write_run_thread(thread_id1)
         self.write_run_thread(thread_id2)
@@ -960,13 +994,12 @@ class WriterThreadCaseUnhandledExceptionsBasic(debugger_unittest.AbstractWriterT
         thread_id3 = hit.thread_id
 
         # Requesting the stack in an unhandled exception should provide the stack of the exception,
-        # not the current location of the program).        
+        # not the current location of the program.        
         self.write_get_thread_stack(thread_id3)
         msg = self.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_GET_THREAD_STACK,)))
         assert len(msg.thread.frame) == 0 # In main thread (must have no back frames).
         assert msg.thread.frame['name'] == '<module>'
-        
-        self.write_run_thread(thread_id3)
+        check(hit, 'IndexError', 'in main')
 
         self.log.append('Marking finished ok.')
         self.finished_ok = True
@@ -1727,21 +1760,29 @@ class WriterThreadCaseHandledExceptions1(debugger_unittest.AbstractWriterThread)
             ignore_libraries=1
         )
         self.write_make_initial_run()
+        
+        def check(hit):
+            self.write_get_frame(hit.thread_id, hit.frame_id)
+            self.wait_for_message(accept_message=lambda msg:'__exception__' in msg and 'IndexError' in msg, unquote_msg=False)
+            self.write_get_current_exception(hit.thread_id)
+            msg = self.wait_for_message(accept_message=lambda msg:'IndexError' in msg and 'exc_type="' in msg and 'exc_desc="' in msg, unquote_msg=False)
+            assert msg.thread['exc_desc'] == 'foo'
+            assert unquote(msg.thread['exc_type']) in (
+                "&lt;type 'exceptions.IndexError'&gt;",  # py2 
+                "&lt;class 'IndexError'&gt;"  # py3
+            )
+
+            assert unquote(unquote(msg.thread.frame[0]['file'])).endswith('_debugger_case_exceptions.py')
+            self.write_run_thread(hit.thread_id)
 
         hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=3)
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-        self.wait_for_message(accept_message=lambda msg:'__exception__' in msg and 'IndexError' in msg, unquote_msg=False)
-        self.write_run_thread(hit.thread_id)
+        check(hit)
         
         hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=6)
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-        self.wait_for_message(accept_message=lambda msg:'__exception__' in msg and 'IndexError' in msg, unquote_msg=False)
-        self.write_run_thread(hit.thread_id)
+        check(hit)
         
         hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=10)
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-        self.wait_for_message(accept_message=lambda msg:'__exception__' in msg and 'IndexError' in msg, unquote_msg=False)
-        self.write_run_thread(hit.thread_id)
+        check(hit)
 
         self.finished_ok = True
 


### PR DESCRIPTION
Other changes in the pull request:
- Rename: break_on_exceptions_thrown_in_same_context -> skip_on_exceptions_thrown_in_same_context.
- Make sure that __exception__ is removed when resuming.