### PR TITLE
Add tests for continue on disconnect.

### DIFF
--- a/tests/resources/system_tests/test_disconnect/disconnect_test.py
+++ b/tests/resources/system_tests/test_disconnect/disconnect_test.py
@@ -18,6 +18,7 @@ elif os.getenv('PTVSD_IS_ATTACHED', None) is not None:
 def main():
     count = 0
     while count < 50:
+        print(count)
         time.sleep(0.3)
         if os.getenv('PTVSD_BREAK_INTO_DEBUGGER', None) is not None:
             ptvsd.break_into_debugger()

--- a/tests/resources/system_tests/test_disconnect/disconnect_test.py
+++ b/tests/resources/system_tests/test_disconnect/disconnect_test.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import time
+import ptvsd
+
+if os.getenv('PTVSD_ENABLE_ATTACH', None) is not None:
+    ptvsd.enable_attach((sys.argv[1], sys.argv[2]))
+
+if os.getenv('PTVSD_WAIT_FOR_ATTACH', None) is not None:
+    print('waiting for attach')
+    ptvsd.wait_for_attach()
+elif os.getenv('PTVSD_IS_ATTACHED', None) is not None:
+    print('checking is attached')
+    while not ptvsd.is_attached():
+        time.sleep(0.1)
+
+
+def main():
+    count = 0
+    while count < 50:
+        time.sleep(0.3)
+        if os.getenv('PTVSD_BREAK_INTO_DEBUGGER', None) is not None:
+            ptvsd.break_into_debugger()
+        count += 1
+    path = os.getenv('PTVSD_TARGET_FILE', None)
+    if path is not None:
+        with open(path, 'a') as f:
+            print('HERE :)', file=f)
+
+
+main()

--- a/tests/resources/system_tests/test_disconnect/mypkg/__main__.py
+++ b/tests/resources/system_tests/test_disconnect/mypkg/__main__.py
@@ -1,0 +1,31 @@
+import os
+import sys
+import time
+import ptvsd
+
+if os.getenv('PTVSD_ENABLE_ATTACH', None) is not None:
+    ptvsd.enable_attach((sys.argv[1], sys.argv[2]))
+
+if os.getenv('PTVSD_WAIT_FOR_ATTACH', None) is not None:
+    print('waiting for attach')
+    ptvsd.wait_for_attach()
+elif os.getenv('PTVSD_IS_ATTACHED', None) is not None:
+    print('checking is attached')
+    while not ptvsd.is_attached():
+        time.sleep(0.1)
+
+
+def main():
+    count = 0
+    while count < 50:
+        time.sleep(0.1)
+        if os.getenv('PTVSD_BREAK_INTO_DEBUGGER', None) is not None:
+            ptvsd.break_into_debugger()
+        count += 1
+    path = os.getenv('PTVSD_TARGET_FILE', None)
+    if path is not None:
+        with open(path, 'a') as f:
+            print('HERE :)', file=f)
+
+
+main()

--- a/tests/resources/system_tests/test_disconnect/mypkg/__main__.py
+++ b/tests/resources/system_tests/test_disconnect/mypkg/__main__.py
@@ -18,6 +18,7 @@ elif os.getenv('PTVSD_IS_ATTACHED', None) is not None:
 def main():
     count = 0
     while count < 50:
+        print(count)
         time.sleep(0.1)
         if os.getenv('PTVSD_BREAK_INTO_DEBUGGER', None) is not None:
             ptvsd.break_into_debugger()

--- a/tests/system_tests/test_disconnect.py
+++ b/tests/system_tests/test_disconnect.py
@@ -1,0 +1,299 @@
+import os
+import os.path
+import random
+import unittest
+
+from tests.helpers.debugsession import Awaitable
+from tests.helpers.resource import TestResources
+from . import (
+    lifecycle_handshake,
+    LifecycleTestsBase, DebugInfo, PORT
+)
+
+TEST_FILES = TestResources.from_module(__name__)
+
+
+class CheckFile(object):
+    def __init__(self, root):
+        self._root = root
+
+    def __enter__(self):
+        self._path = self._get_check_file_name(self._root)
+        return self
+
+    def __exit__(self, *args):
+        if os.path.exists(self._path):
+            os.remove(self._path)
+
+    @property
+    def filepath(self):
+        return self._path
+
+    def _get_check_file_name(self, root):
+        name = 'test_%d.txt' % random.randint(10000, 99999)
+        path = os.path.join(root, name)
+        if os.path.exists(path):
+            os.remove(path)
+        return path
+
+
+class ContinueOnDisconnectTests(LifecycleTestsBase):
+    def run_test_attach_disconnect(self, debug_info, path_to_check,
+                                   pause=False):
+        options = {'debugOptions': ['RedirectOutput']}
+        with self.start_debugging(debug_info) as dbg:
+            session = dbg.session
+            stopped = session.get_awaiter_for_event('stopped')
+            (_, req_launch_attach, _, _, _, req_threads
+             ) = lifecycle_handshake(
+                 session, debug_info.starttype,
+                 options=options, threads=True)
+            Awaitable.wait_all(req_launch_attach, req_threads)
+
+            if pause:
+                req_pause = session.send_request('pause', threadId=0)
+                Awaitable.wait_all(req_pause, stopped)
+            else:
+                stopped.wait()
+
+            thread_id = stopped.event.body['threadId']
+            self._set_var_to_end_loop(session, thread_id)
+
+            req_disconnect = session.send_request('disconnect', restart=False)
+            req_disconnect.wait()
+
+        if debug_info.starttype == 'launch':
+            self.assertFalse(os.path.exists(path_to_check))
+        else:
+            self.assertTrue(os.path.exists(path_to_check))
+            with open(path_to_check, 'r') as f:
+                self.assertEqual('HERE :)\n', f.read())
+
+    def _set_var_to_end_loop(self, session, thread_id):
+        # Set count > 1000 to end the loop
+        req_stacktrace = session.send_request(
+            'stackTrace',
+            threadId=thread_id,
+        )
+        req_stacktrace.wait()
+        frames = req_stacktrace.resp.body['stackFrames']
+        frame_id = frames[0]['id']
+        req_scopes = session.send_request(
+            'scopes',
+            frameId=frame_id,
+        )
+        req_scopes.wait()
+        scopes = req_scopes.resp.body['scopes']
+        variables_reference = scopes[0]['variablesReference']
+        req_setvar = session.send_request(
+                'setVariable',
+                variablesReference=variables_reference,
+                name='count',
+                value='1000'
+            )
+        req_setvar.wait()
+
+
+class LaunchFileDisconnectLifecycleTests(ContinueOnDisconnectTests):
+    @unittest.skip('needs fixing')
+    def test_launch_pause_disconnect(self):
+        filename = TEST_FILES.resolve('disconnect_test.py')
+        cwd = os.path.dirname(filename)
+
+        with CheckFile(cwd) as cf:
+            debug_info = DebugInfo(
+                filename=filename,
+                cwd=cwd,
+                env={
+                    'PTVSD_TARGET_FILE': cf.filepath,
+                },
+                verbose=True
+            )
+            self.run_test_attach_disconnect(
+                debug_info, cf.filepath, pause=True)
+
+    @unittest.skip('#712')
+    def test_launch_break_disconnect(self):
+        filename = TEST_FILES.resolve('disconnect_test.py')
+        cwd = os.path.dirname(filename)
+
+        with CheckFile(cwd) as cf:
+            debug_info = DebugInfo(
+                filename=filename,
+                cwd=cwd,
+                env={
+                    'PTVSD_TARGET_FILE': cf.filepath,
+                    'PTVSD_BREAK_INTO_DEBUGGER': True,
+                }
+            )
+            self.run_test_attach_disconnect(
+                debug_info, cf.filepath, pause=True)
+
+
+class LaunchModuleDisconnectLifecycleTests(ContinueOnDisconnectTests):
+    @unittest.skip('needs fixing')
+    def test_launch_pause_disconnect(self):
+        module_name = 'mypkg'
+        env = TEST_FILES.env_with_py_path()
+        cwd = TEST_FILES.parent.root
+        with CheckFile(cwd) as cf:
+            env['PTVSD_TARGET_FILE'] = cf.filepath
+            debug_info = DebugInfo(
+                modulename=module_name,
+                cwd=cwd,
+                env=env
+            )
+            self.run_test_attach_disconnect(
+                debug_info, cf.filepath, pause=True)
+
+    @unittest.skip('#712')
+    def test_launch_break_disconnect(self):
+        module_name = 'mypkg'
+        env = TEST_FILES.env_with_py_path()
+        cwd = TEST_FILES.parent.root
+        with CheckFile(cwd) as cf:
+            env['PTVSD_TARGET_FILE'] = cf.filepath
+            env['PTVSD_BREAK_INTO_DEBUGGER'] = 'True'
+            debug_info = DebugInfo(
+                modulename=module_name,
+                cwd=cwd,
+                env=env
+            )
+            self.run_test_attach_disconnect(
+                debug_info, cf.filepath)
+
+
+class ServerAttachDisconnectLifecycleTests(ContinueOnDisconnectTests):
+    def run_test(self, env, pause=False):
+        filename = TEST_FILES.resolve('disconnect_test.py')
+        cwd = os.path.dirname(filename)
+        argv = ['localhost', str(PORT)]
+        with CheckFile(cwd) as cf:
+            env['PTVSD_TARGET_FILE'] = cf.filepath
+            debug_info = DebugInfo(
+                filename=filename,
+                cwd=cwd,
+                argv=argv,
+                env=env,
+                starttype='attach',
+            )
+            self.run_test_attach_disconnect(
+                debug_info, cf.filepath, pause=pause)
+
+    def test_attach_pause_disconnect(self):
+        env = {}
+        self.run_test(env, pause=True)
+
+    @unittest.skip('needs fixing')
+    def test_attach_break_disconnect(self):
+        env = {
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+            # this case should NOT use PTVSD_ENABLE_ATTACH
+        }
+        self.run_test(env)
+
+    @unittest.skip('needs fixing')
+    def test_attach_check_disconnect(self):
+        env = {
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+            # this case should NOT use PTVSD_ENABLE_ATTACH
+            'PTVSD_IS_ATTACHED': 'True',
+        }
+        self.run_test(env)
+
+
+class PTVSDAttachDisconnectLifecycleTests(ContinueOnDisconnectTests):
+    def run_test(self, env, pause=False):
+        filename = TEST_FILES.resolve('disconnect_test.py')
+        cwd = os.path.dirname(filename)
+        argv = ['localhost', str(PORT)]
+        with CheckFile(cwd) as cf:
+            env['PTVSD_TARGET_FILE'] = cf.filepath
+            debug_info = DebugInfo(
+                filename=filename,
+                cwd=cwd,
+                argv=argv,
+                env=env,
+                starttype='attach',
+                attachtype='import',
+            )
+            self.run_test_attach_disconnect(
+                debug_info, cf.filepath, pause=pause)
+
+    def test_enable_attach_pause_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+        }
+        self.run_test(env, pause=True)
+
+    def test_enable_attach_break_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+        }
+        self.run_test(env)
+
+    def test_enable_attach_wait_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+            'PTVSD_WAIT_FOR_ATTACH': 'True',
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+        }
+        self.run_test(env)
+
+    def test_enable_attach_check_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+            'PTVSD_IS_ATTACHED': 'True',
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+        }
+        self.run_test(env)
+
+
+class PTVSDModuleAttachDisconnectLifecycleTests(ContinueOnDisconnectTests):
+    def run_test(self, env, pause=False):
+        module_name = 'mypkg'
+        env.update(TEST_FILES.env_with_py_path())
+        cwd = TEST_FILES.root
+        argv = ['localhost', str(PORT)]
+        with CheckFile(cwd) as cf:
+            env['PTVSD_TARGET_FILE'] = cf.filepath
+            debug_info = DebugInfo(
+                modulename=module_name,
+                cwd=cwd,
+                argv=argv,
+                env=env,
+                starttype='attach',
+                attachtype='import',
+            )
+            self.run_test_attach_disconnect(
+                debug_info, cf.filepath, pause=pause)
+
+    def test_enable_attach_pause_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+        }
+        self.run_test(env, pause=True)
+
+    def test_enable_attach_break_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+        }
+        self.run_test(env)
+
+    def test_enable_attach_wait_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+            'PTVSD_WAIT_FOR_ATTACH': 'True',
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+        }
+        self.run_test(env)
+
+    def test_enable_attach_check_disconnect(self):
+        env = {
+            'PTVSD_ENABLE_ATTACH': 'True',
+            'PTVSD_IS_ATTACHED': 'True',
+            'PTVSD_BREAK_INTO_DEBUGGER': 'True',
+        }
+        self.run_test(env)


### PR DESCRIPTION
Fixes #708 

Found a few new issues (fixes not in this PR):
1. `break_into_debugger` does not work in Server Attach mode, i,e., `python -m ptvsd --port 5678 --server test.py` #742
2. Launch with disconnect has test issues where disconnect request does not reach `ptvsd` #743
