### PR TITLE
Fix 253 builtin breakpoint

### DIFF
--- a/ptvsd/_vendored/force_pydevd.py
+++ b/ptvsd/_vendored/force_pydevd.py
@@ -39,3 +39,17 @@ preimport('pydevd', [
     'pydevd_plugins',
     'pydevd',
 ])
+
+# When pydevd is imported it sets the breakpoint behavior, but it needs to be
+# overridden because the pydevd version will connect to the remote debugger by
+# default, but without using the ptvsd protocol (so, we need to use the ptvsd
+# API to handle things as expected by the debug adapter).
+import pydevd  # noqa
+import ptvsd  # noqa
+
+
+def ptvsd_breakpointhook():
+    ptvsd.break_into_debugger()
+
+
+pydevd.install_breakpointhook(ptvsd_breakpointhook)

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -560,22 +560,18 @@ def start_client(host, port):
     except ImportError:
         pass  # May not be available everywhere.
 
-    MAX_TRIES = 100
-    i = 0
-    while i<MAX_TRIES:
-        try:
-            s.connect((host, port))
-        except:
-            i+=1
-            time.sleep(0.2)
-            continue
+    try:
+        s.settimeout(10)  # 10 seconds timeout
+        s.connect((host, port))
+        s.settimeout(None)  # no timeout after connected
         pydevd_log(1, "Connected.")
         return s
+    except:
+        sys.stderr.write("Could not connect to %s: %s\n" % (host, port))
+        sys.stderr.flush()
+        traceback.print_exc()
+        raise
 
-    sys.stderr.write("Could not connect to %s: %s\n" % (host, port))
-    sys.stderr.flush()
-    traceback.print_exc()
-    sys.exit(1) #TODO: is it safe?
 
 
 

--- a/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_utils.py
+++ b/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_utils.py
@@ -339,6 +339,7 @@ def dump_threads(stream=None):
     stream.write('===============================================================================\n')
     stream.write('Threads running\n')
     stream.write('================================= Thread Dump =================================\n')
+    stream.flush()
 
     for thread_id, stack in _current_frames().items():
         stream.write('\n-------------------------------------------------------------------------------\n')
@@ -358,5 +359,7 @@ def dump_threads(stream=None):
                 except:
                     stream.write('Unable to get str of: %s' % (type(stack.f_locals['self']),))
                 stream.write('\n')
+        stream.flush()
 
     stream.write('\n=============================== END Thread Dump ===============================')
+    stream.flush()

--- a/ptvsd/_vendored/pydevd/pydev_sitecustomize/sitecustomize.py
+++ b/ptvsd/_vendored/pydevd/pydev_sitecustomize/sitecustomize.py
@@ -56,6 +56,40 @@ except:
             def dict_contains(d, key):
                 return d.has_key(key)
 
+def install_breakpointhook():
+    def custom_sitecustomize_breakpointhook(*args, **kwargs):
+        import os
+        hookname = os.getenv('PYTHONBREAKPOINT')
+        if hookname is not None and len(hookname) > 0 and hasattr(sys, '__breakpointhook__'):
+            sys.__breakpointhook__(*args, **kwargs)
+        else:
+            sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+            import pydevd
+            kwargs.setdefault('stop_at_frame', sys._getframe().f_back)
+            pydevd.settrace(*args, **kwargs)
+
+    if sys.version_info[0:2] >= (3, 7):
+        # There are some choices on how to provide the breakpoint hook. Namely, we can provide a 
+        # PYTHONBREAKPOINT which provides the import path for a method to be executed or we
+        # can override sys.breakpointhook.
+        # pydevd overrides sys.breakpointhook instead of providing an environment variable because
+        # it's possible that the debugger starts the user program but is not available in the 
+        # PYTHONPATH (and would thus fail to be imported if PYTHONBREAKPOINT was set to pydevd.settrace).
+        # Note that the implementation still takes PYTHONBREAKPOINT in account (so, if it was provided
+        # by someone else, it'd still work).
+        sys.breakpointhook = custom_sitecustomize_breakpointhook
+    else:
+        if sys.version_info[0] >= 3:
+            import builtins as __builtin__ # Py3
+        else:
+            import __builtin__
+
+        # In older versions, breakpoint() isn't really available, so, install the hook directly
+        # in the builtins.
+        __builtin__.breakpoint = custom_sitecustomize_breakpointhook
+
+# Install the breakpoint hook at import time.
+install_breakpointhook()
 
 #-----------------------------------------------------------------------------------------------------------------------
 #now that we've finished the needed pydev sitecustomize, let's run the default one (if available)

--- a/ptvsd/_vendored/pydevd/pydevd.py
+++ b/ptvsd/_vendored/pydevd/pydevd.py
@@ -55,11 +55,37 @@ __version__ = '.'.join(__version_info_str__)
 
 #IMPORTANT: pydevd_constants must be the 1st thing defined because it'll keep a reference to the original sys._getframe
 
+def install_breakpointhook(pydevd_breakpointhook=None):
+    if pydevd_breakpointhook is None:
+        def pydevd_breakpointhook(*args, **kwargs):
+            hookname = os.getenv('PYTHONBREAKPOINT')
+            if hookname is not None and len(hookname) > 0 and hasattr(sys, '__breakpointhook__'):
+                sys.__breakpointhook__(*args, **kwargs)
+            else:
+                settrace(*args, **kwargs)
 
+    if sys.version_info[0:2] >= (3, 7):
+        # There are some choices on how to provide the breakpoint hook. Namely, we can provide a 
+        # PYTHONBREAKPOINT which provides the import path for a method to be executed or we
+        # can override sys.breakpointhook.
+        # pydevd overrides sys.breakpointhook instead of providing an environment variable because
+        # it's possible that the debugger starts the user program but is not available in the 
+        # PYTHONPATH (and would thus fail to be imported if PYTHONBREAKPOINT was set to pydevd.settrace).
+        # Note that the implementation still takes PYTHONBREAKPOINT in account (so, if it was provided
+        # by someone else, it'd still work).
+        sys.breakpointhook = pydevd_breakpointhook
+    else:
+        if sys.version_info[0] >= 3:
+            import builtins as __builtin__ # Py3
+        else:
+            import __builtin__
 
+        # In older versions, breakpoint() isn't really available, so, install the hook directly
+        # in the builtins.
+        __builtin__.breakpoint = pydevd_breakpointhook
 
-
-
+# Install the breakpoint hook at import time.
+install_breakpointhook()
 
 SUPPORT_PLUGINS = not IS_JYTH_LESS25
 PluginManager = None

--- a/ptvsd/_vendored/pydevd/tests_python/debugger_fixtures.py
+++ b/ptvsd/_vendored/pydevd/tests_python/debugger_fixtures.py
@@ -1,0 +1,272 @@
+from contextlib import contextmanager
+import os
+import threading
+import time
+
+import pytest
+
+from tests_python import debugger_unittest
+from tests_python.debugger_unittest import get_free_port, overrides, IS_CPYTHON, IS_JYTHON, IS_IRONPYTHON
+
+import sys
+
+
+def get_java_location():
+    from java.lang import System  # @UnresolvedImport
+    jre_dir = System.getProperty("java.home")
+    for f in [os.path.join(jre_dir, 'bin', 'java.exe'), os.path.join(jre_dir, 'bin', 'java')]:
+        if os.path.exists(f):
+            return f
+    raise RuntimeError('Unable to find java executable')
+
+
+def get_jython_jar():
+    from java.lang import ClassLoader  # @UnresolvedImport
+    cl = ClassLoader.getSystemClassLoader()
+    paths = map(lambda url: url.getFile(), cl.getURLs())
+    for p in paths:
+        if 'jython.jar' in p:
+            return p
+    raise RuntimeError('Unable to find jython.jar')
+
+
+class _WriterThreadCaseMSwitch(debugger_unittest.AbstractWriterThread):
+
+    TEST_FILE = 'tests_python.resources._debugger_case_m_switch'
+    IS_MODULE = True
+
+    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
+    def get_environ(self):
+        env = os.environ.copy()
+        curr_pythonpath = env.get('PYTHONPATH', '')
+
+        root_dirname = os.path.dirname(os.path.dirname(__file__))
+
+        curr_pythonpath += root_dirname + os.pathsep
+        env['PYTHONPATH'] = curr_pythonpath
+        return env
+
+    @overrides(debugger_unittest.AbstractWriterThread.get_main_filename)
+    def get_main_filename(self):
+        return debugger_unittest._get_debugger_test_file('_debugger_case_m_switch.py')
+
+
+class _WriterThreadCaseModuleWithEntryPoint(_WriterThreadCaseMSwitch):
+
+    TEST_FILE = 'tests_python.resources._debugger_case_module_entry_point:main'
+    IS_MODULE = True
+
+    @overrides(_WriterThreadCaseMSwitch.get_main_filename)
+    def get_main_filename(self):
+        return debugger_unittest._get_debugger_test_file('_debugger_case_module_entry_point.py')
+
+
+class AbstractWriterThreadCaseDjango(debugger_unittest.AbstractWriterThread):
+
+    FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
+
+    def _ignore_stderr_line(self, line):
+        if debugger_unittest.AbstractWriterThread._ignore_stderr_line(self, line):
+            return True
+
+        if 'GET /my_app' in line:
+            return True
+
+        return False
+
+    def get_command_line_args(self):
+        free_port = get_free_port()
+        self.django_port = free_port
+        return [
+            debugger_unittest._get_debugger_test_file(os.path.join('my_django_proj_17', 'manage.py')),
+            'runserver',
+            '--noreload',
+            str(free_port),
+        ]
+
+    def write_add_breakpoint_django(self, line, func, template):
+        '''
+            @param line: starts at 1
+        '''
+        breakpoint_id = self.next_breakpoint_id()
+        template_file = debugger_unittest._get_debugger_test_file(os.path.join('my_django_proj_17', 'my_app', 'templates', 'my_app', template))
+        self.write("111\t%s\t%s\t%s\t%s\t%s\t%s\tNone\tNone" % (self.next_seq(), breakpoint_id, 'django-line', template_file, line, func))
+        self.log.append('write_add_django_breakpoint: %s line: %s func: %s' % (breakpoint_id, line, func))
+        return breakpoint_id
+
+    def create_request_thread(self, uri):
+        outer = self
+
+        class T(threading.Thread):
+
+            def run(self):
+                try:
+                    from urllib.request import urlopen
+                except ImportError:
+                    from urllib import urlopen
+                for _ in range(10):
+                    try:
+                        stream = urlopen('http://127.0.0.1:%s/%s' % (outer.django_port, uri))
+                        self.contents = stream.read()
+                        break
+                    except IOError:
+                        continue
+
+        return T()
+
+
+class DebuggerRunnerSimple(debugger_unittest.DebuggerRunner):
+
+    def get_command_line(self):
+        if IS_JYTHON:
+            if sys.executable is not None:
+                # i.e.: we're running with the provided jython.exe
+                return [sys.executable]
+            else:
+
+                return [
+                    get_java_location(),
+                    '-classpath',
+                    get_jython_jar(),
+                    'org.python.util.jython'
+                ]
+
+        if IS_CPYTHON:
+            return [sys.executable, '-u']
+
+        if IS_IRONPYTHON:
+            return [
+                    sys.executable,
+                    '-X:Frames'
+                ]
+
+        raise RuntimeError('Unable to provide command line')
+
+
+class DebuggerRunnerRemote(debugger_unittest.DebuggerRunner):
+
+    def get_command_line(self):
+        return [sys.executable, '-u']
+
+    def add_command_line_args(self, args):
+        writer = self.writer
+
+        ret = args + [self.writer.TEST_FILE]
+        ret = writer.update_command_line_args(ret)  # Provide a hook for the writer
+        return ret
+
+
+@pytest.fixture
+def case_setup():
+
+    runner = DebuggerRunnerSimple()
+
+    class WriterThread(debugger_unittest.AbstractWriterThread):
+        pass
+
+    class CaseSetup(object):
+
+        @contextmanager
+        def test_file(
+                self,
+                filename,
+                **kwargs
+            ):
+            WriterThread.TEST_FILE = debugger_unittest._get_debugger_test_file(filename)
+            for key, value in kwargs.items():
+                assert hasattr(WriterThread, key)
+                setattr(WriterThread, key, value)
+
+            with runner.check_case(WriterThread) as writer:
+                yield writer
+
+    return CaseSetup()
+
+
+@pytest.fixture
+def case_setup_remote():
+
+    runner = DebuggerRunnerRemote()
+
+    class WriterThread(debugger_unittest.AbstractWriterThread):
+        pass
+
+    class CaseSetup(object):
+
+        @contextmanager
+        def test_file(
+                self,
+                filename,
+                **kwargs
+            ):
+
+            def update_command_line_args(writer, args):
+                ret = debugger_unittest.AbstractWriterThread.update_command_line_args(writer, args)
+                ret.append(str(writer.port))
+                return ret
+
+            WriterThread.TEST_FILE = debugger_unittest._get_debugger_test_file(filename)
+            WriterThread.update_command_line_args = update_command_line_args
+            for key, value in kwargs.items():
+                assert hasattr(WriterThread, key)
+                setattr(WriterThread, key, value)
+
+            with runner.check_case(WriterThread) as writer:
+                yield writer
+
+    return CaseSetup()
+
+
+@pytest.fixture
+def case_setup_m_switch():
+
+    runner = DebuggerRunnerSimple()
+
+    class WriterThread(_WriterThreadCaseMSwitch):
+        pass
+
+    class CaseSetup(object):
+
+        @contextmanager
+        def test_file(self):
+            with runner.check_case(WriterThread) as writer:
+                yield writer
+
+    return CaseSetup()
+
+
+@pytest.fixture
+def case_setup_m_switch_entry_point():
+
+    runner = DebuggerRunnerSimple()
+
+    class WriterThread(_WriterThreadCaseModuleWithEntryPoint):
+        pass
+
+    class CaseSetup(object):
+
+        @contextmanager
+        def test_file(self):
+            with runner.check_case(WriterThread) as writer:
+                yield writer
+
+    return CaseSetup()
+
+
+@pytest.fixture
+def case_setup_django():
+
+    runner = DebuggerRunnerSimple()
+
+    class WriterThread(AbstractWriterThreadCaseDjango):
+        pass
+
+    class CaseSetup(object):
+
+        @contextmanager
+        def test_file(self, filename):
+            WriterThread.TEST_FILE = debugger_unittest._get_debugger_test_file(filename)
+            with runner.check_case(WriterThread) as writer:
+                yield writer
+
+    return CaseSetup()

--- a/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
+++ b/ptvsd/_vendored/pydevd/tests_python/debugger_unittest.py
@@ -1,10 +1,9 @@
-from _pydevd_bundle.pydevd_constants import IS_JYTHON
 from collections import namedtuple
+from contextlib import contextmanager
 try:
     from urllib import quote, quote_plus, unquote_plus
 except ImportError:
-    from urllib.parse import quote, quote_plus, unquote_plus #@UnresolvedImport
-
+    from urllib.parse import quote, quote_plus, unquote_plus  # @UnresolvedImport
 
 import os
 import re
@@ -16,7 +15,6 @@ import time
 import traceback
 
 from _pydev_bundle import pydev_localhost
-
 
 IS_PY3K = sys.version_info[0] >= 3
 
@@ -85,19 +83,23 @@ CMD_VERSION = 501
 CMD_RETURN = 502
 CMD_ERROR = 901
 
-
 REASON_CAUGHT_EXCEPTION = CMD_STEP_CAUGHT_EXCEPTION
 REASON_UNCAUGHT_EXCEPTION = CMD_ADD_EXCEPTION_BREAK
 REASON_STOP_ON_BREAKPOINT = CMD_SET_BREAK
 REASON_THREAD_SUSPEND = CMD_THREAD_SUSPEND
 REASON_STEP_INTO_MY_CODE = CMD_STEP_INTO_MY_CODE
 
-
 # Always True (because otherwise when we do have an error, it's hard to diagnose).
 SHOW_WRITES_AND_READS = True
 SHOW_OTHER_DEBUG_INFO = True
 SHOW_STDOUT = True
 
+import platform
+
+IS_CPYTHON = platform.python_implementation() == 'CPython'
+IS_IRONPYTHON = platform.python_implementation() == 'IronPython'
+IS_JYTHON = platform.python_implementation() == 'Jython'
+IS_APPVEYOR = os.environ.get('APPVEYOR', '') in ('True', 'true', '1')
 
 try:
     from thread import start_new_thread
@@ -108,13 +110,15 @@ try:
     xrange
 except:
     xrange = range
-    
+
 Hit = namedtuple('Hit', 'thread_id, frame_id, line, suspend_type, name, file')
+
 
 def overrides(method):
     '''
     Helper to check that one method overrides another (redeclared in unit-tests to avoid importing pydevd).
     '''
+
     def wrapper(func):
         if func.__name__ != method.__name__:
             msg = "Wrong @override: %r expected, but overwriting %r."
@@ -128,37 +132,60 @@ def overrides(method):
 
     return wrapper
 
+
+TIMEOUT = 20
+
+
+def wait_for_condition(condition, msg=None):
+    curtime = time.time()
+    while True:
+        if condition():
+            break
+        if time.time() - curtime > TIMEOUT:
+            error_msg = 'Condition not reached in %s seconds'
+            if msg is not None:
+                error_msg += '\n'
+                if callable(msg):
+                    error_msg += msg()
+                else:
+                    error_msg += str(msg)
+
+            raise AssertionError(error_msg)
+        time.sleep(.05)
+
+
 #=======================================================================================================================
 # ReaderThread
 #=======================================================================================================================
 class ReaderThread(threading.Thread):
 
-    TIMEOUT = 15
-    
+    MESSAGES_TIMEOUT = 15
+
     def __init__(self, sock):
         threading.Thread.__init__(self)
         try:
             from queue import Queue
         except ImportError:
             from Queue import Queue
-            
+
         self.setDaemon(True)
         self.sock = sock
         self._queue = Queue()
         self.all_received = []
         self._kill = False
-        
-    def set_timeout(self, timeout):
-        self.TIMEOUT = timeout
+
+    def set_messages_timeout(self, timeout):
+        self.MESSAGES_TIMEOUT = timeout
 
     def get_next_message(self, context_message):
         try:
-            msg = self._queue.get(block=True, timeout=self.TIMEOUT)
+            msg = self._queue.get(block=True, timeout=self.MESSAGES_TIMEOUT)
         except:
-            raise AssertionError('No message was written in %s seconds. Error message:\n%s' % (self.TIMEOUT, context_message,))
+            raise AssertionError('No message was written in %s seconds. Error message:\n%s' % (self.MESSAGES_TIMEOUT, context_message,))
         else:
             frame = sys._getframe().f_back
             frame_info = ''
+            i = 3
             while frame:
                 stack_msg = ' --  File "%s", line %s, in %s\n' % (frame.f_code.co_filename, frame.f_lineno, frame.f_code.co_name)
                 if 'run' == frame.f_code.co_name:
@@ -166,6 +193,9 @@ class ReaderThread(threading.Thread):
                     break
                 frame_info += stack_msg
                 frame = frame.f_back
+                i -= 1
+                if i == 0:
+                    break
             frame = None
             sys.stdout.write('Message returned in get_next_message(): %s --  ctx: %s, asked at:\n%s\n' % (unquote_plus(unquote_plus(msg)), context_message, frame_info))
         return msg
@@ -182,13 +212,13 @@ class ReaderThread(threading.Thread):
 
                 while '\n' in buf:
                     # Print each part...
-                    i = buf.index('\n')+1
+                    i = buf.index('\n') + 1
                     last_received = buf[:i]
                     buf = buf[i:]
 
                     if SHOW_WRITES_AND_READS:
-                        print('Test Reader Thread Received %s' % (last_received, ))
-                        
+                        print('Test Reader Thread Received %s' % (last_received,))
+
                     self._queue.put(last_received)
         except:
             pass  # ok, finished it
@@ -201,6 +231,29 @@ class ReaderThread(threading.Thread):
             self.sock.close()
 
 
+def read_process(stream, buffer, debug_stream, stream_name, finish):
+    while True:
+        line = stream.readline()
+        if not line:
+            break
+
+        if IS_PY3K:
+            line = line.decode('utf-8', errors='replace')
+
+        if SHOW_STDOUT:
+            debug_stream.write('%s: %s' % (stream_name, line,))
+        buffer.append(line)
+
+        if finish[0]:
+            return
+
+
+def start_in_daemon_thread(target, args):
+    t0 = threading.Thread(target=target, args=args)
+    t0.setDaemon(True)
+    t0.start()
+
+
 class DebuggerRunner(object):
 
     def get_command_line(self):
@@ -210,12 +263,12 @@ class DebuggerRunner(object):
         raise NotImplementedError
 
     def add_command_line_args(self, args):
-        writer_thread = self.writer_thread
-        port = int(writer_thread.port)
+        writer = self.writer
+        port = int(writer.port)
 
         localhost = pydev_localhost.get_localhost()
         ret = [
-            writer_thread.get_pydevd_file(),
+            writer.get_pydevd_file(),
             '--DEBUG_RECORD_SOCKET_READS',
             '--qt-support',
             '--client',
@@ -223,26 +276,36 @@ class DebuggerRunner(object):
             '--port',
             str(port),
         ]
-        
-        if writer_thread.IS_MODULE:
+
+        if writer.IS_MODULE:
             ret += ['--module']
-        
-        ret += ['--file'] + writer_thread.get_command_line_args()
-        ret = writer_thread.update_command_line_args(ret)  # Provide a hook for the writer
+
+        ret += ['--file'] + writer.get_command_line_args()
+        ret = writer.update_command_line_args(ret)  # Provide a hook for the writer
         return args + ret
 
-    def check_case(self, writer_thread_class):
-        if callable(writer_thread_class):
-            writer_thread = writer_thread_class()
+    def check_case_simple(self, target, test_file):
+
+        class WriterThreadCase(AbstractWriterThread):
+
+            TEST_FILE = _get_debugger_test_file(test_file)
+
+            def run(self):
+                return target(self)
+
+        with self.check_case(WriterThreadCase) as writer:
+            yield writer
+
+    @contextmanager
+    def check_case(self, writer_class):
+        if callable(writer_class):
+            writer = writer_class()
         else:
-            writer_thread = writer_thread_class
+            writer = writer_class
         try:
-            writer_thread.start()
-            for _i in xrange(40000):
-                if hasattr(writer_thread, 'port'):
-                    break
-                time.sleep(.01)
-            self.writer_thread = writer_thread
+            writer.start()
+            wait_for_condition(lambda: hasattr(writer, 'port'))
+            self.writer = writer
 
             args = self.get_command_line()
 
@@ -251,47 +314,42 @@ class DebuggerRunner(object):
             if SHOW_OTHER_DEBUG_INFO:
                 print('executing', ' '.join(args))
 
-            ret = self.run_process(args, writer_thread)
-        finally:
-            writer_thread.do_kill()
-            writer_thread.log = []
-            
-        stdout = ret['stdout']
-        stderr = ret['stderr']
-        writer_thread.additional_output_checks(''.join(stdout), ''.join(stderr))
-        return ret
+            with self.run_process(args, writer) as dct_with_stdout_stder:
+                wait_for_condition(lambda: writer.finished_initialization)
 
-    def create_process(self, args, writer_thread):
+                writer.get_stdout = lambda: ''.join(dct_with_stdout_stder['stdout'])
+                writer.get_stderr = lambda: ''.join(dct_with_stdout_stder['stderr'])
+
+                yield writer
+        finally:
+            writer.do_kill()
+            writer.log = []
+
+        stdout = dct_with_stdout_stder['stdout']
+        stderr = dct_with_stdout_stder['stderr']
+        writer.additional_output_checks(''.join(stdout), ''.join(stderr))
+
+    def create_process(self, args, writer):
         process = subprocess.Popen(
             args,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=writer_thread.get_cwd() if writer_thread is not None else '.',
-            env=writer_thread.get_environ() if writer_thread is not None else None,
+            cwd=writer.get_cwd() if writer is not None else '.',
+            env=writer.get_environ() if writer is not None else None,
         )
         return process
 
-    def run_process(self, args, writer_thread):
-        process = self.create_process(args, writer_thread)
+    @contextmanager
+    def run_process(self, args, writer):
+        process = self.create_process(args, writer)
         stdout = []
         stderr = []
         finish = [False]
+        dct_with_stdout_stder = {}
 
         try:
-            def read(stream, buffer, debug_stream, stream_name):
-                for line in stream.readlines():
-                    if finish[0]:
-                        return
-                    if IS_PY3K:
-                        line = line.decode('utf-8', errors='replace')
-
-                    if SHOW_STDOUT:
-                        debug_stream.write('%s: %s' % (stream_name, line,))
-                    buffer.append(line)
-
-            start_new_thread(read, (process.stdout, stdout, sys.stdout, 'stdout'))
-            start_new_thread(read, (process.stderr, stderr, sys.stderr, 'stderr'))
-
+            start_in_daemon_thread(read_process, (process.stdout, stdout, sys.stdout, 'stdout', finish))
+            start_in_daemon_thread(read_process, (process.stderr, stderr, sys.stderr, 'stderr', finish))
 
             if SHOW_OTHER_DEBUG_INFO:
                 print('Both processes started')
@@ -301,78 +359,73 @@ class DebuggerRunner(object):
             initial_time = time.time()
             shown_intermediate = False
             dumped_threads = False
+
+            dct_with_stdout_stder['stdout'] = stdout
+            dct_with_stdout_stder['stderr'] = stderr
+            yield dct_with_stdout_stder
+
+            if not writer.finished_ok:
+                self.fail_with_message(
+                    "The thread that was doing the tests didn't finish successfully.", stdout, stderr, writer)
+
             while True:
                 if process.poll() is not None:
                     break
                 else:
-                    if writer_thread is not None:
-                        if not writer_thread.isAlive():
-                            if writer_thread.FORCE_KILL_PROCESS_WHEN_FINISHED_OK:
-                                process.kill()
-                                continue
+                    if writer is not None:
+                        if writer.FORCE_KILL_PROCESS_WHEN_FINISHED_OK:
+                            process.kill()
+                            continue
 
-                            if not shown_intermediate and (time.time() - initial_time > 10):
-                                print('Warning: writer thread exited and process still did not (%.2fs seconds elapsed).' % (time.time() - initial_time,))
-                                shown_intermediate = True
-                                
-                            if time.time() - initial_time > 15:
-                                if not dumped_threads:
-                                    dumped_threads = True
-                                    # 15 seconds elapsed and it still didn't finish. Ask for a thread dump
-                                    # (we'll be able to see it later on the test output stderr).
-                                    try:
-                                        writer_thread.write_dump_threads()
-                                    except:
-                                        traceback.print_exc()
+                        if not shown_intermediate and (time.time() - initial_time > (TIMEOUT / 3.)):  # 1/3 of timeout
+                            print('Warning: writer thread exited and process still did not (%.2fs seconds elapsed).' % (time.time() - initial_time,))
+                            shown_intermediate = True
 
-                                
-                            if time.time() - initial_time > 20:
-                                process.kill()
-                                time.sleep(.2)
-                                self.fail_with_message(
-                                    "The other process should've exited but still didn't (%.2fs seconds timeout for process to exit)." % (time.time() - initial_time,),
-                                    stdout, stderr, writer_thread
-                                )
+                        if time.time() - initial_time > ((TIMEOUT / 3.) * 2.):  # 2/3 of timeout
+                            if not dumped_threads:
+                                dumped_threads = True
+                                # It still didn't finish. Ask for a thread dump
+                                # (we'll be able to see it later on the test output stderr).
+                                try:
+                                    writer.write_dump_threads()
+                                except:
+                                    traceback.print_exc()
+
+                        if time.time() - initial_time > TIMEOUT:  # timed out
+                            process.kill()
+                            time.sleep(.2)
+                            self.fail_with_message(
+                                "The other process should've exited but still didn't (%.2fs seconds timeout for process to exit)." % (time.time() - initial_time,),
+                                stdout, stderr, writer
+                            )
                 time.sleep(.2)
 
-
-            if writer_thread is not None:
-                if not writer_thread.FORCE_KILL_PROCESS_WHEN_FINISHED_OK:
+            if writer is not None:
+                if not writer.FORCE_KILL_PROCESS_WHEN_FINISHED_OK:
                     poll = process.poll()
                     if poll < 0:
                         self.fail_with_message(
-                            "The other process exited with error code: " + str(poll), stdout, stderr, writer_thread)
-
+                            "The other process exited with error code: " + str(poll), stdout, stderr, writer)
 
                     if stdout is None:
                         self.fail_with_message(
-                            "The other process may still be running -- and didn't give any output.", stdout, stderr, writer_thread)
+                            "The other process may still be running -- and didn't give any output.", stdout, stderr, writer)
 
                     check = 0
-                    while not writer_thread.check_test_suceeded_msg(stdout, stderr):
+                    while not writer.check_test_suceeded_msg(stdout, stderr):
                         check += 1
                         if check == 50:
-                            self.fail_with_message("TEST SUCEEDED not found.", stdout, stderr, writer_thread)
+                            self.fail_with_message("TEST SUCEEDED not found.", stdout, stderr, writer)
                         time.sleep(.1)
 
-                for _i in xrange(100):
-                    if not writer_thread.finished_ok:
-                        time.sleep(.1)
-
-                if not writer_thread.finished_ok:
-                    self.fail_with_message(
-                        "The thread that was doing the tests didn't finish successfully.", stdout, stderr, writer_thread)
         finally:
             finish[0] = True
 
-        return {'stdout':stdout, 'stderr':stderr}
-
     def fail_with_message(self, msg, stdout, stderr, writerThread):
-        raise AssertionError(msg+
-            "\n\n===========================\nStdout: \n"+''.join(stdout)+
-            "\n\n===========================\nStderr:"+''.join(stderr)+
-            "\n\n===========================\nLog:\n"+'\n'.join(getattr(writerThread, 'log', [])))
-
+        raise AssertionError(msg +
+            "\n\n===========================\nStdout: \n" + ''.join(stdout) +
+            "\n\n===========================\nStderr:" + ''.join(stderr) +
+            "\n\n===========================\nLog:\n" + '\n'.join(getattr(writerThread, 'log', [])))
 
 
 #=======================================================================================================================
@@ -382,51 +435,57 @@ class AbstractWriterThread(threading.Thread):
 
     FORCE_KILL_PROCESS_WHEN_FINISHED_OK = False
     IS_MODULE = False
+    TEST_FILE = None
 
-    def __init__(self):
-        threading.Thread.__init__(self)
+    def __init__(self, *args, **kwargs):
+        threading.Thread.__init__(self, *args, **kwargs)
         self.setDaemon(True)
         self.finished_ok = False
+        self.finished_initialization = False
         self._next_breakpoint_id = 0
         self.log = []
-        
+
+    def run(self):
+        self.start_socket()
+
     def check_test_suceeded_msg(self, stdout, stderr):
         return 'TEST SUCEEDED' in ''.join(stdout)
-    
+
     def update_command_line_args(self, args):
         return args
-        
+
     def _ignore_stderr_line(self, line):
         if line.startswith((
-            'debugger: ', 
-            '>>', 
-            '<<', 
+            'debugger: ',
+            '>>',
+            '<<',
             'warning: Debugger speedups',
             'pydev debugger: New process is launching',
-            'pydev debugger: To debug that process'
+            'pydev debugger: To debug that process',
             )):
             return True
-        
+
         if re.match(r'^(\d+)\t(\d)+', line):
             return True
-        
+
         if IS_JYTHON:
             for expected in (
-                'org.python.netty.util.concurrent.DefaultPromise', 
-                'org.python.netty.util.concurrent.SingleThreadEventExecutor', 
+                'org.python.netty.util.concurrent.DefaultPromise',
+                'org.python.netty.util.concurrent.SingleThreadEventExecutor',
                 'Failed to submit a listener notification task. Event loop shut down?',
                 'java.util.concurrent.RejectedExecutionException',
                 'An event executor terminated with non-empty task',
                 'java.lang.UnsupportedOperationException',
+                "RuntimeWarning: Parent module '_pydevd_bundle' not found while handling absolute import",
                 ):
                 if expected in line:
                     return True
 
             if line.strip().startswith('at '):
-                return True        
-            
+                return True
+
         return False
-        
+
     def additional_output_checks(self, stdout, stderr):
         for line in stderr.splitlines():
             line = line.strip()
@@ -452,7 +511,7 @@ class AbstractWriterThread(threading.Thread):
     def do_kill(self):
         if hasattr(self, 'server_socket'):
             self.server_socket.close()
-            
+
         if hasattr(self, 'reader_thread'):
             # if it's not created, it's not there...
             self.reader_thread.do_kill()
@@ -470,6 +529,7 @@ class AbstractWriterThread(threading.Thread):
         self.sock.send(msg)
 
     def start_socket(self, port=None):
+        assert not hasattr(self, 'port'), 'Socket already initialized.'
         from _pydev_bundle.pydev_localhost import get_socket_name
         if SHOW_WRITES_AND_READS:
             print('start_socket')
@@ -498,6 +558,7 @@ class AbstractWriterThread(threading.Thread):
         # initial command is always the version
         self.write_version()
         self.log.append('start_socket')
+        self.finished_initialization = True
 
     def next_breakpoint_id(self):
         self._next_breakpoint_id += 1
@@ -525,39 +586,38 @@ class AbstractWriterThread(threading.Thread):
             msg = self.reader_thread.get_next_message('wait_output')
             if "<xml><io s=" in msg:
                 if 'ctx="1"' in msg:
-                    ctx='stdout'
+                    ctx = 'stdout'
                 elif 'ctx="2"' in msg:
-                    ctx='stderr'
+                    ctx = 'stderr'
                 else:
                     raise AssertionError('IO message without ctx.')
-                    
+
                 msg = unquote_plus(unquote_plus(msg.split('"')[1]))
                 return msg, ctx
 
-        
     def wait_for_breakpoint_hit(self, reason=REASON_STOP_ON_BREAKPOINT, **kwargs):
         '''
         108 is over
         109 is return
         111 is breakpoint
-        
+
         :param reason: may be the actual reason (int or string) or a list of reasons.
         '''
         # note: those must be passed in kwargs.
         line = kwargs.get('line')
         file = kwargs.get('file')
-        
+
         self.log.append('Start: wait_for_breakpoint_hit')
         # wait for hit breakpoint
         if not isinstance(reason, (list, tuple)):
             reason = (reason,)
-        
+
         def accept_message(last):
             for r in reason:
                 if ('stop_reason="%s"' % (r,)) in last:
                     return True
             return False
-            
+
         msg = self.wait_for_message(accept_message)
 
         # we have something like <xml><thread id="12152656" stop_reason="111"><frame id="12453120" name="encode" ...
@@ -574,12 +634,12 @@ class AbstractWriterThread(threading.Thread):
 
         if file is not None:
             assert frame_file.endswith(file), 'Expected hit to be in file %s, was: %s' % (file, frame_file)
-            
+
         if line is not None:
             assert line == frame_line, 'Expected hit to be in line %s, was: %s' % (line, frame_line)
 
         self.log.append('End(1): wait_for_breakpoint_hit: %s' % (msg.original_xml,))
-        
+
         return Hit(
             thread_id=thread_id, frame_id=frame_id, line=frame_line, suspend_type=suspend_type, name=name, file=frame_file)
 
@@ -618,17 +678,16 @@ class AbstractWriterThread(threading.Thread):
         last = unquote_plus(last)
         if expected in last:
             return True
-            
-        return False
 
+        return False
 
     def wait_for_multiple_vars(self, expected_vars):
         if not isinstance(expected_vars, (list, tuple)):
             expected_vars = [expected_vars]
-            
+
         all_found = []
         ignored = []
-        
+
         while True:
             try:
                 last = self.reader_thread.get_next_message('wait_for_multiple_vars: %s' % (expected_vars,))
@@ -639,7 +698,7 @@ class AbstractWriterThread(threading.Thread):
                         missing.append(v)
                 raise ValueError('Not Found:\n%s\nNot found messages: %s\nFound messages: %s\nExpected messages: %s\nIgnored messages:\n%s' % (
                     '\n'.join(missing), len(missing), len(all_found), len(expected_vars), '\n'.join(ignored)))
-                
+
             was_message_used = False
             new_expected = []
             for expected in expected_vars:
@@ -656,18 +715,18 @@ class AbstractWriterThread(threading.Thread):
                         was_message_used = True
                         found_expected = True
                         all_found.append(expected)
-                        
+
                 if not found_expected:
                     new_expected.append(expected)
 
             expected_vars = new_expected
-                        
+
             if not expected_vars:
                 return True
-            
+
             if not was_message_used:
                 ignored.append(last)
-                        
+
     wait_for_var = wait_for_multiple_vars
     wait_for_vars = wait_for_multiple_vars
     wait_for_evaluation = wait_for_multiple_vars
@@ -679,7 +738,7 @@ class AbstractWriterThread(threading.Thread):
     def write_version(self):
         from _pydevd_bundle.pydevd_constants import IS_WINDOWS
         self.write("501\t%s\t1.0\t%s\tID" % (self.next_seq(), 'WINDOWS' if IS_WINDOWS else 'UNIX'))
-        
+
     def get_main_filename(self):
         return self.TEST_FILE
 
@@ -703,31 +762,31 @@ class AbstractWriterThread(threading.Thread):
 
     def write_stop_on_start(self, stop=True):
         self.write("%s\t%s\t%s" % (CMD_STOP_ON_START, self.next_seq(), stop))
-        
+
     def write_dump_threads(self):
         self.write("%s\t%s\t" % (CMD_THREAD_DUMP_TO_STDERR, self.next_seq()))
-        
+
     def write_add_exception_breakpoint(self, exception):
         self.write("%s\t%s\t%s" % (CMD_ADD_EXCEPTION_BREAK, self.next_seq(), exception))
         self.log.append('write_add_exception_breakpoint: %s' % (exception,))
-        
+
     def write_get_current_exception(self, thread_id):
         self.write("%s\t%s\t%s" % (CMD_GET_EXCEPTION_DETAILS, self.next_seq(), thread_id))
 
     def write_set_py_exception_globals(
-            self, 
+            self,
             break_on_uncaught,
             break_on_caught,
-            skip_on_exceptions_thrown_in_same_context, 
+            skip_on_exceptions_thrown_in_same_context,
             ignore_exceptions_thrown_in_lines_with_ignore_exception,
             ignore_libraries,
             exceptions=()
         ):
         # Only set the globals, others
         self.write("131\t%s\t%s" % (self.next_seq(), '%s;%s;%s;%s;%s;%s' % (
-            'true' if break_on_uncaught else 'false', 
-            'true' if break_on_caught else 'false', 
-            'true' if skip_on_exceptions_thrown_in_same_context else 'false', 
+            'true' if break_on_uncaught else 'false',
+            'true' if break_on_caught else 'false',
+            'true' if skip_on_exceptions_thrown_in_same_context else 'false',
             'true' if ignore_exceptions_thrown_in_lines_with_ignore_exception else 'false',
             'true' if ignore_libraries else 'false',
             ';'.join(exceptions)
@@ -739,7 +798,7 @@ class AbstractWriterThread(threading.Thread):
 
     def write_set_project_roots(self, project_roots):
         self.write("%s\t%s\t%s" % (CMD_SET_PROJECT_ROOTS, self.next_seq(), '\t'.join(str(x) for x in project_roots)))
-        
+
     def write_add_exception_breakpoint_with_policy(
             self, exception, notify_on_handled_exceptions, notify_on_unhandled_exceptions, ignore_libraries):
         self.write("%s\t%s\t%s" % (CMD_ADD_EXCEPTION_BREAK, self.next_seq(), '\t'.join(str(x) for x in [
@@ -776,11 +835,11 @@ class AbstractWriterThread(threading.Thread):
     def write_run_thread(self, thread_id):
         self.log.append('write_run_thread')
         self.write("%s\t%s\t%s" % (CMD_THREAD_RUN, self.next_seq(), thread_id,))
-        
+
     def write_get_thread_stack(self, thread_id):
         self.log.append('write_get_thread_stack')
         self.write("%s\t%s\t%s" % (CMD_GET_THREAD_STACK, self.next_seq(), thread_id,))
-        
+
     def write_load_source(self, filename):
         self.log.append('write_load_source')
         self.write("%s\t%s\t%s" % (CMD_LOAD_SOURCE, self.next_seq(), filename,))
@@ -811,12 +870,12 @@ class AbstractWriterThread(threading.Thread):
     def write_get_next_statement_targets(self, thread_id, frame_id):
         self.write("201\t%s\t%s\t%s" % (self.next_seq(), thread_id, frame_id))
         self.log.append('write_get_next_statement_targets')
-        
+
     def write_list_threads(self):
         seq = self.next_seq()
         self.write("%s\t%s\t" % (CMD_LIST_THREADS, seq))
         return seq
-        
+
     def wait_for_list_threads(self, seq):
         return self.wait_for_message(lambda msg:msg.startswith('502\t%s' % (seq,)))
 
@@ -846,8 +905,9 @@ class AbstractWriterThread(threading.Thread):
                     return last
             if prev != last:
                 print('Ignored message: %r' % (last,))
-                
+
             prev = last
+
 
 def _get_debugger_test_file(filename):
     try:
@@ -863,6 +923,7 @@ def _get_debugger_test_file(filename):
     if not os.path.exists(ret):
         raise AssertionError('Expected: %s to exist.' % (ret,))
     return ret
+
 
 def get_free_port():
     from _pydev_bundle.pydev_localhost import get_socket_name

--- a/ptvsd/_vendored/pydevd/tests_python/performance_check.py
+++ b/ptvsd/_vendored/pydevd/tests_python/performance_check.py
@@ -1,16 +1,23 @@
-import debugger_unittest
+from tests_python import debugger_unittest
 import sys
 import re
 import os
-import math
 
 CHECK_BASELINE, CHECK_REGULAR, CHECK_CYTHON = 'baseline', 'regular', 'cython'
+
+pytest_plugins = [
+    str('tests_python.debugger_fixtures'),
+]
+
+RUNS = 5
+
 
 class PerformanceWriterThread(debugger_unittest.AbstractWriterThread):
 
     CHECK = None
 
-    debugger_unittest.AbstractWriterThread.get_environ # overrides
+    debugger_unittest.AbstractWriterThread.get_environ  # overrides
+
     def get_environ(self):
         env = os.environ.copy()
         if self.CHECK == CHECK_BASELINE:
@@ -23,7 +30,8 @@ class PerformanceWriterThread(debugger_unittest.AbstractWriterThread):
             raise AssertionError("Don't know what to check.")
         return env
 
-    debugger_unittest.AbstractWriterThread.get_pydevd_file # overrides
+    debugger_unittest.AbstractWriterThread.get_pydevd_file  # overrides
+
     def get_pydevd_file(self):
         if self.CHECK == CHECK_BASELINE:
             return os.path.abspath(os.path.join(r'X:\PyDev.Debugger.baseline', 'pydevd.py'))
@@ -32,101 +40,42 @@ class PerformanceWriterThread(debugger_unittest.AbstractWriterThread):
         return os.path.abspath(os.path.join(dirname, 'pydevd.py'))
 
 
-class WriterThreadPerformance1(PerformanceWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_performance_1.py')
-    BENCHMARK_NAME = 'method_calls_with_breakpoint'
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(17, 'method')
-        self.write_make_initial_run()
-        self.finished_ok = True
-
-class WriterThreadPerformance2(PerformanceWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_performance_1.py')
-    BENCHMARK_NAME = 'method_calls_without_breakpoint'
-
-    def run(self):
-        self.start_socket()
-        self.write_make_initial_run()
-        self.finished_ok = True
-
-class WriterThreadPerformance3(PerformanceWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_performance_1.py')
-    BENCHMARK_NAME = 'method_calls_with_step_over'
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(26, None)
-
-        self.write_make_initial_run()
-        thread_id, frame_id, line = self.wait_for_breakpoint_hit('111', True)
-
-        self.write_step_over(thread_id)
-        thread_id, frame_id, line = self.wait_for_breakpoint_hit('108', True)
-
-        self.write_run_thread(thread_id)
-        self.finished_ok = True
-
-class WriterThreadPerformance4(PerformanceWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_performance_1.py')
-    BENCHMARK_NAME = 'method_calls_with_exception_breakpoint'
-
-    def run(self):
-        self.start_socket()
-        self.write_add_exception_breakpoint('ValueError')
-
-        self.write_make_initial_run()
-        self.finished_ok = True
-
-class WriterThreadPerformance5(PerformanceWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_performance_2.py')
-    BENCHMARK_NAME = 'global_scope_1_with_breakpoint'
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(23, None)
-
-        self.write_make_initial_run()
-        self.finished_ok = True
-        
-class WriterThreadPerformance6(PerformanceWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_performance_3.py')
-    BENCHMARK_NAME = 'global_scope_2_with_breakpoint'
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(17, None)
-
-        self.write_make_initial_run()
-        self.finished_ok = True
-
-
 class CheckDebuggerPerformance(debugger_unittest.DebuggerRunner):
 
     def get_command_line(self):
         return [sys.executable]
 
-    def _get_time_from_result(self, result):
-        stdout = ''.join(result['stdout'])
+    def _get_time_from_result(self, stdout):
         match = re.search(r'TotalTime>>((\d|\.)+)<<', stdout)
         time_taken = match.group(1)
         return float(time_taken)
 
-    def obtain_results(self, writer_thread_class):
-        runs = 5
+    def obtain_results(self, benchmark_name, filename):
+
+        class PerformanceCheck(PerformanceWriterThread):
+            TEST_FILE = debugger_unittest._get_debugger_test_file(filename)
+            BENCHMARK_NAME = benchmark_name
+
+        writer_thread_class = PerformanceCheck
+
+        runs = RUNS
         all_times = []
         for _ in range(runs):
-            all_times.append(self._get_time_from_result(self.check_case(writer_thread_class)))
+            stdout_ref = []
+
+            def store_stdout(stdout, stderr):
+                stdout_ref.append(stdout)
+
+            with self.check_case(writer_thread_class) as writer:
+                writer.additional_output_checks = store_stdout
+                yield writer
+
+            assert len(stdout_ref) == 1
+            all_times.append(self._get_time_from_result(stdout_ref[0]))
             print('partial for: %s: %.3fs' % (writer_thread_class.BENCHMARK_NAME, all_times[-1]))
-        all_times.remove(min(all_times))
-        all_times.remove(max(all_times))
+        if len(all_times) > 3:
+            all_times.remove(min(all_times))
+            all_times.remove(max(all_times))
         time_when_debugged = sum(all_times) / float(len(all_times))
 
         args = self.get_command_line()
@@ -139,7 +88,7 @@ class CheckDebuggerPerformance(debugger_unittest.DebuggerRunner):
             SPEEDTIN_AUTHORIZATION_KEY = os.environ['SPEEDTIN_AUTHORIZATION_KEY']
 
             # sys.path.append(r'X:\speedtin\pyspeedtin')
-            import pyspeedtin # If the authorization key is there, pyspeedtin must be available
+            import pyspeedtin  # If the authorization key is there, pyspeedtin must be available
             import pydevd
             pydevd_cython_project_id, pydevd_pure_python_project_id = 6, 7
             if writer_thread_class.CHECK == CHECK_BASELINE:
@@ -152,20 +101,20 @@ class CheckDebuggerPerformance(debugger_unittest.DebuggerRunner):
                 raise AssertionError('Wrong check: %s' % (writer_thread_class.CHECK))
             for project_id in project_ids:
                 api = pyspeedtin.PySpeedTinApi(authorization_key=SPEEDTIN_AUTHORIZATION_KEY, project_id=project_id)
-                
+
                 benchmark_name = writer_thread_class.BENCHMARK_NAME
-                
+
                 if writer_thread_class.CHECK == CHECK_BASELINE:
                     version = '0.0.1_baseline'
-                    return # No longer commit the baseline (it's immutable right now).
+                    return  # No longer commit the baseline (it's immutable right now).
                 else:
-                    version=pydevd.__version__,
-                
+                    version = pydevd.__version__,
+
                 commit_id, branch, commit_date = api.git_commit_id_branch_and_date_from_path(pydevd.__file__)
                 api.add_benchmark(benchmark_name)
                 api.add_measurement(
                     benchmark_name,
-                    value=time_when_debugged, 
+                    value=time_when_debugged,
                     version=version,
                     released=False,
                     branch=branch,
@@ -173,29 +122,83 @@ class CheckDebuggerPerformance(debugger_unittest.DebuggerRunner):
                     commit_date=commit_date,
                 )
                 api.commit()
-                
-        return '%s: %.3fs ' % (writer_thread_class.BENCHMARK_NAME, time_when_debugged)
 
+        self.performance_msg = '%s: %.3fs ' % (writer_thread_class.BENCHMARK_NAME, time_when_debugged)
 
     def check_performance1(self):
-        return self.obtain_results(WriterThreadPerformance1)
+        for writer in self.obtain_results('method_calls_with_breakpoint', '_performance_1.py'):
+            writer.write_add_breakpoint(17, 'method')
+            writer.write_make_initial_run()
+            writer.finished_ok = True
+
+        return self.performance_msg
 
     def check_performance2(self):
-        return self.obtain_results(WriterThreadPerformance2)
+        for writer in self.obtain_results('method_calls_without_breakpoint', '_performance_1.py'):
+            writer.write_make_initial_run()
+            writer.finished_ok = True
+
+        return self.performance_msg
 
     def check_performance3(self):
-        return self.obtain_results(WriterThreadPerformance3)
+        for writer in self.obtain_results('method_calls_with_step_over', '_performance_1.py'):
+            writer.write_add_breakpoint(26, None)
+
+            writer.write_make_initial_run()
+            hit = writer.wait_for_breakpoint_hit('111')
+
+            writer.write_step_over(hit.thread_id)
+            hit = writer.wait_for_breakpoint_hit('108')
+
+            writer.write_run_thread(hit.thread_id)
+            writer.finished_ok = True
+
+        return self.performance_msg
 
     def check_performance4(self):
-        return self.obtain_results(WriterThreadPerformance4)
-        
+        for writer in self.obtain_results('method_calls_with_exception_breakpoint', '_performance_1.py'):
+            writer.write_add_exception_breakpoint('ValueError')
+            writer.write_make_initial_run()
+            writer.finished_ok = True
+
+        return self.performance_msg
+
     def check_performance5(self):
-        return self.obtain_results(WriterThreadPerformance5)
-        
+        for writer in self.obtain_results('global_scope_1_with_breakpoint', '_performance_2.py'):
+            writer.write_add_breakpoint(23, None)
+            writer.write_make_initial_run()
+            writer.finished_ok = True
+
+        return self.performance_msg
+
     def check_performance6(self):
-        return self.obtain_results(WriterThreadPerformance6)
+        for writer in self.obtain_results('global_scope_2_with_breakpoint', '_performance_3.py'):
+            writer.write_add_breakpoint(17, None)
+            writer.write_make_initial_run()
+            writer.finished_ok = True
+
+        return self.performance_msg
+
 
 if __name__ == '__main__':
+    # Local times gotten:
+    #
+    # Checking: regular
+    # method_calls_with_breakpoint: 1.139s
+    # method_calls_without_breakpoint: 0.268s
+    # method_calls_with_step_over: 2.601s
+    # method_calls_with_exception_breakpoint: 0.242s
+    # global_scope_1_with_breakpoint: 3.232s
+    # global_scope_2_with_breakpoint: 3.059s
+    # Checking: cython
+    # method_calls_with_breakpoint: 0.587s
+    # method_calls_without_breakpoint: 0.176s
+    # method_calls_with_step_over: 1.240s
+    # method_calls_with_exception_breakpoint: 0.176s
+    # global_scope_1_with_breakpoint: 2.523s
+    # global_scope_2_with_breakpoint: 1.483s
+    # TotalTime for profile: 157.73s
+
     debugger_unittest.SHOW_WRITES_AND_READS = False
     debugger_unittest.SHOW_OTHER_DEBUG_INFO = False
     debugger_unittest.SHOW_STDOUT = False
@@ -206,7 +209,7 @@ if __name__ == '__main__':
     msgs = []
     for check in (
             # CHECK_BASELINE, -- Checks against the version checked out at X:\PyDev.Debugger.baseline.
-            CHECK_REGULAR, 
+            CHECK_REGULAR,
             CHECK_CYTHON
         ):
         PerformanceWriterThread.CHECK = check
@@ -218,8 +221,8 @@ if __name__ == '__main__':
         msgs.append(check_debugger_performance.check_performance4())
         msgs.append(check_debugger_performance.check_performance5())
         msgs.append(check_debugger_performance.check_performance6())
-        
+
     for msg in msgs:
         print(msg)
 
-    print('TotalTime for profile: %.2fs' % (time.time()-start_time,))
+    print('TotalTime for profile: %.2fs' % (time.time() - start_time,))

--- a/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_breakpoint.py
+++ b/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_breakpoint.py
@@ -1,0 +1,6 @@
+def break_in_method():
+    breakpoint()  # Builtin on Py3, but we provide a backport on Py2.
+
+
+break_in_method()
+print('TEST SUCEEDED')

--- a/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_breakpoint_remote.py
+++ b/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_breakpoint_remote.py
@@ -1,0 +1,15 @@
+if __name__ == '__main__':
+    import os
+    import sys
+    port = int(sys.argv[1])
+    root_dirname = os.path.dirname(os.path.dirname(__file__))
+    
+    if root_dirname not in sys.path:
+        sys.path.append(root_dirname)
+        
+    import pydevd
+    print('before pydevd.settrace')
+    breakpoint(port=port)
+    print('after pydevd.settrace')
+    print('TEST SUCEEDED!')
+    

--- a/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_breakpoint_remote_no_import.py
+++ b/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_breakpoint_remote_no_import.py
@@ -1,0 +1,14 @@
+if __name__ == '__main__':
+    import os
+    import sys
+    port = int(sys.argv[1])
+    root_dirname = os.path.dirname(os.path.dirname(__file__))
+    
+    if root_dirname not in sys.path:
+        sys.path.append(root_dirname)
+        
+    print('before pydevd.settrace')
+    breakpoint(port=port)  # Set up through custom sitecustomize.py
+    print('after pydevd.settrace')
+    print('TEST SUCEEDED!')
+    

--- a/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
+++ b/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
@@ -1,4 +1,4 @@
-#coding: utf-8
+# coding: utf-8
 '''
     The idea is that we record the commands sent to the debugger and reproduce them from this script
     (so, this works as the client, which spawns the debugger as a separate process and communicates
@@ -7,34 +7,32 @@
     Note that it's a python script but it'll spawn a process to run as jython, ironpython and as python.
 '''
 import os
-import platform
 import sys
-import threading
 import time
-import unittest
 
 import pytest
 
 from tests_python import debugger_unittest
-from tests_python.debugger_unittest import (get_free_port, CMD_SET_PROPERTY_TRACE, REASON_CAUGHT_EXCEPTION, 
+from tests_python.debugger_unittest import (CMD_SET_PROPERTY_TRACE, REASON_CAUGHT_EXCEPTION,
     REASON_UNCAUGHT_EXCEPTION, REASON_STOP_ON_BREAKPOINT, REASON_THREAD_SUSPEND, overrides, CMD_THREAD_CREATE,
-    CMD_GET_THREAD_STACK, REASON_STEP_INTO_MY_CODE, CMD_GET_EXCEPTION_DETAILS)
+    CMD_GET_THREAD_STACK, REASON_STEP_INTO_MY_CODE, CMD_GET_EXCEPTION_DETAILS, IS_IRONPYTHON, IS_JYTHON, IS_CPYTHON,
+    IS_APPVEYOR)
 from _pydevd_bundle.pydevd_constants import IS_WINDOWS
 try:
     from urllib import unquote
 except ImportError:
     from urllib.parse import unquote
 
-IS_CPYTHON = platform.python_implementation() == 'CPython'
-IS_IRONPYTHON = platform.python_implementation() == 'IronPython'
-IS_JYTHON = platform.python_implementation() == 'Jython'
-IS_APPVEYOR = os.environ.get('APPVEYOR', '') in ('True', 'true', '1')
+from tests_python.debug_constants import TEST_CYTHON
+
+pytest_plugins = [
+    str('tests_python.debugger_fixtures'),
+]
 
 try:
     xrange
 except:
     xrange = range
-
 
 TEST_DJANGO = False
 if sys.version_info[:2] == (2, 7):
@@ -50,7 +48,7 @@ if sys.version_info[0] == 2:
     IS_PY2 = True
 
 IS_PY26 = sys.version_info[:2] == (2, 6)
-    
+
 if IS_PY2:
     builtin_qualifier = "__builtin__"
 else:
@@ -60,334 +58,515 @@ IS_PY36 = False
 if sys.version_info[0] == 3 and sys.version_info[1] == 6:
     IS_PY36 = True
 
-from tests_python.debug_constants import TEST_CYTHON
-from tests_python.debug_constants import TEST_JYTHON
 
-#=======================================================================================================================
-# WriterThreadCaseSetNextStatement
-#======================================================================================================================
-class WriterThreadCaseSetNextStatement(debugger_unittest.AbstractWriterThread):
+@pytest.mark.skipif(IS_IRONPYTHON, reason='Test needs gc.get_referrers to really check anything.')
+def test_case_referrers(case_setup):
+    with case_setup.test_file('_debugger_case1.py') as writer:
+        writer.log.append('writing add breakpoint')
+        writer.write_add_breakpoint(6, 'set_up')
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_set_next_statement.py')
+        writer.log.append('making initial run')
+        writer.write_make_initial_run()
 
-    def run(self):
-        self.start_socket()
-        breakpoint_id = self.write_add_breakpoint(6, None)
-        self.write_make_initial_run()
+        writer.log.append('waiting for breakpoint hit')
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=6)
+        writer.log.append('get frame')
+        writer.write_get_frame(thread_id, frame_id)
 
-        self.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'a')
-        self.wait_for_evaluation('<var name="a" type="int" qualifier="{0}" value="int: 2"'.format(builtin_qualifier))
-        self.write_set_next_statement(hit.thread_id, 2, 'method')
-        hit = self.wait_for_breakpoint_hit('127', line=2)
+        writer.log.append('step over')
+        writer.write_step_over(thread_id)
 
-        self.write_step_over(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('108')
+        writer.log.append('get frame')
+        writer.write_get_frame(thread_id, frame_id)
 
-        self.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'a')
-        self.wait_for_evaluation('<var name="a" type="int" qualifier="{0}" value="int: 1"'.format(builtin_qualifier))
+        writer.log.append('run thread')
+        writer.write_run_thread(thread_id)
 
-        self.write_remove_breakpoint(breakpoint_id)
-        self.write_run_thread(hit.thread_id)
+        writer.log.append('asserting')
+        try:
+            assert 13 == writer._sequence, 'Expected 13. Had: %s' % writer._sequence
+        except:
+            writer.log.append('assert failed!')
+            raise
+        writer.log.append('asserted')
 
-        self.finished_ok = True
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterThreadCaseGetNextStatementTargets
-#======================================================================================================================
-class WriterThreadCaseGetNextStatementTargets(debugger_unittest.AbstractWriterThread):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_get_next_statement_targets.py')
+def test_case_2(case_setup):
+    with case_setup.test_file('_debugger_case2.py') as writer:
+        writer.write_add_breakpoint(3, 'Call4')  # seq = 3
+        writer.write_make_initial_run()
 
-    def run(self):
-        self.start_socket()
-        breakpoint_id = self.write_add_breakpoint(21, None)
-        self.write_make_initial_run()
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=21)
+        writer.write_get_frame(thread_id, frame_id)  # Note: write get frame but not waiting for it to be gotten.
 
-        self.write_get_next_statement_targets(hit.thread_id, hit.frame_id)
-        targets = self.wait_for_get_next_statement_targets()
-        expected = set((2, 3, 5, 8, 9, 10, 12, 13, 14, 15, 17, 18, 19, 21))
-        assert targets == expected, 'Expected targets to be %s, was: %s' % (expected, targets)
+        writer.write_add_breakpoint(14, 'Call2')
 
-        self.write_remove_breakpoint(breakpoint_id)
-        self.write_run_thread(hit.thread_id)
+        writer.write_run_thread(thread_id)
 
-        self.finished_ok = True
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
 
-#=======================================================================================================================
-# AbstractWriterThreadCaseDjango
-#======================================================================================================================
-class AbstractWriterThreadCaseDjango(debugger_unittest.AbstractWriterThread):
-    FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
-    
-    def _ignore_stderr_line(self, line):
-        if debugger_unittest.AbstractWriterThread._ignore_stderr_line(self, line):
-            return True
-        
-        if 'GET /my_app' in line:
-            return True
-        
-        return False
+        writer.write_get_frame(thread_id, frame_id)  # Note: write get frame but not waiting for it to be gotten.
 
-    def get_command_line_args(self):
-        free_port = get_free_port()
-        self.django_port = free_port
-        return [
-            debugger_unittest._get_debugger_test_file(os.path.join('my_django_proj_17', 'manage.py')),
-            'runserver',
-            '--noreload',
-            str(free_port),
-        ]
-    def write_add_breakpoint_django(self, line, func, template):
-        '''
-            @param line: starts at 1
-        '''
-        breakpoint_id = self.next_breakpoint_id()
-        template_file = debugger_unittest._get_debugger_test_file(os.path.join('my_django_proj_17', 'my_app', 'templates', 'my_app', template))
-        self.write("111\t%s\t%s\t%s\t%s\t%s\t%s\tNone\tNone" % (self.next_seq(), breakpoint_id, 'django-line', template_file, line, func))
-        self.log.append('write_add_django_breakpoint: %s line: %s func: %s' % (breakpoint_id, line, func))
-        return breakpoint_id
+        writer.write_run_thread(thread_id)
 
-    def create_request_thread(self, uri):
-        outer= self
-        class T(threading.Thread):
-            def run(self):
-                try:
-                    from urllib.request import urlopen
-                except ImportError:
-                    from urllib import urlopen
-                for _ in xrange(10):
-                    try:
-                        stream = urlopen('http://127.0.0.1:%s/%s' % (outer.django_port,uri))
-                        self.contents = stream.read()
-                        break
-                    except IOError:
-                        continue
-        return T()
+        writer.log.append('Checking sequence. Found: %s' % (writer._sequence))
+        assert 15 == writer._sequence, 'Expected 15. Had: %s' % writer._sequence
 
-#=======================================================================================================================
-# WriterThreadCaseDjango
-#======================================================================================================================
-class WriterThreadCaseDjango(AbstractWriterThreadCaseDjango):
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint_django(5, None, 'index.html')
-        self.write_make_initial_run()
 
-        t = self.create_request_thread('my_app')
-        time.sleep(5)  # Give django some time to get to startup before requesting the page
-        t.start()
+@pytest.mark.skipif(IS_IRONPYTHON, reason='This test fails once in a while due to timing issues on IronPython, so, skipping it.')
+def test_case_3(case_setup):
+    with case_setup.test_file('_debugger_case3.py') as writer:
+        writer.write_make_initial_run()
+        time.sleep(.5)
+        breakpoint_id = writer.write_add_breakpoint(4, '')
+        writer.write_add_breakpoint(5, 'FuncNotAvailable')  # Check that it doesn't get hit in the global when a function is available
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=5)
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'entry')
-        self.wait_for_vars([
-            '<var name="key" type="str"',
-            'v1'
-        ])
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
 
-        self.write_run_thread(hit.thread_id)
+        writer.write_get_frame(thread_id, frame_id)
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=5)
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'entry')
-        self.wait_for_vars([
-            '<var name="key" type="str"',
-            'v2'
-        ])
+        writer.write_run_thread(thread_id)
 
-        self.write_run_thread(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
 
-        for _ in xrange(10):
-            if hasattr(t, 'contents'):
-                break
-            time.sleep(.3)
-        else:
-            raise AssertionError('Django did not return contents properly!')
+        writer.write_get_frame(thread_id, frame_id)
 
-        contents = t.contents.replace(' ', '').replace('\r', '').replace('\n', '')
-        if contents != '<ul><li>v1:v1</li><li>v2:v2</li></ul>':
-            raise AssertionError('%s != <ul><li>v1:v1</li><li>v2:v2</li></ul>' % (contents,))
+        writer.write_remove_breakpoint(breakpoint_id)
 
-        self.finished_ok = True
+        writer.write_run_thread(thread_id)
 
-#=======================================================================================================================
-# WriterThreadCaseDjango2
-#======================================================================================================================
-class WriterThreadCaseDjango2(AbstractWriterThreadCaseDjango):
+        assert 17 == writer._sequence, 'Expected 17. Had: %s' % writer._sequence
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint_django(4, None, 'name.html')
-        self.write_make_initial_run()
+        writer.finished_ok = True
 
-        t = self.create_request_thread('my_app/name')
-        time.sleep(5)  # Give django some time to get to startup before requesting the page
-        t.start()
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=4)
+@pytest.mark.skipif(IS_JYTHON, reason='This test is flaky on Jython, so, skipping it.')
+def test_case_4(case_setup):
+    with case_setup.test_file('_debugger_case4.py') as writer:
+        writer.FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
+        writer.write_make_initial_run()
 
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-        self.wait_for_var('<var name="form" type="NameForm" qualifier="my_app.forms" value="NameForm%253A')
-        self.write_run_thread(hit.thread_id)
-        self.finished_ok = True
+        thread_id = writer.wait_for_new_thread()
 
-#=======================================================================================================================
-# WriterThreadCase19 - [Test Case]: Evaluate '__' attributes
-#======================================================================================================================
-class WriterThreadCase19(debugger_unittest.AbstractWriterThread):
+        writer.write_suspend_thread(thread_id)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case19.py')
+        hit = writer.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
+        assert hit.thread_id == thread_id
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(8, None)
-        self.write_make_initial_run()
+        writer.write_run_thread(thread_id)
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=8)
+        writer.finished_ok = True
 
-        self.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'a.__var')
-        self.wait_for_evaluation([
+
+def test_case_5(case_setup):
+    with case_setup.test_file('_debugger_case56.py') as writer:
+        breakpoint_id = writer.write_add_breakpoint(2, 'Call2')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
+
+        writer.write_get_frame(thread_id, frame_id)
+
+        writer.write_remove_breakpoint(breakpoint_id)
+
+        writer.write_step_return(thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('109')
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
+        line = hit.line
+
+        assert line == 8, 'Expecting it to go to line 8. Went to: %s' % line
+
+        writer.write_step_in(thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('107')
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
+        line = hit.line
+
+        # goes to line 4 in jython (function declaration line)
+        assert line in (4, 5), 'Expecting it to go to line 4 or 5. Went to: %s' % line
+
+        writer.write_run_thread(thread_id)
+
+        assert 15 == writer._sequence, 'Expected 15. Had: %s' % writer._sequence
+
+        writer.finished_ok = True
+
+
+def test_case_6(case_setup):
+    with case_setup.test_file('_debugger_case56.py') as writer:
+        writer.write_add_breakpoint(2, 'Call2')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
+
+        writer.write_get_frame(thread_id, frame_id)
+
+        writer.write_step_return(thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('109')
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
+        line = hit.line
+
+        assert line == 8, 'Expecting it to go to line 8. Went to: %s' % line
+
+        writer.write_step_in(thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('107')
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
+        line = hit.line
+
+        # goes to line 4 in jython (function declaration line)
+        assert line in (4, 5), 'Expecting it to go to line 4 or 5. Went to: %s' % line
+
+        writer.write_run_thread(thread_id)
+
+        assert 13 == writer._sequence, 'Expected 15. Had: %s' % writer._sequence
+
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(IS_IRONPYTHON, reason='This test is flaky on Jython, so, skipping it.')
+def test_case_7(case_setup):
+    # This test checks that we start without variables and at each step a new var is created, but on ironpython,
+    # the variables exist all at once (with None values), so, we can't test it properly.
+    with case_setup.test_file('_debugger_case7.py') as writer:
+        writer.write_add_breakpoint(2, 'Call')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit('111')
+
+        writer.write_get_frame(hit.thread_id, hit.frame_id)
+
+        writer.wait_for_vars('<xml></xml>')  # no vars at this point
+
+        writer.write_step_over(hit.thread_id)
+
+        writer.wait_for_breakpoint_hit('108')
+
+        writer.write_get_frame(hit.thread_id, hit.frame_id)
+
+        writer.wait_for_vars([
             [
-                '<var name="a.__var" type="int" qualifier="{0}" value="int'.format(builtin_qualifier),
-                '<var name="a.__var" type="int"  value="int', # jython
+                '<xml><var name="variable_for_test_1" type="int" qualifier="{0}" value="int%253A 10" />%0A</xml>'.format(builtin_qualifier),
+                '<var name="variable_for_test_1" type="int"  value="int',  # jython
             ]
         ])
-        self.write_run_thread(hit.thread_id)
+
+        writer.write_step_over(hit.thread_id)
+
+        writer.wait_for_breakpoint_hit('108')
+
+        writer.write_get_frame(hit.thread_id, hit.frame_id)
+
+        writer.wait_for_vars([
+            [
+                '<xml><var name="variable_for_test_1" type="int" qualifier="{0}" value="int%253A 10" />%0A<var name="variable_for_test_2" type="int" qualifier="{0}" value="int%253A 20" />%0A</xml>'.format(builtin_qualifier),
+                '<var name="variable_for_test_1" type="int"  value="int%253A 10" />%0A<var name="variable_for_test_2" type="int"  value="int%253A 20" />%0A',  # jython
+            ]
+        ])
+
+        writer.write_run_thread(hit.thread_id)
+
+        assert 17 == writer._sequence, 'Expected 17. Had: %s' % writer._sequence
+
+        writer.finished_ok = True
 
 
-        self.finished_ok = True
+def test_case_8(case_setup):
+    with case_setup.test_file('_debugger_case89.py') as writer:
+        writer.write_add_breakpoint(10, 'Method3')
+        writer.write_make_initial_run()
 
-#=======================================================================================================================
-# WriterThreadCase20 - Check that we were notified of threads creation before they started to run
-#======================================================================================================================
-class WriterThreadCase20(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit('111')
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case20.py')
+        writer.write_step_return(hit.thread_id)
 
-    def run(self):
-        self.start_socket()
-        self.write_make_initial_run()
+        hit = writer.wait_for_breakpoint_hit('109', line=15)
 
-        # We already check if it prints 'TEST SUCEEDED' by default, so, nothing
-        # else should be needed in this test as it tests what's needed just by
-        # running the module.
-        self.finished_ok = True
+        writer.write_run_thread(hit.thread_id)
 
+        assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
 
-#=======================================================================================================================
-# WriterThreadCase18 - [Test Case]: change local variable
-#======================================================================================================================
-class WriterThreadCase18(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case18.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(5, 'm2')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=5)
-
-        self.write_change_variable(hit.thread_id, hit.frame_id, 'a', '40')
-        self.wait_for_var('<xml><var name="" type="int" qualifier="{0}" value="int%253A 40" />%0A</xml>'.format(builtin_qualifier,))
-        self.write_run_thread(hit.thread_id)
-
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCase17 - [Test Case]: dont trace
-#======================================================================================================================
-class WriterThreadCase17(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case17.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_enable_dont_trace(True)
-        self.write_add_breakpoint(27, 'main')
-        self.write_add_breakpoint(29, 'main')
-        self.write_add_breakpoint(31, 'main')
-        self.write_add_breakpoint(33, 'main')
-        self.write_make_initial_run()
-
-        for _i in range(4):
-            hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
-
-            self.write_step_in(hit.thread_id)
-            hit = self.wait_for_breakpoint_hit('107', line=2)
-            # Should Skip step into properties setter
-            self.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
 
 
-        self.finished_ok = True
+def test_case_9(case_setup):
+    with case_setup.test_file('_debugger_case89.py') as writer:
+        writer.write_add_breakpoint(10, 'Method3')
+        writer.write_make_initial_run()
 
-#=======================================================================================================================
-# WriterThreadCase17a - [Test Case]: dont trace return
-#======================================================================================================================
-class WriterThreadCase17a(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit('111')
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case17a.py')
+        # Note: no active exception (should not give an error and should return no
+        # exception details as there's no exception).
+        writer.write_get_current_exception(hit.thread_id)
 
-    def run(self):
-        self.start_socket()
-        self.write_enable_dont_trace(True)
-        self.write_add_breakpoint(2, 'm1')
-        self.write_make_initial_run()
+        msg = writer.wait_for_message(accept_message=lambda msg:msg.strip().startswith(str(CMD_GET_EXCEPTION_DETAILS)))
+        assert msg.thread['id'] == hit.thread_id
+        assert not hasattr(msg.thread, 'frames')  # No frames should be found.
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=2)
+        writer.write_step_over(hit.thread_id)
 
-        self.write_step_in(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('107', line=10)
+        hit = writer.wait_for_breakpoint_hit('108', line=11)
 
+        writer.write_step_over(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('108', line=12)
+
+        writer.write_run_thread(hit.thread_id)
+
+        assert 13 == writer._sequence, 'Expected 13. Had: %s' % writer._sequence
+
+        writer.finished_ok = True
+
+
+def test_case_10(case_setup):
+    with case_setup.test_file('_debugger_case_simple_calls.py') as writer:
+        writer.write_add_breakpoint(2, 'None')  # None or Method should make hit.
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit('111')
+
+        writer.write_step_return(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('109', line=11)
+
+        writer.write_step_over(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('108', line=12)
+
+        writer.write_run_thread(hit.thread_id)
+
+        assert 11 == writer._sequence, 'Expected 11. Had: %s' % writer._sequence
+
+        writer.finished_ok = True
+
+
+def test_case_11(case_setup):
+    with case_setup.test_file('_debugger_case_simple_calls.py') as writer:
+        writer.write_add_breakpoint(2, 'Method1')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit('111', line=2)
+
+        writer.write_step_over(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('108', line=3)
+
+        writer.write_step_over(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('108', line=11)
+
+        writer.write_step_over(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('108', line=12)
+
+        writer.write_run_thread(hit.thread_id)
+
+        assert 13 == writer._sequence, 'Expected 13. Had: %s' % writer._sequence
+
+        writer.finished_ok = True
+
+
+def test_case_12(case_setup):
+    with case_setup.test_file('_debugger_case_simple_calls.py') as writer:
+        writer.write_add_breakpoint(2, '')  # Should not be hit: setting empty function (not None) should only hit global.
+        writer.write_add_breakpoint(6, 'Method1a')
+        writer.write_add_breakpoint(11, 'Method2')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit('111', line=11)
+
+        writer.write_step_return(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit('111', line=6)  # not a return (it stopped in the other breakpoint)
+
+        writer.write_run_thread(hit.thread_id)
+
+        assert 13 == writer._sequence, 'Expected 13. Had: %s' % writer._sequence
+
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(IS_IRONPYTHON, reason='Failing on IronPython (needs to be investigated).')
+def test_case_13(case_setup):
+    with case_setup.test_file('_debugger_case13.py') as writer:
+
+        def _ignore_stderr_line(line):
+            if original_ignore_stderr_line(line):
+                return True
+
+            if IS_JYTHON:
+                for expected in (
+                    "RuntimeWarning: Parent module '_pydevd_bundle' not found while handling absolute import",
+                    "import __builtin__"):
+                    if expected in line:
+                        return True
+
+            return False
+
+        original_ignore_stderr_line = writer._ignore_stderr_line
+        writer._ignore_stderr_line = _ignore_stderr_line
+
+        writer.write_add_breakpoint(35, 'main')
+        writer.write("%s\t%s\t%s" % (CMD_SET_PROPERTY_TRACE, writer.next_seq(), "true;false;false;true"))
+        writer.write_make_initial_run()
+        hit = writer.wait_for_breakpoint_hit('111')
+
+        writer.write_get_frame(hit.thread_id, hit.frame_id)
+
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('107', line=25)
+        # Should go inside setter method
+
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('107')
+
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('107', line=21)
+        # Should go inside getter method
+
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('107')
+
+        # Disable property tracing
+        writer.write("%s\t%s\t%s" % (CMD_SET_PROPERTY_TRACE, writer.next_seq(), "true;true;true;true"))
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('107', line=39)
         # Should Skip step into properties setter
-        assert hit.name == 'm3'
-        self.write_run_thread(hit.thread_id)
 
-        self.finished_ok = True
+        # Enable property tracing
+        writer.write("%s\t%s\t%s" % (CMD_SET_PROPERTY_TRACE, writer.next_seq(), "true;false;false;true"))
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('107', line=8)
+        # Should go inside getter method
 
-#=======================================================================================================================
-# WriterThreadCase16 - [Test Case]: numpy.ndarray resolver
-#======================================================================================================================
-class WriterThreadCase16(debugger_unittest.AbstractWriterThread):
+        writer.write_run_thread(hit.thread_id)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case16.py')
+        writer.finished_ok = True
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(9, 'main')
-        self.write_make_initial_run()
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
+def test_case_14(case_setup):
+    # Interactive Debug Console
+    with case_setup.test_file('_debugger_case14.py') as writer:
+        writer.write_add_breakpoint(22, 'main')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit('111')
+        assert hit.thread_id, '%s not valid.' % hit.thread_id
+        assert hit.frame_id, '%s not valid.' % hit.frame_id
+
+        # Access some variable
+        writer.write_debug_console_expression("%s\t%s\tEVALUATE\tcarObj.color" % (hit.thread_id, hit.frame_id))
+        writer.wait_for_var(['<more>False</more>', '%27Black%27'])
+        assert 7 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
+
+        # Change some variable
+        writer.write_debug_console_expression("%s\t%s\tEVALUATE\tcarObj.color='Red'" % (hit.thread_id, hit.frame_id))
+        writer.write_debug_console_expression("%s\t%s\tEVALUATE\tcarObj.color" % (hit.thread_id, hit.frame_id))
+        writer.wait_for_var(['<more>False</more>', '%27Red%27'])
+        assert 11 == writer._sequence, 'Expected 13. Had: %s' % writer._sequence
+
+        # Iterate some loop
+        writer.write_debug_console_expression("%s\t%s\tEVALUATE\tfor i in range(3):" % (hit.thread_id, hit.frame_id))
+        writer.wait_for_var(['<xml><more>True</more></xml>'])
+        writer.write_debug_console_expression("%s\t%s\tEVALUATE\t    print(i)" % (hit.thread_id, hit.frame_id))
+        writer.wait_for_var(['<xml><more>True</more></xml>'])
+        writer.write_debug_console_expression("%s\t%s\tEVALUATE\t" % (hit.thread_id, hit.frame_id))
+        writer.wait_for_var(
+            [
+                '<xml><more>False</more><output message="0"></output><output message="1"></output><output message="2"></output></xml>'            ]
+            )
+        assert 17 == writer._sequence, 'Expected 19. Had: %s' % writer._sequence
+
+        writer.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
+
+
+def test_case_15(case_setup):
+    with case_setup.test_file('_debugger_case15.py') as writer:
+        writer.write_add_breakpoint(22, 'main')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
+
+        # Access some variable
+        writer.write_custom_operation("%s\t%s\tEXPRESSION\tcarObj.color" % (hit.thread_id, hit.frame_id), "EXEC", "f=lambda x: 'val=%s' % x", "f")
+        writer.wait_for_custom_operation('val=Black')
+        assert 7 == writer._sequence, 'Expected 7. Had: %s' % writer._sequence
+
+        writer.write_custom_operation("%s\t%s\tEXPRESSION\tcarObj.color" % (hit.thread_id, hit.frame_id), "EXECFILE", debugger_unittest._get_debugger_test_file('_debugger_case15_execfile.py'), "f")
+        writer.wait_for_custom_operation('val=Black')
+        assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
+
+        writer.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
+
+
+def test_case_16(case_setup):
+    # numpy.ndarray resolver
+    try:
+        import numpy
+    except ImportError:
+        pytest.skip('numpy not available')
+    with case_setup.test_file('_debugger_case16.py') as writer:
+        writer.write_add_breakpoint(9, 'main')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
 
         # In this test we check that the three arrays of different shapes, sizes and types
         # are all resolved properly as ndarrays.
 
         # First pass check is that we have all three expected variables defined
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-        self.wait_for_multiple_vars((
+        writer.write_get_frame(hit.thread_id, hit.frame_id)
+        writer.wait_for_multiple_vars((
             (
                 '<var name="smallarray" type="ndarray" qualifier="numpy" value="ndarray%253A %255B 0.%252B1.j  1.%252B1.j  2.%252B1.j  3.%252B1.j  4.%252B1.j  5.%252B1.j  6.%252B1.j  7.%252B1.j  8.%252B1.j%250A  9.%252B1.j 10.%252B1.j 11.%252B1.j 12.%252B1.j 13.%252B1.j 14.%252B1.j 15.%252B1.j 16.%252B1.j 17.%252B1.j%250A 18.%252B1.j 19.%252B1.j 20.%252B1.j 21.%252B1.j 22.%252B1.j 23.%252B1.j 24.%252B1.j 25.%252B1.j 26.%252B1.j%250A 27.%252B1.j 28.%252B1.j 29.%252B1.j 30.%252B1.j 31.%252B1.j 32.%252B1.j 33.%252B1.j 34.%252B1.j 35.%252B1.j%250A 36.%252B1.j 37.%252B1.j 38.%252B1.j 39.%252B1.j 40.%252B1.j 41.%252B1.j 42.%252B1.j 43.%252B1.j 44.%252B1.j%250A 45.%252B1.j 46.%252B1.j 47.%252B1.j 48.%252B1.j 49.%252B1.j 50.%252B1.j 51.%252B1.j 52.%252B1.j 53.%252B1.j%250A 54.%252B1.j 55.%252B1.j 56.%252B1.j 57.%252B1.j 58.%252B1.j 59.%252B1.j 60.%252B1.j 61.%252B1.j 62.%252B1.j%250A 63.%252B1.j 64.%252B1.j 65.%252B1.j 66.%252B1.j 67.%252B1.j 68.%252B1.j 69.%252B1.j 70.%252B1.j 71.%252B1.j%250A 72.%252B1.j 73.%252B1.j 74.%252B1.j 75.%252B1.j 76.%252B1.j 77.%252B1.j 78.%252B1.j 79.%252B1.j 80.%252B1.j%250A 81.%252B1.j 82.%252B1.j 83.%252B1.j 84.%252B1.j 85.%252B1.j 86.%252B1.j 87.%252B1.j 88.%252B1.j 89.%252B1.j%250A 90.%252B1.j 91.%252B1.j 92.%252B1.j 93.%252B1.j 94.%252B1.j 95.%252B1.j 96.%252B1.j 97.%252B1.j 98.%252B1.j%250A 99.%252B1.j%255D" isContainer="True" />',
                 '<var name="smallarray" type="ndarray" qualifier="numpy" value="ndarray%253A %255B  0.%252B1.j   1.%252B1.j   2.%252B1.j   3.%252B1.j   4.%252B1.j   5.%252B1.j   6.%252B1.j   7.%252B1.j%250A   8.%252B1.j   9.%252B1.j  10.%252B1.j  11.%252B1.j  12.%252B1.j  13.%252B1.j  14.%252B1.j  15.%252B1.j%250A  16.%252B1.j  17.%252B1.j  18.%252B1.j  19.%252B1.j  20.%252B1.j  21.%252B1.j  22.%252B1.j  23.%252B1.j%250A  24.%252B1.j  25.%252B1.j  26.%252B1.j  27.%252B1.j  28.%252B1.j  29.%252B1.j  30.%252B1.j  31.%252B1.j%250A  32.%252B1.j  33.%252B1.j  34.%252B1.j  35.%252B1.j  36.%252B1.j  37.%252B1.j  38.%252B1.j  39.%252B1.j%250A  40.%252B1.j  41.%252B1.j  42.%252B1.j  43.%252B1.j  44.%252B1.j  45.%252B1.j  46.%252B1.j  47.%252B1.j%250A  48.%252B1.j  49.%252B1.j  50.%252B1.j  51.%252B1.j  52.%252B1.j  53.%252B1.j  54.%252B1.j  55.%252B1.j%250A  56.%252B1.j  57.%252B1.j  58.%252B1.j  59.%252B1.j  60.%252B1.j  61.%252B1.j  62.%252B1.j  63.%252B1.j%250A  64.%252B1.j  65.%252B1.j  66.%252B1.j  67.%252B1.j  68.%252B1.j  69.%252B1.j  70.%252B1.j  71.%252B1.j%250A  72.%252B1.j  73.%252B1.j  74.%252B1.j  75.%252B1.j  76.%252B1.j  77.%252B1.j  78.%252B1.j  79.%252B1.j%250A  80.%252B1.j  81.%252B1.j  82.%252B1.j  83.%252B1.j  84.%252B1.j  85.%252B1.j  86.%252B1.j  87.%252B1.j%250A  88.%252B1.j  89.%252B1.j  90.%252B1.j  91.%252B1.j  92.%252B1.j  93.%252B1.j  94.%252B1.j  95.%252B1.j%250A  96.%252B1.j  97.%252B1.j  98.%252B1.j  99.%252B1.j%255D" isContainer="True" />'
             ),
-            
+
             (
                 '<var name="bigarray" type="ndarray" qualifier="numpy" value="ndarray%253A %255B%255B    0     1     2 ...  9997  9998  9999%255D%250A %255B10000 10001 10002 ... 19997 19998 19999%255D%250A %255B20000 20001 20002 ... 29997 29998 29999%255D%250A ...%250A %255B70000 70001 70002 ... 79997 79998 79999%255D%250A %255B80000 80001 80002 ... 89997 89998 89999%255D%250A %255B90000 90001 90002 ... 99997 99998 99999%255D%255D" isContainer="True" />',
                 '<var name="bigarray" type="ndarray" qualifier="numpy" value="ndarray%253A %255B%255B    0     1     2 ...%252C  9997  9998  9999%255D%250A %255B10000 10001 10002 ...%252C 19997 19998 19999%255D%250A %255B20000 20001 20002 ...%252C 29997 29998 29999%255D%250A ...%252C %250A %255B70000 70001 70002 ...%252C 79997 79998 79999%255D%250A %255B80000 80001 80002 ...%252C 89997 89998 89999%255D%250A %255B90000 90001 90002 ...%252C 99997 99998 99999%255D%255D" isContainer="True" />'
             ),
-            
+
             # Any of the ones below will do.
             (
-                '<var name="hugearray" type="ndarray" qualifier="numpy" value="ndarray%253A %255B      0       1       2 ... 9999997 9999998 9999999%255D" isContainer="True" />', 
+                '<var name="hugearray" type="ndarray" qualifier="numpy" value="ndarray%253A %255B      0       1       2 ... 9999997 9999998 9999999%255D" isContainer="True" />',
                 '<var name="hugearray" type="ndarray" qualifier="numpy" value="ndarray%253A %255B      0       1       2 ...%252C 9999997 9999998 9999999%255D" isContainer="True" />'
             )
         ))
 
         # For each variable, check each of the resolved (meta data) attributes...
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'smallarray')
-        self.wait_for_multiple_vars((
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'smallarray')
+        writer.wait_for_multiple_vars((
             '<var name="min" type="complex128"',
             '<var name="max" type="complex128"',
             '<var name="shape" type="tuple"',
@@ -395,12 +574,12 @@ class WriterThreadCase16(debugger_unittest.AbstractWriterThread):
             '<var name="size" type="int"',
         ))
         # ...and check that the internals are resolved properly
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'smallarray\t__internals__')
-        self.wait_for_var('<var name="%27size%27')
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'smallarray\t__internals__')
+        writer.wait_for_var('<var name="%27size%27')
 
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'bigarray')
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'bigarray')
         # isContainer could be true on some numpy versions, so, we only check for the var begin.
-        self.wait_for_multiple_vars((
+        writer.wait_for_multiple_vars((
             [
                 '<var name="min" type="int64" qualifier="numpy" value="int64%253A 0"',
                 '<var name="min" type="int64" qualifier="numpy" value="int64%3A 0"',
@@ -416,13 +595,13 @@ class WriterThreadCase16(debugger_unittest.AbstractWriterThread):
             '<var name="dtype" type="dtype"',
             '<var name="size" type="int"'
         ))
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'bigarray\t__internals__')
-        self.wait_for_var('<var name="%27size%27')
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'bigarray\t__internals__')
+        writer.wait_for_var('<var name="%27size%27')
 
         # this one is different because it crosses the magic threshold where we don't calculate
         # the min/max
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'hugearray')
-        self.wait_for_var((
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'hugearray')
+        writer.wait_for_var((
             [
                 '<var name="min" type="str" qualifier={0} value="str%253A ndarray too big%252C calculating min would slow down debugging" />'.format(builtin_qualifier),
                 '<var name="min" type="str" qualifier={0} value="str%3A ndarray too big%252C calculating min would slow down debugging" />'.format(builtin_qualifier),
@@ -439,545 +618,368 @@ class WriterThreadCase16(debugger_unittest.AbstractWriterThread):
             '<var name="dtype" type="dtype"',
             '<var name="size" type="int"',
         ))
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'hugearray\t__internals__')
-        self.wait_for_var('<var name="%27size%27')
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'hugearray\t__internals__')
+        writer.wait_for_var('<var name="%27size%27')
 
-        self.write_run_thread(hit.thread_id)
-        self.finished_ok = True
-
-
-#=======================================================================================================================
-# WriterThreadCase15 - [Test Case]: Custom Commands
-#======================================================================================================================
-class WriterThreadCase15(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case15.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(22, 'main')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
-
-        # Access some variable
-        self.write_custom_operation("%s\t%s\tEXPRESSION\tcarObj.color" % (hit.thread_id, hit.frame_id), "EXEC", "f=lambda x: 'val=%s' % x", "f")
-        self.wait_for_custom_operation('val=Black')
-        assert 7 == self._sequence, 'Expected 7. Had: %s' % self._sequence
-
-        self.write_custom_operation("%s\t%s\tEXPRESSION\tcarObj.color" % (hit.thread_id, hit.frame_id), "EXECFILE", debugger_unittest._get_debugger_test_file('_debugger_case15_execfile.py'), "f")
-        self.wait_for_custom_operation('val=Black')
-        assert 9 == self._sequence, 'Expected 9. Had: %s' % self._sequence
-
-        self.write_run_thread(hit.thread_id)
-        self.finished_ok = True
+        writer.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
 
 
+def test_case_17(case_setup):
+    # Check dont trace
+    with case_setup.test_file('_debugger_case17.py') as writer:
+        writer.write_enable_dont_trace(True)
+        writer.write_add_breakpoint(27, 'main')
+        writer.write_add_breakpoint(29, 'main')
+        writer.write_add_breakpoint(31, 'main')
+        writer.write_add_breakpoint(33, 'main')
+        writer.write_make_initial_run()
 
-#=======================================================================================================================
-# WriterThreadCase14 - [Test Case]: Interactive Debug Console
-#======================================================================================================================
-class WriterThreadCase14(debugger_unittest.AbstractWriterThread):
+        for _i in range(4):
+            hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case14.py')
+            writer.write_step_in(hit.thread_id)
+            hit = writer.wait_for_breakpoint_hit('107', line=2)
+            # Should Skip step into properties setter
+            writer.write_run_thread(hit.thread_id)
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(22, 'main')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111')
-        assert hit.thread_id, '%s not valid.' % hit.thread_id
-        assert hit.frame_id, '%s not valid.' % hit.frame_id
-
-        # Access some variable
-        self.write_debug_console_expression("%s\t%s\tEVALUATE\tcarObj.color" % (hit.thread_id, hit.frame_id))
-        self.wait_for_var(['<more>False</more>', '%27Black%27'])
-        assert 7 == self._sequence, 'Expected 9. Had: %s' % self._sequence
-
-        # Change some variable
-        self.write_debug_console_expression("%s\t%s\tEVALUATE\tcarObj.color='Red'" % (hit.thread_id, hit.frame_id))
-        self.write_debug_console_expression("%s\t%s\tEVALUATE\tcarObj.color" % (hit.thread_id, hit.frame_id))
-        self.wait_for_var(['<more>False</more>', '%27Red%27'])
-        assert 11 == self._sequence, 'Expected 13. Had: %s' % self._sequence
-
-        # Iterate some loop
-        self.write_debug_console_expression("%s\t%s\tEVALUATE\tfor i in range(3):" % (hit.thread_id, hit.frame_id))
-        self.wait_for_var(['<xml><more>True</more></xml>'])
-        self.write_debug_console_expression("%s\t%s\tEVALUATE\t    print(i)" % (hit.thread_id, hit.frame_id))
-        self.wait_for_var(['<xml><more>True</more></xml>'])
-        self.write_debug_console_expression("%s\t%s\tEVALUATE\t" % (hit.thread_id, hit.frame_id))
-        self.wait_for_var(
-            [
-                '<xml><more>False</more><output message="0"></output><output message="1"></output><output message="2"></output></xml>'            ]
-            )
-        assert 17 == self._sequence, 'Expected 19. Had: %s' % self._sequence
-
-        self.write_run_thread(hit.thread_id)
-        self.finished_ok = True
+        writer.finished_ok = True
 
 
-#=======================================================================================================================
-# WriterThreadCase13
-#======================================================================================================================
-class WriterThreadCase13(debugger_unittest.AbstractWriterThread):
+def test_case_17a(case_setup):
+    # Check dont trace return
+    with case_setup.test_file('_debugger_case17a.py') as writer:
+        writer.write_enable_dont_trace(True)
+        writer.write_add_breakpoint(2, 'm1')
+        writer.write_make_initial_run()
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case13.py')
-    
-    def _ignore_stderr_line(self, line):
-        if debugger_unittest.AbstractWriterThread._ignore_stderr_line(self, line):
-            return True
-        
-        if IS_JYTHON:
-            for expected in (
-                "RuntimeWarning: Parent module '_pydevd_bundle' not found while handling absolute import",
-                "import __builtin__"):
-                if expected in line:
-                    return True
-        
-        return False
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=2)
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(35, 'main')
-        self.write("%s\t%s\t%s" % (CMD_SET_PROPERTY_TRACE, self.next_seq(), "true;false;false;true"))
-        self.write_make_initial_run()
-        hit = self.wait_for_breakpoint_hit('111')
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('107', line=10)
 
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-
-        self.write_step_in(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('107', line=25)
-        # Should go inside setter method
-
-        self.write_step_in(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('107')
-
-        self.write_step_in(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('107', line=21)
-        # Should go inside getter method
-
-        self.write_step_in(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('107')
-
-        # Disable property tracing
-        self.write("%s\t%s\t%s" % (CMD_SET_PROPERTY_TRACE, self.next_seq(), "true;true;true;true"))
-        self.write_step_in(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('107', line=39)
         # Should Skip step into properties setter
+        assert hit.name == 'm3'
+        writer.write_run_thread(hit.thread_id)
 
-        # Enable property tracing
-        self.write("%s\t%s\t%s" % (CMD_SET_PROPERTY_TRACE, self.next_seq(), "true;false;false;true"))
-        self.write_step_in(hit.thread_id)
-        hit = self.wait_for_breakpoint_hit('107', line=8)
-        # Should go inside getter method
+        writer.finished_ok = True
 
-        self.write_run_thread(hit.thread_id)
 
-        self.finished_ok = True
+def test_case_18(case_setup):
+    # change local variable
+    if IS_IRONPYTHON or IS_JYTHON:
+        pytest.skip('Unsupported assign to local')
 
-#=======================================================================================================================
-# WriterThreadCase12
-#======================================================================================================================
-class WriterThreadCase12(debugger_unittest.AbstractWriterThread):
+    with case_setup.test_file('_debugger_case18.py') as writer:
+        writer.write_add_breakpoint(5, 'm2')
+        writer.write_make_initial_run()
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_simple_calls.py')
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=5)
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(2, '')  # Should not be hit: setting empty function (not None) should only hit global.
-        self.write_add_breakpoint(6, 'Method1a')
-        self.write_add_breakpoint(11, 'Method2')
-        self.write_make_initial_run()
+        writer.write_change_variable(hit.thread_id, hit.frame_id, 'a', '40')
+        writer.wait_for_var('<xml><var name="" type="int" qualifier="{0}" value="int%253A 40" />%0A</xml>'.format(builtin_qualifier,))
+        writer.write_run_thread(hit.thread_id)
 
-        hit = self.wait_for_breakpoint_hit('111', line=11)
+        writer.finished_ok = True
 
-        self.write_step_return(hit.thread_id)
 
-        hit = self.wait_for_breakpoint_hit('111', line=6)  # not a return (it stopped in the other breakpoint)
+def test_case_19(case_setup):
+    # Check evaluate '__' attributes
+    with case_setup.test_file('_debugger_case19.py') as writer:
+        writer.write_add_breakpoint(8, None)
+        writer.write_make_initial_run()
 
-        self.write_run_thread(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=8)
 
-        assert 13 == self._sequence, 'Expected 13. Had: %s' % self._sequence
-
-        self.finished_ok = True
-
-
-
-#=======================================================================================================================
-# WriterThreadCase11
-#======================================================================================================================
-class WriterThreadCase11(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_simple_calls.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(2, 'Method1')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111', line=2)
-
-        self.write_step_over(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('108', line=3)
-
-        self.write_step_over(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('108', line=11)
-
-        self.write_step_over(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('108', line=12)
-
-        self.write_run_thread(hit.thread_id)
-
-        assert 13 == self._sequence, 'Expected 13. Had: %s' % self._sequence
-
-        self.finished_ok = True
-
-
-
-#=======================================================================================================================
-# WriterThreadCase10
-#======================================================================================================================
-class WriterThreadCase10(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_simple_calls.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(2, 'None')  # None or Method should make hit.
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111')
-
-        self.write_step_return(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('109', line=11)
-
-        self.write_step_over(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('108', line=12)
-
-        self.write_run_thread(hit.thread_id)
-
-        assert 11 == self._sequence, 'Expected 11. Had: %s' % self._sequence
-
-        self.finished_ok = True
-
-
-
-#=======================================================================================================================
-# WriterThreadCase9
-#======================================================================================================================
-class WriterThreadCase9(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case89.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(10, 'Method3')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111')
-
-        # Note: no active exception (should not give an error and should return no
-        # exception details as there's no exception).        
-        self.write_get_current_exception(hit.thread_id)
-
-        msg = self.wait_for_message(accept_message=lambda msg:msg.strip().startswith(str(CMD_GET_EXCEPTION_DETAILS)))
-        assert msg.thread['id'] == hit.thread_id
-        assert not hasattr(msg.thread, 'frames')  # No frames should be found.
-
-        self.write_step_over(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('108', line=11)
-
-        self.write_step_over(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('108', line=12)
-
-        self.write_run_thread(hit.thread_id)
-
-        assert 13 == self._sequence, 'Expected 13. Had: %s' % self._sequence
-
-        self.finished_ok = True
-
-
-#=======================================================================================================================
-# WriterThreadCase8
-#======================================================================================================================
-class WriterThreadCase8(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case89.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(10, 'Method3')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111')
-
-        self.write_step_return(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('109', line=15)
-
-        self.write_run_thread(hit.thread_id)
-
-        assert 9 == self._sequence, 'Expected 9. Had: %s' % self._sequence
-
-        self.finished_ok = True
-
-
-
-
-#=======================================================================================================================
-# WriterThreadCase7
-#======================================================================================================================
-class WriterThreadCase7(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case7.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(2, 'Call')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111')
-
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-
-        self.wait_for_vars('<xml></xml>')  # no vars at this point
-
-        self.write_step_over(hit.thread_id)
-
-        self.wait_for_breakpoint_hit('108')
-
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-
-        self.wait_for_vars([
+        writer.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'a.__var')
+        writer.wait_for_evaluation([
             [
-                '<xml><var name="variable_for_test_1" type="int" qualifier="{0}" value="int%253A 10" />%0A</xml>'.format(builtin_qualifier),
-                '<var name="variable_for_test_1" type="int"  value="int',  # jython
+                '<var name="a.__var" type="int" qualifier="{0}" value="int'.format(builtin_qualifier),
+                '<var name="a.__var" type="int"  value="int',  # jython
             ]
         ])
+        writer.write_run_thread(hit.thread_id)
 
-        self.write_step_over(hit.thread_id)
+        writer.finished_ok = True
 
-        self.wait_for_breakpoint_hit('108')
 
-        self.write_get_frame(hit.thread_id, hit.frame_id)
+@pytest.mark.skipif(IS_JYTHON, reason='Monkey-patching related to starting threads not done on Jython.')
+def test_case_20(case_setup):
+    # Check that we were notified of threads creation before they started to run
+    with case_setup.test_file('_debugger_case20.py') as writer:
+        writer.write_make_initial_run()
 
-        self.wait_for_vars([
-            [
-                '<xml><var name="variable_for_test_1" type="int" qualifier="{0}" value="int%253A 10" />%0A<var name="variable_for_test_2" type="int" qualifier="{0}" value="int%253A 20" />%0A</xml>'.format(builtin_qualifier),
-                '<var name="variable_for_test_1" type="int"  value="int%253A 10" />%0A<var name="variable_for_test_2" type="int"  value="int%253A 20" />%0A',  # jython
-            ]
+        # We already check if it prints 'TEST SUCEEDED' by default, so, nothing
+        # else should be needed in this test as it tests what's needed just by
+        # running the module.
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(not TEST_DJANGO, reason='No django available')
+def test_case_django(case_setup_django):
+    with case_setup_django.test_file('') as writer:
+        writer.write_add_breakpoint_django(5, None, 'index.html')
+        writer.write_make_initial_run()
+
+        t = writer.create_request_thread('my_app')
+        time.sleep(5)  # Give django some time to get to startup before requesting the page
+        t.start()
+
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=5)
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'entry')
+        writer.wait_for_vars([
+            '<var name="key" type="str"',
+            'v1'
         ])
 
-        self.write_run_thread(hit.thread_id)
+        writer.write_run_thread(hit.thread_id)
 
-        assert 17 == self._sequence, 'Expected 17. Had: %s' % self._sequence
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=5)
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'entry')
+        writer.wait_for_vars([
+            '<var name="key" type="str"',
+            'v2'
+        ])
 
-        self.finished_ok = True
+        writer.write_run_thread(hit.thread_id)
+
+        for _ in xrange(10):
+            if hasattr(t, 'contents'):
+                break
+            time.sleep(.3)
+        else:
+            raise AssertionError('Django did not return contents properly!')
+
+        contents = t.contents.replace(' ', '').replace('\r', '').replace('\n', '')
+        if contents != '<ul><li>v1:v1</li><li>v2:v2</li></ul>':
+            raise AssertionError('%s != <ul><li>v1:v1</li><li>v2:v2</li></ul>' % (contents,))
+
+        writer.finished_ok = True
 
 
+@pytest.mark.skipif(not TEST_DJANGO, reason='No django available')
+def test_case_django2(case_setup_django):
+    with case_setup_django.test_file('') as writer:
+        writer.write_add_breakpoint_django(4, None, 'name.html')
+        writer.write_make_initial_run()
 
-#=======================================================================================================================
-# WriterThreadCase6
-#=======================================================================================================================
-class WriterThreadCase6(debugger_unittest.AbstractWriterThread):
+        t = writer.create_request_thread('my_app/name')
+        time.sleep(5)  # Give django some time to get to startup before requesting the page
+        t.start()
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case56.py')
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=4)
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(2, 'Call2')
-        self.write_make_initial_run()
+        writer.write_get_frame(hit.thread_id, hit.frame_id)
+        writer.wait_for_var('<var name="form" type="NameForm" qualifier="my_app.forms" value="NameForm%253A')
+        writer.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
 
-        hit = self.wait_for_breakpoint_hit()
+
+@pytest.mark.skipif(not TEST_CYTHON, reason='No cython available')
+def test_cython(case_setup):
+    from _pydevd_bundle import pydevd_cython
+    assert pydevd_cython.trace_dispatch is not None
+
+
+def _has_qt():
+    try:
+        from PySide import QtCore  # @UnresolvedImport
+        return True
+    except:
+        try:
+            from PyQt4 import QtCore  # @UnresolvedImport
+            return True
+        except:
+            try:
+                from PyQt5 import QtCore  # @UnresolvedImport
+                return True
+            except:
+                pass
+    return False
+
+
+@pytest.mark.skipif(not _has_qt(), reason='No qt available')
+def test_case_qthread1(case_setup):
+    with case_setup.test_file('_debugger_case_qthread1.py') as writer:
+        breakpoint_id = writer.write_add_breakpoint(19, 'run')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
+
+        writer.write_remove_breakpoint(breakpoint_id)
+        writer.write_run_thread(hit.thread_id)
+
+        writer.log.append('Checking sequence. Found: %s' % (writer._sequence))
+        assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
+
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(not _has_qt(), reason='No qt available')
+def test_case_qthread2(case_setup):
+    with case_setup.test_file('_debugger_case_qthread2.py') as writer:
+        breakpoint_id = writer.write_add_breakpoint(24, 'long_running')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
         thread_id = hit.thread_id
-        frame_id = hit.frame_id 
 
-        self.write_get_frame(thread_id, frame_id)
+        writer.write_remove_breakpoint(breakpoint_id)
+        writer.write_run_thread(thread_id)
 
-        self.write_step_return(thread_id)
+        writer.log.append('Checking sequence. Found: %s' % (writer._sequence))
+        assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
 
-        hit = self.wait_for_breakpoint_hit('109')
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(not _has_qt(), reason='No qt available')
+def test_case_qthread3(case_setup):
+    with case_setup.test_file('_debugger_case_qthread3.py') as writer:
+        breakpoint_id = writer.write_add_breakpoint(22, 'run')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
         thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        line = hit.line
+        frame_id = hit.frame_id
+
+        writer.write_remove_breakpoint(breakpoint_id)
+        writer.write_run_thread(thread_id)
+
+        writer.log.append('Checking sequence. Found: %s' % (writer._sequence))
+        assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
+
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
 
 
-        assert line == 8, 'Expecting it to go to line 8. Went to: %s' % line
+@pytest.mark.skipif(not _has_qt(), reason='No qt available')
+def test_case_qthread4(case_setup):
+    with case_setup.test_file('_debugger_case_qthread4.py') as writer:
+        original_additional_output_checks = writer.additional_output_checks
 
-        self.write_step_in(thread_id)
+        def additional_output_checks(stdout, stderr):
+            original_additional_output_checks(stdout, stderr)
+            if 'On start called' not in stdout:
+                raise AssertionError('Expected "On start called" to be in stdout:\n%s' % (stdout,))
+            if 'Done sleeping' not in stdout:
+                raise AssertionError('Expected "Done sleeping" to be in stdout:\n%s' % (stdout,))
+            if 'native Qt signal is not callable' in stderr:
+                raise AssertionError('Did not expect "native Qt signal is not callable" to be in stderr:\n%s' % (stderr,))
 
-        hit = self.wait_for_breakpoint_hit('107')
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        line = hit.line
+        breakpoint_id = writer.write_add_breakpoint(28, 'on_start')  # breakpoint on print('On start called2').
+        writer.write_make_initial_run()
 
-        # goes to line 4 in jython (function declaration line)
-        assert line in (4, 5), 'Expecting it to go to line 4 or 5. Went to: %s' % line
+        hit = writer.wait_for_breakpoint_hit()
 
-        self.write_run_thread(thread_id)
+        writer.write_remove_breakpoint(breakpoint_id)
+        writer.write_run_thread(hit.thread_id)
 
-        assert 13 == self._sequence, 'Expected 15. Had: %s' % self._sequence
+        writer.log.append('Checking sequence. Found: %s' % (writer._sequence))
+        assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
 
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCase5
-#=======================================================================================================================
-class WriterThreadCase5(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case56.py')
-
-    def run(self):
-        self.start_socket()
-        breakpoint_id = self.write_add_breakpoint(2, 'Call2')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-
-        self.write_get_frame(thread_id, frame_id)
-
-        self.write_remove_breakpoint(breakpoint_id)
-
-        self.write_step_return(thread_id)
-
-        hit = self.wait_for_breakpoint_hit('109')
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        line = hit.line
-
-        assert line == 8, 'Expecting it to go to line 8. Went to: %s' % line
-
-        self.write_step_in(thread_id)
-
-        hit = self.wait_for_breakpoint_hit('107')
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        line = hit.line
-
-        # goes to line 4 in jython (function declaration line)
-        assert line in (4, 5), 'Expecting it to go to line 4 or 5. Went to: %s' % line
-
-        self.write_run_thread(thread_id)
-
-        assert 15 == self._sequence, 'Expected 15. Had: %s' % self._sequence
-
-        self.finished_ok = True
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
 
 
-#=======================================================================================================================
-# WriterThreadCase4
-#=======================================================================================================================
-class WriterThreadCase4(debugger_unittest.AbstractWriterThread):
+def test_m_switch(case_setup_m_switch):
+    with case_setup_m_switch.test_file() as writer:
+        writer.log.append('writing add breakpoint')
+        breakpoint_id = writer.write_add_breakpoint(1, None)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case4.py')
+        writer.log.append('making initial run')
+        writer.write_make_initial_run()
 
-    def run(self):
-        self.start_socket()
-        self.write_make_initial_run()
+        writer.log.append('waiting for breakpoint hit')
+        hit = writer.wait_for_breakpoint_hit()
 
-        thread_id = self.wait_for_new_thread()
+        writer.write_remove_breakpoint(breakpoint_id)
 
-        self.write_suspend_thread(thread_id)
+        writer.log.append('run thread')
+        writer.write_run_thread(hit.thread_id)
 
-        hit = self.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
-        assert hit.thread_id == thread_id
+        writer.log.append('asserting')
+        try:
+            assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
+        except:
+            writer.log.append('assert failed!')
+            raise
+        writer.log.append('asserted')
 
-        self.write_run_thread(thread_id)
-
-        self.finished_ok = True
+        writer.finished_ok = True
 
 
-#=======================================================================================================================
-# WriterThreadCase3
-#=======================================================================================================================
-class WriterThreadCase3(debugger_unittest.AbstractWriterThread):
+def test_module_entry_point(case_setup_m_switch_entry_point):
+    with case_setup_m_switch_entry_point.test_file() as writer:
+        writer.log.append('writing add breakpoint')
+        breakpoint_id = writer.write_add_breakpoint(1, None)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case3.py')
+        writer.log.append('making initial run')
+        writer.write_make_initial_run()
 
-    def run(self):
-        self.start_socket()
-        self.write_make_initial_run()
-        time.sleep(.5)
-        breakpoint_id = self.write_add_breakpoint(4, '')
-        self.write_add_breakpoint(5, 'FuncNotAvailable')  # Check that it doesn't get hit in the global when a function is available
+        writer.log.append('waiting for breakpoint hit')
+        hit = writer.wait_for_breakpoint_hit()
 
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
+        writer.write_remove_breakpoint(breakpoint_id)
 
-        self.write_get_frame(thread_id, frame_id)
+        writer.log.append('run thread')
+        writer.write_run_thread(hit.thread_id)
 
-        self.write_run_thread(thread_id)
+        writer.log.append('asserting')
+        try:
+            assert 9 == writer._sequence, 'Expected 9. Had: %s' % writer._sequence
+        except:
+            writer.log.append('assert failed!')
+            raise
+        writer.log.append('asserted')
 
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
+        writer.finished_ok = True
 
-        self.write_get_frame(thread_id, frame_id)
 
-        self.write_remove_breakpoint(breakpoint_id)
+@pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
+def test_unhandled_exceptions_basic(case_setup):
 
-        self.write_run_thread(thread_id)
-
-        assert 17 == self._sequence, 'Expected 17. Had: %s' % self._sequence
-
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseUnhandledExceptionsBasic
-#=======================================================================================================================
-class WriterThreadCaseUnhandledExceptionsBasic(debugger_unittest.AbstractWriterThread):
-
-    # Note: expecting unhandled exceptions to be printed to stdout.
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_unhandled_exceptions.py')
-
-    @overrides(debugger_unittest.AbstractWriterThread.check_test_suceeded_msg)
-    def check_test_suceeded_msg(self, stdout, stderr):
+    def check_test_suceeded_msg(writer, stdout, stderr):
+        # Don't call super (we have an unhandled exception in the stack trace).
         return 'TEST SUCEEDED' in ''.join(stdout) and 'TEST SUCEEDED' in ''.join(stderr)
 
-    @overrides(debugger_unittest.AbstractWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
+    def additional_output_checks(writer, stdout, stderr):
         if 'raise Exception' not in stderr:
             raise AssertionError('Expected test to have an unhandled exception.\nstdout:\n%s\n\nstderr:\n%s' % (
                 stdout, stderr))
-        # Don't call super (we have an unhandled exception in the stack trace).
-        
-    def run(self):
-        self.start_socket()
-        self.write_add_exception_breakpoint_with_policy('Exception', "0", "1", "0")
-        self.write_make_initial_run()
-        
-        def check(hit, exc_type, exc_desc):        
-            self.write_get_current_exception(hit.thread_id)
-            msg = self.wait_for_message(accept_message=lambda msg:exc_type in msg and 'exc_type="' in msg and 'exc_desc="' in msg, unquote_msg=False)
+
+    with case_setup.test_file(
+            '_debugger_case_unhandled_exceptions.py',
+            check_test_suceeded_msg=check_test_suceeded_msg,
+            additional_output_checks=additional_output_checks,
+        ) as writer:
+
+        writer.write_add_exception_breakpoint_with_policy('Exception', "0", "1", "0")
+        writer.write_make_initial_run()
+
+        def check(hit, exc_type, exc_desc):
+            writer.write_get_current_exception(hit.thread_id)
+            msg = writer.wait_for_message(accept_message=lambda msg:exc_type in msg and 'exc_type="' in msg and 'exc_desc="' in msg, unquote_msg=False)
             assert unquote(msg.thread['exc_desc']) == exc_desc
             assert unquote(msg.thread['exc_type']) in (
-                "&lt;type 'exceptions.%s'&gt;" % (exc_type,),  # py2 
+                "&lt;type 'exceptions.%s'&gt;" % (exc_type,),  # py2
                 "&lt;class '%s'&gt;" % (exc_type,)  # py3
             )
             if len(msg.thread.frame) == 0:
                 assert unquote(unquote(msg.thread.frame['file'])).endswith('_debugger_case_unhandled_exceptions.py')
             else:
                 assert unquote(unquote(msg.thread.frame[0]['file'])).endswith('_debugger_case_unhandled_exceptions.py')
-            self.write_run_thread(hit.thread_id)
+            writer.write_run_thread(hit.thread_id)
 
         # Will stop in 2 background threads
-        hit0 = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        hit0 = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
         thread_id1 = hit0.thread_id
-        
-        hit1 = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+
+        hit1 = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
         thread_id2 = hit1.thread_id
-        
+
         if hit0.name == 'thread_func2':
             check(hit0, 'ValueError', 'in thread 2')
             check(hit1, 'Exception', 'in thread 1')
@@ -985,944 +987,505 @@ class WriterThreadCaseUnhandledExceptionsBasic(debugger_unittest.AbstractWriterT
             check(hit0, 'Exception', 'in thread 1')
             check(hit1, 'ValueError', 'in thread 2')
 
-        self.write_run_thread(thread_id1)
-        self.write_run_thread(thread_id2)
+        writer.write_run_thread(thread_id1)
+        writer.write_run_thread(thread_id2)
 
         # Will stop in main thread
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        hit = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
         assert hit.name == '<module>'
         thread_id3 = hit.thread_id
 
         # Requesting the stack in an unhandled exception should provide the stack of the exception,
-        # not the current location of the program.        
-        self.write_get_thread_stack(thread_id3)
-        msg = self.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_GET_THREAD_STACK,)))
-        assert len(msg.thread.frame) == 0 # In main thread (must have no back frames).
+        # not the current location of the program.
+        writer.write_get_thread_stack(thread_id3)
+        msg = writer.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_GET_THREAD_STACK,)))
+        assert len(msg.thread.frame) == 0  # In main thread (must have no back frames).
         assert msg.thread.frame['name'] == '<module>'
         check(hit, 'IndexError', 'in main')
 
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterThreadCaseUnhandledExceptionsOnTopLevel
-#=======================================================================================================================
-class WriterThreadCaseUnhandledExceptionsOnTopLevel(debugger_unittest.AbstractWriterThread):
+
+@pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
+def test_unhandled_exceptions_in_top_level(case_setup):
 
     # Note: expecting unhandled exception to be printed to stderr.
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_unhandled_exceptions_on_top_level.py')
-
-    @overrides(debugger_unittest.AbstractWriterThread.check_test_suceeded_msg)
-    def check_test_suceeded_msg(self, stdout, stderr):
+    def check_test_suceeded_msg(writer, stdout, stderr):
         return 'TEST SUCEEDED' in ''.join(stderr)
-    
-    @overrides(debugger_unittest.AbstractWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
+
+    def additional_output_checks(writer, stdout, stderr):
         # Don't call super as we have an expected exception
         if 'ValueError: TEST SUCEEDED' not in stderr:
             raise AssertionError('"ValueError: TEST SUCEEDED" not in stderr.\nstdout:\n%s\n\nstderr:\n%s' % (
                 stdout, stderr))
 
-    def run(self):
-        self.start_socket()
-        self.write_add_exception_breakpoint_with_policy('Exception', "0", "1", "0")
-        self.write_make_initial_run()
+    with case_setup.test_file(
+            '_debugger_case_unhandled_exceptions_on_top_level.py',
+            additional_output_checks=additional_output_checks,
+            check_test_suceeded_msg=check_test_suceeded_msg,
+        ) as writer:
+
+        writer.write_add_exception_breakpoint_with_policy('Exception', "0", "1", "0")
+        writer.write_make_initial_run()
 
         # Will stop in main thread
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
 
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterThreadCaseUnhandledExceptionsOnTopLevel2
-#=======================================================================================================================
-class WriterThreadCaseUnhandledExceptionsOnTopLevel2(debugger_unittest.AbstractWriterThread):
 
+@pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
+def test_unhandled_exceptions_in_top_level2(case_setup):
     # Note: expecting unhandled exception to be printed to stderr.
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_unhandled_exceptions_on_top_level.py')
 
-    @overrides(debugger_unittest.AbstractWriterThread.check_test_suceeded_msg)
-    def check_test_suceeded_msg(self, stdout, stderr):
-        return 'TEST SUCEEDED' in ''.join(stderr)
-    
-    @overrides(debugger_unittest.AbstractWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
-        # Don't call super as we have an expected exception
-        if 'ValueError: TEST SUCEEDED' not in stderr:
-            raise AssertionError('"ValueError: TEST SUCEEDED" not in stderr.\nstdout:\n%s\n\nstderr:\n%s' % (
-                stdout, stderr))
-
-        
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
-    def get_environ(self):
+    def get_environ(writer):
         env = os.environ.copy()
         curr_pythonpath = env.get('PYTHONPATH', '')
 
-        pydevd_dirname = os.path.dirname(self.get_pydevd_file())
+        pydevd_dirname = os.path.dirname(writer.get_pydevd_file())
 
         curr_pythonpath = pydevd_dirname + os.pathsep + curr_pythonpath
         env['PYTHONPATH'] = curr_pythonpath
         return env
-        
-    def update_command_line_args(self, args):
+
+    def check_test_suceeded_msg(writer, stdout, stderr):
+        return 'TEST SUCEEDED' in ''.join(stderr)
+
+    def additional_output_checks(writer, stdout, stderr):
+        # Don't call super as we have an expected exception
+        if 'ValueError: TEST SUCEEDED' not in stderr:
+            raise AssertionError('"ValueError: TEST SUCEEDED" not in stderr.\nstdout:\n%s\n\nstderr:\n%s' % (
+                stdout, stderr))
+
+    def update_command_line_args(writer, args):
         # Start pydevd with '-m' to see how it deal with being called with
         # runpy at the start.
         assert args[0].endswith('pydevd.py')
         args = ['-m', 'pydevd'] + args[1:]
         return args
 
-    def run(self):
-        self.start_socket()
-        self.write_add_exception_breakpoint_with_policy('Exception', "0", "1", "0")
-        self.write_make_initial_run()
+    with case_setup.test_file(
+            '_debugger_case_unhandled_exceptions_on_top_level.py',
+            get_environ=get_environ,
+            additional_output_checks=additional_output_checks,
+            check_test_suceeded_msg=check_test_suceeded_msg,
+            update_command_line_args=update_command_line_args,
+            ) as writer:
+
+        writer.write_add_exception_breakpoint_with_policy('Exception', "0", "1", "0")
+        writer.write_make_initial_run()
 
         # Should stop (only once) in the main thread.
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
 
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
-        
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterThreadCaseUnhandledExceptionsOnTopLevel3
-#=======================================================================================================================
-class WriterThreadCaseUnhandledExceptionsOnTopLevel3(debugger_unittest.AbstractWriterThread):
 
-    # Note: expecting unhandled exception to be printed to stderr.
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_unhandled_exceptions_on_top_level.py')
+@pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
+def test_unhandled_exceptions_in_top_level3(case_setup):
 
-    @overrides(debugger_unittest.AbstractWriterThread.check_test_suceeded_msg)
-    def check_test_suceeded_msg(self, stdout, stderr):
+    def check_test_suceeded_msg(writer, stdout, stderr):
         return 'TEST SUCEEDED' in ''.join(stderr)
-    
-    @overrides(debugger_unittest.AbstractWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
+
+    def additional_output_checks(writer, stdout, stderr):
         # Don't call super as we have an expected exception
         if 'ValueError: TEST SUCEEDED' not in stderr:
             raise AssertionError('"ValueError: TEST SUCEEDED" not in stderr.\nstdout:\n%s\n\nstderr:\n%s' % (
                 stdout, stderr))
 
-    def run(self):
-        self.start_socket()
+    with case_setup.test_file(
+            '_debugger_case_unhandled_exceptions_on_top_level.py',
+            additional_output_checks=additional_output_checks,
+            check_test_suceeded_msg=check_test_suceeded_msg,
+        ) as writer:
+
         # Handled and unhandled
-        self.write_add_exception_breakpoint_with_policy('Exception', "1", "1", "0")
-        self.write_make_initial_run()
+        writer.write_add_exception_breakpoint_with_policy('Exception', "1", "1", "0")
+        writer.write_make_initial_run()
 
         # Will stop in main thread twice: once one we find that the exception is being
         # thrown and another in postmortem mode when we discover it's uncaught.
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
-        
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
 
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
-        
+        hit = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
 
-#=======================================================================================================================
-# WriterThreadCaseUnhandledExceptionsOnTopLevel4
-#=======================================================================================================================
-class WriterThreadCaseUnhandledExceptionsOnTopLevel4(debugger_unittest.AbstractWriterThread):
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
+def test_unhandled_exceptions_in_top_level4(case_setup):
+
+    def check_test_suceeded_msg(writer, stdout, stderr):
+        return 'TEST SUCEEDED' in ''.join(stderr)
+
+    def additional_output_checks(writer, stdout, stderr):
+        # Don't call super as we have an expected exception
+        assert 'ValueError: TEST SUCEEDED' in stderr
 
     # Note: expecting unhandled exception to be printed to stderr.
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_unhandled_exceptions_on_top_level2.py')
+    with case_setup.test_file(
+        '_debugger_case_unhandled_exceptions_on_top_level2.py',
+        additional_output_checks=additional_output_checks,
+        check_test_suceeded_msg=check_test_suceeded_msg,
+        ) as writer:
 
-    @overrides(debugger_unittest.AbstractWriterThread.check_test_suceeded_msg)
-    def check_test_suceeded_msg(self, stdout, stderr):
-        return 'TEST SUCEEDED' in ''.join(stderr)
-    
-    @overrides(debugger_unittest.AbstractWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
-        # Don't call super as we have an expected exception
-        assert 'ValueError: TEST SUCEEDED' in stderr
-
-    def run(self):
-        self.start_socket()
         # Handled and unhandled
-        self.write_add_exception_breakpoint_with_policy('Exception', "1", "1", "0")
-        self.write_make_initial_run()
+        writer.write_add_exception_breakpoint_with_policy('Exception', "1", "1", "0")
+        writer.write_make_initial_run()
 
-        # We have an exception thrown and handled and another which is thrown and is then unhandled. 
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
+        # We have an exception thrown and handled and another which is thrown and is then unhandled.
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
 
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
-        
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
 
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
-        
-        
-#=======================================================================================================================
-# WriterThreadCase2
-#=======================================================================================================================
-class WriterThreadCase2(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case2.py')
+        writer.log.append('Marking finished ok.')
+        writer.finished_ok = True
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(3, 'Call4')  # seq = 3
-        self.write_make_initial_run()
 
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
+@pytest.mark.skipif(not IS_CPYTHON or (IS_PY36 and not IS_WINDOWS), reason='Only for Python (failing on 3.6 on travis (linux) -- needs to be investigated).')
+def test_case_set_next_statement(case_setup):
+    with case_setup.test_file('_debugger_case_set_next_statement.py') as writer:
+        breakpoint_id = writer.write_add_breakpoint(6, None)
+        writer.write_make_initial_run()
 
-        self.write_get_frame(thread_id, frame_id)  # Note: write get frame but not waiting for it to be gotten.
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=6)
 
-        self.write_add_breakpoint(14, 'Call2')
+        writer.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'a')
+        writer.wait_for_evaluation('<var name="a" type="int" qualifier="{0}" value="int: 2"'.format(builtin_qualifier))
+        writer.write_set_next_statement(hit.thread_id, 2, 'method')
+        hit = writer.wait_for_breakpoint_hit('127', line=2)
 
-        self.write_run_thread(thread_id)
+        writer.write_step_over(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit('108')
 
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
+        writer.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'a')
+        writer.wait_for_evaluation('<var name="a" type="int" qualifier="{0}" value="int: 1"'.format(builtin_qualifier))
 
-        self.write_get_frame(thread_id, frame_id)  # Note: write get frame but not waiting for it to be gotten.
+        writer.write_remove_breakpoint(breakpoint_id)
+        writer.write_run_thread(hit.thread_id)
 
-        self.write_run_thread(thread_id)
+        writer.finished_ok = True
 
-        self.log.append('Checking sequence. Found: %s' % (self._sequence))
-        assert 15 == self._sequence, 'Expected 15. Had: %s' % self._sequence
 
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
+@pytest.mark.skipif(not IS_CPYTHON, reason='Only for Python.')
+def test_case_get_next_statement_targets(case_setup):
+    with case_setup.test_file('_debugger_case_get_next_statement_targets.py') as writer:
+        breakpoint_id = writer.write_add_breakpoint(21, None)
+        writer.write_make_initial_run()
 
-#=======================================================================================================================
-# WriterThreadCaseQThread1
-#=======================================================================================================================
-class WriterThreadCaseQThread1(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT, line=21)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_qthread1.py')
+        writer.write_get_next_statement_targets(hit.thread_id, hit.frame_id)
+        targets = writer.wait_for_get_next_statement_targets()
+        expected = set((2, 3, 5, 8, 9, 10, 12, 13, 14, 15, 17, 18, 19, 21))
+        assert targets == expected, 'Expected targets to be %s, was: %s' % (expected, targets)
 
-    def run(self):
-        self.start_socket()
-        breakpoint_id = self.write_add_breakpoint(19, 'run')
-        self.write_make_initial_run()
+        writer.write_remove_breakpoint(breakpoint_id)
+        writer.write_run_thread(hit.thread_id)
 
-        hit = self.wait_for_breakpoint_hit()
+        writer.finished_ok = True
 
-        self.write_remove_breakpoint(breakpoint_id)
-        self.write_run_thread(hit.thread_id)
 
-        self.log.append('Checking sequence. Found: %s' % (self._sequence))
-        assert 9 == self._sequence, 'Expected 9. Had: %s' % self._sequence
+@pytest.mark.skipif(IS_IRONPYTHON or IS_JYTHON, reason='Failing on IronPython and Jython (needs to be investigated).')
+def test_case_type_ext(case_setup):
+    # Custom type presentation extensions
 
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseQThread2
-#=======================================================================================================================
-class WriterThreadCaseQThread2(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_qthread2.py')
-
-    def run(self):
-        self.start_socket()
-        breakpoint_id = self.write_add_breakpoint(24, 'long_running')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-
-        self.write_remove_breakpoint(breakpoint_id)
-        self.write_run_thread(thread_id)
-
-        self.log.append('Checking sequence. Found: %s' % (self._sequence))
-        assert 9 == self._sequence, 'Expected 9. Had: %s' % self._sequence
-
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseQThread3
-#=======================================================================================================================
-class WriterThreadCaseQThread3(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_qthread3.py')
-
-    def run(self):
-        self.start_socket()
-        breakpoint_id = self.write_add_breakpoint(22, 'run')
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-
-        self.write_remove_breakpoint(breakpoint_id)
-        self.write_run_thread(thread_id)
-
-        self.log.append('Checking sequence. Found: %s' % (self._sequence))
-        assert 9 == self._sequence, 'Expected 9. Had: %s' % self._sequence
-
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseQThread4
-#=======================================================================================================================
-class WriterThreadCaseQThread4(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_qthread4.py')
-
-    def run(self):
-        self.start_socket()
-        breakpoint_id = self.write_add_breakpoint(28, 'on_start') # breakpoint on print('On start called2').
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit()
-
-        self.write_remove_breakpoint(breakpoint_id)
-        self.write_run_thread(hit.thread_id)
-
-        self.log.append('Checking sequence. Found: %s' % (self._sequence))
-        assert 9 == self._sequence, 'Expected 9. Had: %s' % self._sequence
-
-        self.log.append('Marking finished ok.')
-        self.finished_ok = True
-
-    @overrides(debugger_unittest.AbstractWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
-        debugger_unittest.AbstractWriterThread.additional_output_checks(self, stdout, stderr)
-        if 'On start called' not in stdout:
-            raise AssertionError('Expected "On start called" to be in stdout:\n%s' % (stdout,))
-        if 'Done sleeping' not in stdout:
-            raise AssertionError('Expected "Done sleeping" to be in stdout:\n%s' % (stdout,))
-        if 'native Qt signal is not callable' in stderr:
-            raise AssertionError('Did not expect "native Qt signal is not callable" to be in stderr:\n%s' % (stderr,))
-
-#=======================================================================================================================
-# WriterThreadCase1
-#=======================================================================================================================
-class WriterThreadCase1(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case1.py')
-
-    def run(self):
-        self.start_socket()
-
-        self.log.append('writing add breakpoint')
-        self.write_add_breakpoint(6, 'set_up')
-
-        self.log.append('making initial run')
-        self.write_make_initial_run()
-
-        self.log.append('waiting for breakpoint hit')
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-
-        self.log.append('get frame')
-        self.write_get_frame(thread_id, frame_id)
-
-        self.log.append('step over')
-        self.write_step_over(thread_id)
-
-        self.log.append('get frame')
-        self.write_get_frame(thread_id, frame_id)
-
-        self.log.append('run thread')
-        self.write_run_thread(thread_id)
-
-        self.log.append('asserting')
-        try:
-            assert 13 == self._sequence, 'Expected 13. Had: %s' % self._sequence
-        except:
-            self.log.append('assert failed!')
-            raise
-        self.log.append('asserted')
-
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseMSwitch
-#=======================================================================================================================
-class WriterThreadCaseMSwitch(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = 'tests_python.resources._debugger_case_m_switch'
-    IS_MODULE = True
-
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
     def get_environ(self):
         env = os.environ.copy()
-        curr_pythonpath = env.get('PYTHONPATH', '')
 
-        root_dirname = os.path.dirname(os.path.dirname(__file__))
-
-        curr_pythonpath += root_dirname + os.pathsep
-        env['PYTHONPATH'] = curr_pythonpath
+        python_path = env.get("PYTHONPATH", "")
+        ext_base = debugger_unittest._get_debugger_test_file('my_extensions')
+        env['PYTHONPATH'] = ext_base + os.pathsep + python_path  if python_path else ext_base
         return env
 
-    @overrides(debugger_unittest.AbstractWriterThread.get_main_filename)
-    def get_main_filename(self):
-        return debugger_unittest._get_debugger_test_file('_debugger_case_m_switch.py')
+    with case_setup.test_file('_debugger_case_type_ext.py', get_environ=get_environ) as writer:
+        writer.get_environ = get_environ
 
-    def run(self):
-        self.start_socket()
+        writer.write_add_breakpoint(7, None)
+        writer.write_make_initial_run()
 
-        self.log.append('writing add breakpoint')
-        breakpoint_id = self.write_add_breakpoint(1, None)
-
-        self.log.append('making initial run')
-        self.write_make_initial_run()
-
-        self.log.append('waiting for breakpoint hit')
-        hit = self.wait_for_breakpoint_hit()
-
-        self.write_remove_breakpoint(breakpoint_id)
-
-        self.log.append('run thread')
-        self.write_run_thread(hit.thread_id)
-
-        self.log.append('asserting')
-        try:
-            assert 9 == self._sequence, 'Expected 9. Had: %s' % self._sequence
-        except:
-            self.log.append('assert failed!')
-            raise
-        self.log.append('asserted')
-
-        self.finished_ok = True
-
-
-# =======================================================================================================================
-# WriterThreadCaseModuleWithEntryPoint
-# =======================================================================================================================
-class WriterThreadCaseModuleWithEntryPoint(WriterThreadCaseMSwitch):
-    
-    TEST_FILE = 'tests_python.resources._debugger_case_module_entry_point:main'
-    IS_MODULE = True
-
-    @overrides(WriterThreadCaseMSwitch.get_main_filename)
-    def get_main_filename(self):
-        return debugger_unittest._get_debugger_test_file('_debugger_case_module_entry_point.py')
-
-#=======================================================================================================================
-# AbstractRemoteWriterThread
-#=======================================================================================================================
-class AbstractRemoteWriterThread(debugger_unittest.AbstractWriterThread):
-
-    def update_command_line_args(self, args):
-        ret = debugger_unittest.AbstractWriterThread.update_command_line_args(self, args)
-        ret.append(str(self.port))
-        return ret
-    
-#=======================================================================================================================
-# WriterThreadCaseRemoteDebugger
-#=======================================================================================================================
-class WriterThreadCaseRemoteDebugger(AbstractRemoteWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_remote.py')
-
-    def run(self):
-        self.start_socket()
-
-        self.log.append('making initial run')
-        self.write_make_initial_run()
-
-        self.log.append('waiting for breakpoint hit')
-        hit = self.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
-
-        self.log.append('run thread')
-        self.write_run_thread(hit.thread_id)
-
-        self.log.append('asserting')
-        try:
-            assert 5 == self._sequence, 'Expected 5. Had: %s' % self._sequence
-        except:
-            self.log.append('assert failed!')
-            raise
-        self.log.append('asserted')
-
-        self.finished_ok = True
-        
-#=======================================================================================================================
-# WriterThreadCaseRemoteDebuggerUnhandledExceptions
-#=======================================================================================================================
-class WriterThreadCaseRemoteDebuggerUnhandledExceptions(AbstractRemoteWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_remote_unhandled_exceptions.py')
-    
-    @overrides(AbstractRemoteWriterThread.check_test_suceeded_msg)
-    def check_test_suceeded_msg(self, stdout, stderr):
-        return 'TEST SUCEEDED' in ''.join(stderr)
-    
-    @overrides(AbstractRemoteWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
-        # Don't call super as we have an expected exception
-        assert 'ValueError: TEST SUCEEDED' in stderr
-
-    def run(self):
-        self.start_socket()  # Wait for it to connect back at this port.
-
-        self.log.append('making initial run')
-        self.write_make_initial_run()
-
-        self.log.append('waiting for breakpoint hit')
-        hit = self.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
-        
-        self.write_add_exception_breakpoint_with_policy('Exception', '0', '1', '0')
-
-        self.log.append('run thread')
-        self.write_run_thread(hit.thread_id)
-        
-        self.log.append('waiting for uncaught exception')
-        hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-        self.write_run_thread(hit.thread_id)
-
-        self.log.append('finished ok')
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseRemoteDebuggerUnhandledExceptions2
-#=======================================================================================================================
-class WriterThreadCaseRemoteDebuggerUnhandledExceptions2(AbstractRemoteWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_remote_unhandled_exceptions2.py')
-    
-    @overrides(AbstractRemoteWriterThread.check_test_suceeded_msg)
-    def check_test_suceeded_msg(self, stdout, stderr):
-        return 'TEST SUCEEDED' in ''.join(stderr)
-    
-    @overrides(AbstractRemoteWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
-        # Don't call super as we have an expected exception
-        assert 'ValueError: TEST SUCEEDED' in stderr
-
-    def run(self):
-        self.start_socket()  # Wait for it to connect back at this port.
-
-        self.log.append('making initial run')
-        self.write_make_initial_run()
-
-        self.log.append('waiting for breakpoint hit')
-        hit = self.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
-        
-        self.write_add_exception_breakpoint_with_policy('ValueError', '0', '1', '0')
-
-        self.log.append('run thread')
-        self.write_run_thread(hit.thread_id)
-        
-        self.log.append('waiting for uncaught exception')
-        for _ in range(3):
-            # Note: this isn't ideal, but in the remote attach case, if the
-            # exception is raised at the topmost frame, we consider the exception to
-            # be an uncaught exception even if it'll be handled at that point.
-            # See: https://github.com/Microsoft/ptvsd/issues/580
-            # To properly fix this, we'll need to identify that this exception
-            # will be handled later on with the information we have at hand (so,
-            # no back frame but within a try..except block).
-            hit = self.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
-            self.write_run_thread(hit.thread_id)
-
-        self.log.append('finished ok')
-        self.finished_ok = True
-
-#=======================================================================================================================
-# _SecondaryMultiProcProcessWriterThread
-#=======================================================================================================================
-class _SecondaryMultiProcProcessWriterThread(debugger_unittest.AbstractWriterThread):
-
-    FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
-
-    def __init__(self, server_socket):
-        debugger_unittest.AbstractWriterThread.__init__(self)
-        self.server_socket = server_socket
-
-    def run(self):
-        print('waiting for second process')
-        self.sock, addr = self.server_socket.accept()
-        print('accepted second process')
-
-        from tests_python.debugger_unittest import ReaderThread
-        self.reader_thread = ReaderThread(self.sock)
-        self.reader_thread.start()
-
-        self._sequence = -1
-        # initial command is always the version
-        self.write_version()
-        self.log.append('start_socket')
-        self.write_make_initial_run()
-        time.sleep(.5)
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseRemoteDebuggerMultiProc
-#=======================================================================================================================
-class WriterThreadCaseRemoteDebuggerMultiProc(AbstractRemoteWriterThread):
-
-    # It seems sometimes it becomes flaky on the ci because the process outlives the writer thread...
-    # As we're only interested in knowing if a second connection was received, just kill the related
-    # process.
-    FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_remote_1.py')
-
-    def run(self):
-        self.start_socket()
-
-        self.log.append('making initial run')
-        self.write_make_initial_run()
-
-        self.log.append('waiting for breakpoint hit')
-        hit = self.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
-
-        self.secondary_multi_proc_process_writer_thread  = secondary_multi_proc_process_writer_thread = \
-            _SecondaryMultiProcProcessWriterThread(self.server_socket)
-        secondary_multi_proc_process_writer_thread.start()
-
-        self.log.append('run thread')
-        self.write_run_thread(hit.thread_id)
-
-        for _i in xrange(400):
-            if secondary_multi_proc_process_writer_thread.finished_ok:
-                break
-            time.sleep(.1)
-        else:
-            self.log.append('Secondary process not finished ok!')
-            raise AssertionError('Secondary process not finished ok!')
-
-        self.log.append('Secondary process finished!')
-        try:
-            assert 5 == self._sequence, 'Expected 5. Had: %s' % self._sequence
-        except:
-            self.log.append('assert failed!')
-            raise
-        self.log.append('asserted')
-
-        self.finished_ok = True
-
-    def do_kill(self):
-        debugger_unittest.AbstractWriterThread.do_kill(self)
-        if hasattr(self, 'secondary_multi_proc_process_writer_thread'):
-            self.secondary_multi_proc_process_writer_thread.do_kill()
-
-#=======================================================================================================================
-# WriterThreadCaseTypeExt - [Test Case]: Custom type presentation extensions
-#======================================================================================================================
-class WriterThreadCaseTypeExt(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_type_ext.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(7, None)
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111')
-        self.write_get_frame(hit.thread_id, hit.frame_id)
-        assert self.wait_for_var([
+        hit = writer.wait_for_breakpoint_hit('111')
+        writer.write_get_frame(hit.thread_id, hit.frame_id)
+        assert writer.wait_for_var([
             [
                 r'<var name="my_rect" type="Rect" qualifier="__main__" value="Rectangle%255BLength%253A 5%252C Width%253A 10 %252C Area%253A 50%255D" isContainer="True" />',
                 r'<var name="my_rect" type="Rect"  value="Rect: <__main__.Rect object at',  # Jython
             ]
         ])
-        self.write_get_variable(hit.thread_id, hit.frame_id, 'my_rect')
-        assert self.wait_for_var(r'<var name="area" type="int" qualifier="{0}" value="int%253A 50" />'.format(builtin_qualifier))
-        self.write_run_thread(hit.thread_id)
-        self.finished_ok = True
+        writer.write_get_variable(hit.thread_id, hit.frame_id, 'my_rect')
+        assert writer.wait_for_var(r'<var name="area" type="int" qualifier="{0}" value="int%253A 50" />'.format(builtin_qualifier))
+        writer.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
 
 
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
+@pytest.mark.skipif(IS_IRONPYTHON or IS_JYTHON, reason='Failing on IronPython and Jython (needs to be investigated).')
+def test_case_event_ext(case_setup):
+
     def get_environ(self):
         env = os.environ.copy()
 
-        python_path = env.get("PYTHONPATH","")
+        python_path = env.get("PYTHONPATH", "")
         ext_base = debugger_unittest._get_debugger_test_file('my_extensions')
-        env['PYTHONPATH']= ext_base + os.pathsep + python_path  if python_path else ext_base
-        return env
-
-#=======================================================================================================================
-# WriterThreadCaseEventExt - [Test Case]: Test initialize event for extensions
-#======================================================================================================================
-class WriterThreadCaseEventExt(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_event_ext.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_make_initial_run()
-        self.finished_ok = True
-
-    @overrides(debugger_unittest.AbstractWriterThread.additional_output_checks)
-    def additional_output_checks(self, stdout, stderr):
-        debugger_unittest.AbstractWriterThread.additional_output_checks(self, stdout, stderr)
-        if 'INITIALIZE EVENT RECEIVED' not in stdout:
-            raise AssertionError('No initialize event received')
-
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
-    def get_environ(self):
-        env = os.environ.copy()
-
-        python_path = env.get("PYTHONPATH","")
-        ext_base = debugger_unittest._get_debugger_test_file('my_extensions')
-        env['PYTHONPATH']= ext_base + os.pathsep + python_path  if python_path else ext_base
+        env['PYTHONPATH'] = ext_base + os.pathsep + python_path  if python_path else ext_base
         env["VERIFY_EVENT_TEST"] = "1"
         return env
 
-#=======================================================================================================================
-# WriterThreadCaseThreadCreationDeadlock - check case where there was a deadlock evaluating expressions
-#======================================================================================================================
-class WriterThreadCaseThreadCreationDeadlock(debugger_unittest.AbstractWriterThread):
+    # Test initialize event for extensions
+    with case_setup.test_file('_debugger_case_event_ext.py', get_environ=get_environ) as writer:
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_thread_creation_deadlock.py')
+        original_additional_output_checks = writer.additional_output_checks
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(26, None)
-        self.write_make_initial_run()
+        @overrides(writer.additional_output_checks)
+        def additional_output_checks(stdout, stderr):
+            original_additional_output_checks(stdout, stderr)
+            if 'INITIALIZE EVENT RECEIVED' not in stdout:
+                raise AssertionError('No initialize event received')
 
-        hit = self.wait_for_breakpoint_hit('111')
+        writer.additional_output_checks = additional_output_checks
+
+        writer.write_make_initial_run()
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(IS_JYTHON, reason='Jython does not seem to be creating thread started inside tracing (investigate).')
+def test_case_writer_creation_deadlock(case_setup):
+    # check case where there was a deadlock evaluating expressions
+    with case_setup.test_file('_debugger_case_thread_creation_deadlock.py') as writer:
+        writer.write_add_breakpoint(26, None)
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit('111')
 
         assert hit.line == 26, 'Expected return to be in line 26, was: %s' % (hit.line,)
 
-        self.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'create_thread()')
-        self.wait_for_evaluation('<var name="create_thread()" type="str" qualifier="{0}" value="str: create_thread:ok'.format(builtin_qualifier))
-        self.write_run_thread(hit.thread_id)
+        writer.write_evaluate_expression('%s\t%s\t%s' % (hit.thread_id, hit.frame_id, 'LOCAL'), 'create_thread()')
+        writer.wait_for_evaluation('<var name="create_thread()" type="str" qualifier="{0}" value="str: create_thread:ok'.format(builtin_qualifier))
+        writer.write_run_thread(hit.thread_id)
+
+        writer.finished_ok = True
 
 
-        self.finished_ok = True
+def test_case_skip_breakpoints_in_exceptions(case_setup):
+    # Case where breakpoint is skipped after an exception is raised over it
+    with case_setup.test_file('_debugger_case_skip_breakpoint_in_exceptions.py') as writer:
+        writer.write_add_breakpoint(5, None)
+        writer.write_make_initial_run()
 
-#=======================================================================================================================
-# WriterThreadCaseSkipBreakpointInExceptions - fix case where breakpoint is skipped after an exception is raised over it 
-#======================================================================================================================
-class WriterThreadCaseSkipBreakpointInExceptions(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit('111', line=5)
+        writer.write_run_thread(hit.thread_id)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_skip_breakpoint_in_exceptions.py')
+        hit = writer.wait_for_breakpoint_hit('111', line=5)
+        writer.write_run_thread(hit.thread_id)
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(5, None)
-        self.write_make_initial_run()
-
-        hit = self.wait_for_breakpoint_hit('111', line=5)
-        self.write_run_thread(hit.thread_id)
-
-        hit = self.wait_for_breakpoint_hit('111', line=5)
-        self.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
 
 
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterThreadCaseHandledExceptions0 - Stop only once per handled exception.
-#======================================================================================================================
-class WriterThreadCaseHandledExceptions0(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_exceptions.py')
-
-    def run(self):
-        self.start_socket()
-        self.write_set_project_roots([os.path.dirname(self.TEST_FILE)])
-        self.write_add_exception_breakpoint_with_policy(
+def test_case_handled_exceptions0(case_setup):
+    # Stop only once per handled exception.
+    with case_setup.test_file('_debugger_case_exceptions.py') as writer:
+        writer.write_set_project_roots([os.path.dirname(writer.TEST_FILE)])
+        writer.write_add_exception_breakpoint_with_policy(
             'IndexError',
             notify_on_handled_exceptions=2,  # Notify only once
             notify_on_unhandled_exceptions=0,
             ignore_libraries=1
         )
-        self.write_make_initial_run()
+        writer.write_make_initial_run()
 
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=3)
-        self.write_run_thread(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=3)
+        writer.write_run_thread(hit.thread_id)
 
-        self.finished_ok = True
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterThreadCaseHandledExceptions1 - Stop multiple times for the same handled exception.
-#======================================================================================================================
-class WriterThreadCaseHandledExceptions1(debugger_unittest.AbstractWriterThread):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_exceptions.py')
+@pytest.mark.skipif(IS_JYTHON, reason='Not working on Jython (needs to be investigated).')
+def test_case_handled_exceptions1(case_setup):
 
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
+    # Stop multiple times for the same handled exception.
     def get_environ(self):
         env = os.environ.copy()
 
         env["IDE_PROJECT_ROOTS"] = os.path.dirname(self.TEST_FILE)
         return env
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_exception_breakpoint_with_policy(
+
+    with case_setup.test_file('_debugger_case_exceptions.py', get_environ=get_environ) as writer:
+        writer.write_add_exception_breakpoint_with_policy(
             'IndexError',
             notify_on_handled_exceptions=1,  # Notify multiple times
             notify_on_unhandled_exceptions=0,
             ignore_libraries=1
         )
-        self.write_make_initial_run()
-        
+        writer.write_make_initial_run()
+
         def check(hit):
-            self.write_get_frame(hit.thread_id, hit.frame_id)
-            self.wait_for_message(accept_message=lambda msg:'__exception__' in msg and 'IndexError' in msg, unquote_msg=False)
-            self.write_get_current_exception(hit.thread_id)
-            msg = self.wait_for_message(accept_message=lambda msg:'IndexError' in msg and 'exc_type="' in msg and 'exc_desc="' in msg, unquote_msg=False)
+            writer.write_get_frame(hit.thread_id, hit.frame_id)
+            writer.wait_for_message(accept_message=lambda msg:'__exception__' in msg and 'IndexError' in msg, unquote_msg=False)
+            writer.write_get_current_exception(hit.thread_id)
+            msg = writer.wait_for_message(accept_message=lambda msg:'IndexError' in msg and 'exc_type="' in msg and 'exc_desc="' in msg, unquote_msg=False)
             assert msg.thread['exc_desc'] == 'foo'
             assert unquote(msg.thread['exc_type']) in (
-                "&lt;type 'exceptions.IndexError'&gt;",  # py2 
+                "&lt;type 'exceptions.IndexError'&gt;",  # py2
                 "&lt;class 'IndexError'&gt;"  # py3
             )
 
             assert unquote(unquote(msg.thread.frame[0]['file'])).endswith('_debugger_case_exceptions.py')
-            self.write_run_thread(hit.thread_id)
+            writer.write_run_thread(hit.thread_id)
 
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=3)
-        check(hit)
-        
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=6)
-        check(hit)
-        
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=10)
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=3)
         check(hit)
 
-        self.finished_ok = True
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=6)
+        check(hit)
 
-#=======================================================================================================================
-# WriterThreadCaseHandledExceptions2 - no IDE_PROJECT_ROOTS set.
-#======================================================================================================================
-class WriterThreadCaseHandledExceptions2(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=10)
+        check(hit)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_exceptions.py')
+        writer.finished_ok = True
 
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
+
+def test_case_handled_exceptions2(case_setup):
+
+    # No IDE_PROJECT_ROOTS set.
     def get_environ(self):
         env = os.environ.copy()
 
         # Don't stop anywhere (note: having IDE_PROJECT_ROOTS = '' will consider
         # having anything not under site-packages as being in the project).
-        env["IDE_PROJECT_ROOTS"] = '["empty"]' 
+        env["IDE_PROJECT_ROOTS"] = '["empty"]'
         return env
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_exception_breakpoint_with_policy(
+
+    with case_setup.test_file('_debugger_case_exceptions.py', get_environ=get_environ) as writer:
+        writer.write_add_exception_breakpoint_with_policy(
             'IndexError',
             notify_on_handled_exceptions=1,  # Notify multiple times
             notify_on_unhandled_exceptions=0,
             ignore_libraries=1
         )
-        self.write_make_initial_run()
+        writer.write_make_initial_run()
 
-        self.finished_ok = True
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterThreadCaseHandledExceptions3 -- don't stop on exception thrown in the same context (only at caller).
-#======================================================================================================================
-class WriterThreadCaseHandledExceptions3(debugger_unittest.AbstractWriterThread):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_exceptions.py')
+def test_case_handled_exceptions3(case_setup):
 
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
+    # Don't stop on exception thrown in the same context (only at caller).
     def get_environ(self):
         env = os.environ.copy()
 
         env["IDE_PROJECT_ROOTS"] = os.path.dirname(self.TEST_FILE)
         return env
-    
-    def run(self):
-        self.start_socket()
+
+    with case_setup.test_file('_debugger_case_exceptions.py', get_environ=get_environ) as writer:
         # Note: in this mode we'll only stop once.
-        self.write_set_py_exception_globals(
+        writer.write_set_py_exception_globals(
             break_on_uncaught=False,
             break_on_caught=True,
             skip_on_exceptions_thrown_in_same_context=False,
             ignore_exceptions_thrown_in_lines_with_ignore_exception=True,
-            ignore_libraries=True, 
+            ignore_libraries=True,
             exceptions=('IndexError',)
         )
-            
-        self.write_make_initial_run()
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=3)
-        self.write_run_thread(hit.thread_id)
 
-        self.finished_ok = True
+        writer.write_make_initial_run()
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=3)
+        writer.write_run_thread(hit.thread_id)
+
+        writer.finished_ok = True
 
 
-#=======================================================================================================================
-# WriterThreadCaseHandledExceptions4 -- don't stop on exception thrown in the same context (only at caller).
-#======================================================================================================================
-class WriterThreadCaseHandledExceptions4(debugger_unittest.AbstractWriterThread):
+def test_case_handled_exceptions4(case_setup):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_exceptions.py')
-
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
+    # Don't stop on exception thrown in the same context (only at caller).
     def get_environ(self):
         env = os.environ.copy()
 
         env["IDE_PROJECT_ROOTS"] = os.path.dirname(self.TEST_FILE)
         return env
-    
-    def run(self):
-        self.start_socket()
+
+    with case_setup.test_file('_debugger_case_exceptions.py', get_environ=get_environ) as writer:
         # Note: in this mode we'll only stop once.
-        self.write_set_py_exception_globals(
+        writer.write_set_py_exception_globals(
             break_on_uncaught=False,
             break_on_caught=True,
             skip_on_exceptions_thrown_in_same_context=True,
             ignore_exceptions_thrown_in_lines_with_ignore_exception=True,
-            ignore_libraries=True, 
+            ignore_libraries=True,
             exceptions=('IndexError',)
         )
-            
-        self.write_make_initial_run()
-        hit = self.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=6)
-        self.write_run_thread(hit.thread_id)
 
-        self.finished_ok = True
+        writer.write_make_initial_run()
+        hit = writer.wait_for_breakpoint_hit(REASON_CAUGHT_EXCEPTION, line=6)
+        writer.write_run_thread(hit.thread_id)
 
-#=======================================================================================================================
-# WriterCaseSetTrace
-#======================================================================================================================
-class WriterCaseSetTrace(debugger_unittest.AbstractWriterThread):
+        writer.finished_ok = True
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_settrace.py')
 
-    def run(self):
-        self.start_socket()
-            
-        self.write_make_initial_run()
-        
-        hit = self.wait_for_breakpoint_hit('108', line=12)
-        self.write_run_thread(hit.thread_id)
-        
-        hit = self.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND, line=7)
-        self.write_run_thread(hit.thread_id)
+def test_case_settrace(case_setup):
+    with case_setup.test_file('_debugger_case_settrace.py') as writer:
+        writer.write_make_initial_run()
 
-        self.finished_ok = True
+        hit = writer.wait_for_breakpoint_hit('108', line=12)
+        writer.write_run_thread(hit.thread_id)
 
-#=======================================================================================================================
-# WriterThreadCaseRedirectOutput
-#======================================================================================================================
-class WriterThreadCaseRedirectOutput(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND, line=7)
+        writer.write_run_thread(hit.thread_id)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_redirect.py')
+        writer.finished_ok = True
 
-    def _ignore_stderr_line(self, line):
-        if debugger_unittest.AbstractWriterThread._ignore_stderr_line(self, line):
-            return True
-        return line.startswith((
-            'text',
-            'binary',
-            'a' 
-        ))
 
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
-    def get_environ(self):
+@pytest.mark.skipif(IS_PY26 or IS_JYTHON, reason='scapy only supports 2.7 onwards, not available for jython.')
+def test_case_scapy(case_setup):
+    with case_setup.test_file('_debugger_case_scapy.py') as writer:
+        writer.FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
+        writer.reader_thread.set_messages_timeout(30)  # Starting scapy may be slow (timed out with 15 seconds on appveyor).
+        writer.write_add_breakpoint(2, None)
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
+        thread_id = hit.thread_id
+        frame_id = hit.frame_id
+
+        writer.write_run_thread(thread_id)
+        writer.finished_ok = True
+
+
+@pytest.mark.skipif(IS_APPVEYOR or IS_JYTHON, reason='Flaky on appveyor / Jython encoding issues (needs investigation).')
+def test_redirect_output(case_setup):
+
+    def get_environ(writer):
         env = os.environ.copy()
 
         env["PYTHONIOENCODING"] = 'utf-8'
         return env
-    
-    def run(self):
+
+    with case_setup.test_file('_debugger_case_redirect.py', get_environ=get_environ) as writer:
+        original_ignore_stderr_line = writer._ignore_stderr_line
+
+        @overrides(writer._ignore_stderr_line)
+        def _ignore_stderr_line(line):
+            if original_ignore_stderr_line(line):
+                return True
+            return line.startswith((
+                'text',
+                'binary',
+                'a'
+            ))
+
+        writer._ignore_stderr_line = _ignore_stderr_line
+
         # Note: writes to stdout and stderr are now synchronous (so, the order
         # must always be consistent and there's a message for each write).
         expected = [
@@ -1930,329 +1493,221 @@ class WriterThreadCaseRedirectOutput(debugger_unittest.AbstractWriterThread):
             'binary or text\n',
             'ação1\n',
         ]
-        
+
         if sys.version_info[0] >= 3:
             expected.extend((
                 'binary\n',
                 'ação2\n'.encode(encoding='latin1').decode('utf-8', 'replace'),
                 'ação3\n',
             ))
-        
+
         new_expected = [(x, 'stdout') for x in expected]
         new_expected.extend([(x, 'stderr') for x in expected])
-        
-        
-        self.start_socket()
-        self.write_start_redirect()
-            
-        self.write_make_initial_run()
+
+        writer.write_start_redirect()
+
+        writer.write_make_initial_run()
         msgs = []
+        ignored = []
         while len(msgs) < len(new_expected):
-            msg = self.wait_for_output()
+            try:
+                msg = writer.wait_for_output()
+            except AssertionError:
+                for msg in msgs:
+                    sys.stderr.write('Found: %s\n' % (msg,))
+                for msg in new_expected:
+                    sys.stderr.write('Expected: %s\n' % (msg,))
+                for msg in ignored:
+                    sys.stderr.write('Ignored: %s\n' % (msg,))
+                raise
             if msg not in new_expected:
+                ignored.append(msg)
                 continue
             msgs.append(msg)
-        
+
         if msgs != new_expected:
             print(msgs)
             print(new_expected)
         assert msgs == new_expected
-        self.finished_ok = True
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterThreadCasePathTranslation
-#======================================================================================================================
-class WriterThreadCasePathTranslation(debugger_unittest.AbstractWriterThread):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file(
-        os.path.join('_debugger_case_path_translation.py'))
+def test_path_translation(case_setup):
 
-    def __get_file_in_client(self):
+    def get_file_in_client(writer):
         # Instead of using: test_python/_debugger_case_path_translation.py
         # we'll set the breakpoints at foo/_debugger_case_path_translation.py
-        file_in_client = os.path.dirname(os.path.dirname(self.TEST_FILE))
+        file_in_client = os.path.dirname(os.path.dirname(writer.TEST_FILE))
         return os.path.join(os.path.dirname(file_in_client), 'foo', '_debugger_case_path_translation.py')
-    
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
-    def get_environ(self):
+
+    def get_environ(writer):
         import json
         env = os.environ.copy()
 
         env["PYTHONIOENCODING"] = 'utf-8'
-        
+
+        assert writer.TEST_FILE.endswith('_debugger_case_path_translation.py')
         env["PATHS_FROM_ECLIPSE_TO_PYTHON"] = json.dumps([
             (
-                os.path.dirname(self.__get_file_in_client()),
-                os.path.dirname(self.TEST_FILE)
+                os.path.dirname(get_file_in_client(writer)),
+                os.path.dirname(writer.TEST_FILE)
             )
         ])
         return env
-    
-    def run(self):
+
+    with case_setup.test_file('_debugger_case_path_translation.py', get_environ=get_environ) as writer:
         from tests_python.debugger_unittest import CMD_LOAD_SOURCE
-        self.start_socket()
-        self.write_start_redirect()
-        
-        file_in_client = self.__get_file_in_client()
+        writer.write_start_redirect()
+
+        file_in_client = get_file_in_client(writer)
         assert 'tests_python' not in file_in_client
-        self.write_add_breakpoint(2, 'main', filename=file_in_client)
-        self.write_make_initial_run()
-        
-        xml = self.wait_for_message(lambda msg:'stop_reason="111"' in msg) 
+        writer.write_add_breakpoint(2, 'main', filename=file_in_client)
+        writer.write_make_initial_run()
+
+        xml = writer.wait_for_message(lambda msg:'stop_reason="111"' in msg)
         assert xml.thread.frame[0]['file'] == file_in_client
         thread_id = xml.thread['id']
-        
+
         # Request a file that exists
         files_to_match = [file_in_client]
         if IS_WINDOWS:
             files_to_match.append(file_in_client.upper())
         for f in files_to_match:
-            self.write_load_source(f)
-            self.wait_for_message(
+            writer.write_load_source(f)
+            writer.wait_for_message(
                 lambda msg:
                     '%s\t' % CMD_LOAD_SOURCE in msg and \
                     "def main():" in msg and \
                     "print('break here')" in msg and \
                     "print('TEST SUCEEDED!')" in msg
                 , expect_xml=False)
-        
+
         # Request a file that does not exist
-        self.write_load_source(file_in_client+'not_existent.py')
-        self.wait_for_message(
-            lambda msg:'901\t' in msg and ('FileNotFoundError' in msg or 'IOError' in msg), 
+        writer.write_load_source(file_in_client + 'not_existent.py')
+        writer.wait_for_message(
+            lambda msg:'901\t' in msg and ('FileNotFoundError' in msg or 'IOError' in msg),
             expect_xml=False)
-        
-        self.write_run_thread(thread_id)
 
-        self.finished_ok = True
+        writer.write_run_thread(thread_id)
+
+        writer.finished_ok = True
 
 
-#=======================================================================================================================
-# WriterThreadCaseScapy
-#=======================================================================================================================
-class WriterThreadCaseScapy(debugger_unittest.AbstractWriterThread):
+def test_evaluate_errors(case_setup):
+    with case_setup.test_file('_debugger_case7.py') as writer:
+        writer.write_add_breakpoint(4, 'Call')
+        writer.write_make_initial_run()
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_scapy.py')
-    
-    def run(self):
-        self.start_socket()
-        self.reader_thread.set_timeout(30)  # Starting scapy may be slow (timed out with 15 seconds on appveyor).
-        self.write_add_breakpoint(2, None)
-        self.write_make_initial_run()
-        
-        hit = self.wait_for_breakpoint_hit()
+        hit = writer.wait_for_breakpoint_hit()
         thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        
-        self.write_run_thread(thread_id)
-        self.finished_ok = True
+        frame_id = hit.frame_id
 
-#=======================================================================================================================
-# WriterThreadCaseEvaluateErrors
-#=======================================================================================================================
-class WriterThreadCaseEvaluateErrors(debugger_unittest.AbstractWriterThread):
+        writer.write_evaluate_expression('%s\t%s\t%s' % (thread_id, frame_id, 'LOCAL'), 'name_error')
+        writer.wait_for_evaluation('<var name="name_error" type="NameError"')
+        writer.write_run_thread(thread_id)
+        writer.finished_ok = True
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case7.py')
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(4, 'Call')
-        self.write_make_initial_run()
-        
-        hit = self.wait_for_breakpoint_hit()
+
+def test_list_threads(case_setup):
+    with case_setup.test_file('_debugger_case7.py') as writer:
+        writer.write_add_breakpoint(4, 'Call')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
         thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        
-        self.write_evaluate_expression('%s\t%s\t%s' % (thread_id, frame_id, 'LOCAL'), 'name_error')
-        self.wait_for_evaluation('<var name="name_error" type="NameError"')
-        self.write_run_thread(thread_id)
-        self.finished_ok = True
+        frame_id = hit.frame_id
 
-#=======================================================================================================================
-# WriterThreadCaseListThreads
-#======================================================================================================================
-class WriterThreadCaseListThreads(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case7.py')
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(4, 'Call')
-        self.write_make_initial_run()
-        
-        hit = self.wait_for_breakpoint_hit()
-        thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        
-        seq = self.write_list_threads()
-        msg = self.wait_for_list_threads(seq)
+        seq = writer.write_list_threads()
+        msg = writer.wait_for_list_threads(seq)
         assert msg.thread['name'] == 'MainThread'
         assert msg.thread['id'].startswith('pid')
-        self.write_run_thread(thread_id)
-        self.finished_ok = True
+        writer.write_run_thread(thread_id)
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterCasePrint
-#======================================================================================================================
-class WriterCasePrint(debugger_unittest.AbstractWriterThread):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_print.py')
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(1, 'None')
-        self.write_make_initial_run()
-        
-        hit = self.wait_for_breakpoint_hit()
+def test_case_print(case_setup):
+    with case_setup.test_file('_debugger_case_print.py') as writer:
+        writer.write_add_breakpoint(1, 'None')
+        writer.write_make_initial_run()
+
+        hit = writer.wait_for_breakpoint_hit()
         thread_id = hit.thread_id
-        frame_id = hit.frame_id 
-        
-        self.write_run_thread(thread_id)
-        
-        self.finished_ok = True
+        frame_id = hit.frame_id
 
-#=======================================================================================================================
-# WriterCaseLamda
-#======================================================================================================================
-class WriterCaseLamda(debugger_unittest.AbstractWriterThread):
+        writer.write_run_thread(thread_id)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_lamda.py')
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(1, 'None')
-        self.write_make_initial_run()
-        
-        for _ in range(3): # We'll hit the same breakpoint 3 times.
-            hit = self.wait_for_breakpoint_hit()
-            
-            self.write_run_thread(hit.thread_id)
-        
-        self.finished_ok = True
-        
+        writer.finished_ok = True
 
-#=======================================================================================================================
-# WriterDebugZipFiles
-#======================================================================================================================
-class WriterDebugZipFiles(debugger_unittest.AbstractWriterThread):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_zip_files.py')
+@pytest.mark.skipif(IS_JYTHON, reason='Not working on Jython (needs to be investigated).')
+def test_case_lamdda(case_setup):
+    with case_setup.test_file('_debugger_case_lamda.py') as writer:
+        writer.write_add_breakpoint(1, 'None')
+        writer.write_make_initial_run()
 
-    def __init__(self, tmpdir):
-        self.tmpdir = tmpdir
-        super(WriterDebugZipFiles, self).__init__()
-        import zipfile
-        zip_file = zipfile.ZipFile(
-            str(tmpdir.join('myzip.zip')), 'w')
-        zip_file.writestr('zipped/__init__.py', '')
-        zip_file.writestr('zipped/zipped_contents.py', 'def call_in_zip():\n    return 1')
-        zip_file.close()
-        
-        zip_file = zipfile.ZipFile(
-            str(tmpdir.join('myzip2.egg!')), 'w')
-        zip_file.writestr('zipped2/__init__.py', '')
-        zip_file.writestr('zipped2/zipped_contents2.py', 'def call_in_zip2():\n    return 1')
-        zip_file.close()
+        for _ in range(3):  # We'll hit the same breakpoint 3 times.
+            hit = writer.wait_for_breakpoint_hit()
 
-    @overrides(debugger_unittest.AbstractWriterThread.get_environ)
-    def get_environ(self):
-        env = os.environ.copy()
-        curr_pythonpath = env.get('PYTHONPATH', '')
+            writer.write_run_thread(hit.thread_id)
 
-        curr_pythonpath = str(self.tmpdir.join('myzip.zip')) + os.pathsep + curr_pythonpath
-        curr_pythonpath = str(self.tmpdir.join('myzip2.egg!')) + os.pathsep + curr_pythonpath
-        env['PYTHONPATH'] = curr_pythonpath
-        
-        env["IDE_PROJECT_ROOTS"] = str(self.tmpdir.join('myzip.zip'))
-        return env
+        writer.finished_ok = True
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(
-            2, 
-            'None', 
-            filename=os.path.join(str(self.tmpdir.join('myzip.zip')), 'zipped', 'zipped_contents.py')
-        )
 
-        self.write_add_breakpoint(
-            2, 
-            'None', 
-            filename=os.path.join(str(self.tmpdir.join('myzip2.egg!')), 'zipped2', 'zipped_contents2.py')
-        )
-
-        self.write_make_initial_run()
-        hit = self.wait_for_breakpoint_hit()
-        assert hit.name == 'call_in_zip'
-        self.write_run_thread(hit.thread_id)
-        
-        hit = self.wait_for_breakpoint_hit()
-        assert hit.name == 'call_in_zip2'
-        self.write_run_thread(hit.thread_id)
-        
-        self.finished_ok = True
-
-#=======================================================================================================================
-# WriterCaseBreakpointSuspensionPolicy
-#======================================================================================================================
-class WriterCaseBreakpointSuspensionPolicy(debugger_unittest.AbstractWriterThread):
-
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_suspend_policy.py')
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(25, '', filename=self.TEST_FILE, hit_condition='', is_logpoint=False, suspend_policy='ALL')
-        self.write_make_initial_run()
+@pytest.mark.skipif(IS_JYTHON, reason='Not working properly on Jython (needs investigation).')
+def test_case_suspension_policy(case_setup):
+    with case_setup.test_file('_debugger_case_suspend_policy.py') as writer:
+        writer.write_add_breakpoint(25, '', filename=writer.TEST_FILE, hit_condition='', is_logpoint=False, suspend_policy='ALL')
+        writer.write_make_initial_run()
 
         thread_ids = []
         for i in range(3):
-            self.log.append('Waiting for thread %s of 3 to stop' % (i + 1,))
+            writer.log.append('Waiting for thread %s of 3 to stop' % (i + 1,))
             # One thread is suspended with a breakpoint hit and the other 2 as thread suspended.
-            hit = self.wait_for_breakpoint_hit((REASON_STOP_ON_BREAKPOINT, REASON_THREAD_SUSPEND))
+            hit = writer.wait_for_breakpoint_hit((REASON_STOP_ON_BREAKPOINT, REASON_THREAD_SUSPEND))
             thread_ids.append(hit.thread_id)
-            
+
         for thread_id in thread_ids:
-            self.write_run_thread(thread_id)
-        
-        self.finished_ok = True
+            writer.write_run_thread(thread_id)
 
-#=======================================================================================================================
-# WriterCaseGetThreadStack
-#======================================================================================================================
-class WriterCaseGetThreadStack(debugger_unittest.AbstractWriterThread):
+        writer.finished_ok = True
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_get_thread_stack.py')
-    
-    def _ignore_stderr_line(self, line):
-        if debugger_unittest.AbstractWriterThread._ignore_stderr_line(self, line):
-            return True
-        
-        if IS_JYTHON:
-            for expected in (
-                "RuntimeWarning: Parent module '_pydev_bundle' not found while handling absolute import",
-                "from java.lang import System"):
-                if expected in line:
-                    return True
-        
-        return False
-    
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(18, None)
-        self.write_make_initial_run()
 
-        thread_created_msgs = [self.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_THREAD_CREATE,)))]
-        thread_created_msgs.append(self.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_THREAD_CREATE,))))
+def test_case_get_thread_stack(case_setup):
+    with case_setup.test_file('_debugger_case_get_thread_stack.py') as writer:
+
+        original_ignore_stderr_line = writer._ignore_stderr_line
+
+        @overrides(writer._ignore_stderr_line)
+        def _ignore_stderr_line(line):
+            if original_ignore_stderr_line(line):
+                return True
+
+            if IS_JYTHON:
+                for expected in (
+                    "RuntimeWarning: Parent module '_pydev_bundle' not found while handling absolute import",
+                    "from java.lang import System"):
+                    if expected in line:
+                        return True
+
+            return False
+
+        writer._ignore_stderr_line = _ignore_stderr_line
+        writer.write_add_breakpoint(18, None)
+        writer.write_make_initial_run()
+
+        thread_created_msgs = [writer.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_THREAD_CREATE,)))]
+        thread_created_msgs.append(writer.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_THREAD_CREATE,))))
         thread_id_to_name = {}
         for msg in thread_created_msgs:
             thread_id_to_name[msg.thread['id']] = msg.thread['name']
         assert len(thread_id_to_name) == 2
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
         assert hit.thread_id in thread_id_to_name
 
         for request_thread_id in thread_id_to_name:
-            self.write_get_thread_stack(request_thread_id)
-            msg = self.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_GET_THREAD_STACK,)))
+            writer.write_get_thread_stack(request_thread_id)
+            msg = writer.wait_for_message(lambda msg:msg.startswith('%s\t' % (CMD_GET_THREAD_STACK,)))
             files = [frame['file'] for frame in  msg.thread.frame]
             assert msg.thread['id'] == request_thread_id
             if not files[0].endswith('_debugger_case_get_thread_stack.py'):
@@ -2261,430 +1716,320 @@ class WriterCaseGetThreadStack(debugger_unittest.AbstractWriterThread):
             if ([filename for filename in files if filename.endswith('pydevd.py')]):
                 raise AssertionError('Did not expect to find pydevd.py. Found: %s' % ('\n'.join(files),))
             if request_thread_id == hit.thread_id:
-                assert len(msg.thread.frame) == 0 # In main thread (must have no back frames).
+                assert len(msg.thread.frame) == 0  # In main thread (must have no back frames).
                 assert msg.thread.frame['name'] == '<module>'
             else:
-                assert len(msg.thread.frame) > 1 # Stopped in threading (must have back frames).
+                assert len(msg.thread.frame) > 1  # Stopped in threading (must have back frames).
                 assert msg.thread.frame[0]['name'] == 'method'
 
-        self.write_run_thread(hit.thread_id)
+        writer.write_run_thread(hit.thread_id)
 
-        self.finished_ok = True
+        writer.finished_ok = True
 
 
-#=======================================================================================================================
-# WriterCaseDumpThreadsToStderr
-#======================================================================================================================
-class WriterCaseDumpThreadsToStderr(debugger_unittest.AbstractWriterThread):
+def test_case_dump_threads_to_stderr(case_setup):
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_get_thread_stack.py')
+    from tests_python.debugger_unittest import wait_for_condition
 
-    def additional_output_checks(self, stdout, stderr):
-        assert 'Thread Dump' in stderr and 'Thread pydevd.CommandThread  (daemon: True, pydevd thread: True)' in stderr, \
-            'Did not find thread dump in stderr. stderr:\n%s' % (stderr,)
+    def additional_output_checks(writer, stdout, stderr):
+        assert is_stderr_ok(stderr), make_error_msg(stderr)
 
-    def run(self):
-        self.start_socket()
-        self.write_add_breakpoint(12, None)
-        self.write_make_initial_run()
+    def make_error_msg(stderr):
+        return 'Did not find thread dump in stderr. stderr:\n%s' % (stderr,)
 
-        hit = self.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
+    def is_stderr_ok(stderr):
+        return 'Thread Dump' in stderr and 'Thread pydevd.CommandThread  (daemon: True, pydevd thread: True)' in stderr
 
-        self.write_dump_threads()
-        self.write_run_thread(hit.thread_id)
+    with case_setup.test_file(
+        '_debugger_case_get_thread_stack.py', additional_output_checks=additional_output_checks) as writer:
+        writer.write_add_breakpoint(12, None)
+        writer.write_make_initial_run()
 
-        self.finished_ok = True
-        
-#=======================================================================================================================
-# WriterCaseStopOnStartRegular
-#=======================================================================================================================
-class WriterCaseStopOnStartRegular(debugger_unittest.AbstractWriterThread):
+        hit = writer.wait_for_breakpoint_hit(REASON_STOP_ON_BREAKPOINT)
 
-    TEST_FILE = debugger_unittest._get_debugger_test_file('_debugger_case_simple_calls.py')
+        writer.write_dump_threads()
+        wait_for_condition(
+            lambda: is_stderr_ok(writer.get_stderr()),
+            lambda: make_error_msg(writer.get_stderr())
+            )
+        writer.write_run_thread(hit.thread_id)
 
-    def run(self):
-        self.start_socket()
-        self.write_stop_on_start()
-        self.write_make_initial_run()
+        writer.finished_ok = True
 
-        hit = self.wait_for_breakpoint_hit(REASON_STEP_INTO_MY_CODE, file='_debugger_case_simple_calls.py', line=1)
 
-        self.write_run_thread(hit.thread_id)
+def test_stop_on_start_regular(case_setup):
+    with case_setup.test_file('_debugger_case_simple_calls.py') as writer:
+        writer.write_stop_on_start()
+        writer.write_make_initial_run()
 
-        self.finished_ok = True
+        hit = writer.wait_for_breakpoint_hit(REASON_STEP_INTO_MY_CODE, file='_debugger_case_simple_calls.py', line=1)
 
+        writer.write_run_thread(hit.thread_id)
 
-# ======================================================================================================================
-# WriterCaseStopOnStartMSwitch
-# ======================================================================================================================
-class WriterCaseStopOnStartMSwitch(WriterThreadCaseMSwitch):
-    
-    def run(self):
-        self.start_socket()
-        self.write_stop_on_start()
-        self.write_make_initial_run()
+        writer.finished_ok = True
 
-        hit = self.wait_for_breakpoint_hit(REASON_STEP_INTO_MY_CODE, file='_debugger_case_m_switch.py', line=1)
 
-        self.write_run_thread(hit.thread_id)
+def test_py_37_breakpoint(case_setup):
+    with case_setup.test_file('_debugger_case_breakpoint.py') as writer:
+        writer.write_make_initial_run()
 
-        self.finished_ok = True
+        hit = writer.wait_for_breakpoint_hit(
+            REASON_THREAD_SUSPEND, file='_debugger_case_breakpoint.py', line=2)
 
+        writer.write_run_thread(hit.thread_id)
 
-# ======================================================================================================================
-# WriterCaseStopOnStartEntryPoint
-# ======================================================================================================================
-class WriterCaseStopOnStartEntryPoint(WriterThreadCaseModuleWithEntryPoint):
-    
-    def run(self):
-        self.start_socket()
-        self.write_stop_on_start()
-        self.write_make_initial_run()
+        writer.finished_ok = True
 
-        hit = self.wait_for_breakpoint_hit(REASON_STEP_INTO_MY_CODE, file='_debugger_case_module_entry_point.py', line=1)
 
-        self.write_run_thread(hit.thread_id)
+def test_stop_on_start_m_switch(case_setup_m_switch):
+    with case_setup_m_switch.test_file() as writer:
+        writer.write_stop_on_start()
+        writer.write_make_initial_run()
 
-        self.finished_ok = True
+        hit = writer.wait_for_breakpoint_hit(REASON_STEP_INTO_MY_CODE, file='_debugger_case_m_switch.py', line=1)
 
+        writer.write_run_thread(hit.thread_id)
 
-#=======================================================================================================================
-# Test
-#=======================================================================================================================
-class Test(unittest.TestCase, debugger_unittest.DebuggerRunner):
+        writer.finished_ok = True
 
-    def get_command_line(self):
-        if IS_JYTHON:
-            if sys.executable is not None:
-                # i.e.: we're running with the provided jython.exe
-                return [sys.executable]
-            else:
 
+def test_stop_on_start_entry_point(case_setup_m_switch_entry_point):
+    with case_setup_m_switch_entry_point.test_file() as writer:
+        writer.write_stop_on_start()
+        writer.write_make_initial_run()
 
-                return [
-                    get_java_location(),
-                    '-classpath',
-                    get_jython_jar(),
-                    'org.python.util.jython'
-                ]
+        hit = writer.wait_for_breakpoint_hit(REASON_STEP_INTO_MY_CODE, file='_debugger_case_module_entry_point.py', line=1)
 
-        if IS_CPYTHON:
-            return [sys.executable, '-u']
+        writer.write_run_thread(hit.thread_id)
 
-        if IS_IRONPYTHON:
-            return [
-                    sys.executable,
-                    '-X:Frames'
-                ]
+        writer.finished_ok = True
 
-        raise RuntimeError('Unable to provide command line')
 
-    @pytest.mark.skipif(IS_IRONPYTHON, reason='Test needs gc.get_referrers to really check anything.')
-    def test_case_1(self):
-        self.check_case(WriterThreadCase1)
+@pytest.mark.skipif(IS_JYTHON, reason='Not working properly on Jython (needs investigation).')
+def test_debug_zip_files(case_setup, tmpdir):
 
-    def test_case_2(self):
-        self.check_case(WriterThreadCase2)
+    def get_environ(writer):
+        env = os.environ.copy()
+        curr_pythonpath = env.get('PYTHONPATH', '')
 
-    @pytest.mark.skipif(IS_IRONPYTHON, reason='This test fails once in a while due to timing issues on IronPython, so, skipping it.')
-    def test_case_3(self):
-        self.check_case(WriterThreadCase3)
+        curr_pythonpath = str(tmpdir.join('myzip.zip')) + os.pathsep + curr_pythonpath
+        curr_pythonpath = str(tmpdir.join('myzip2.egg!')) + os.pathsep + curr_pythonpath
+        env['PYTHONPATH'] = curr_pythonpath
 
-    @pytest.mark.skipif(IS_JYTHON, reason='This test is flaky on Jython, so, skipping it.')
-    def test_case_4(self):
-        self.check_case(WriterThreadCase4)
+        env["IDE_PROJECT_ROOTS"] = str(tmpdir.join('myzip.zip'))
+        return env
 
-    def test_case_5(self):
-        self.check_case(WriterThreadCase5)
+    import zipfile
+    zip_file = zipfile.ZipFile(
+        str(tmpdir.join('myzip.zip')), 'w')
+    zip_file.writestr('zipped/__init__.py', '')
+    zip_file.writestr('zipped/zipped_contents.py', 'def call_in_zip():\n    return 1')
+    zip_file.close()
+
+    zip_file = zipfile.ZipFile(
+        str(tmpdir.join('myzip2.egg!')), 'w')
+    zip_file.writestr('zipped2/__init__.py', '')
+    zip_file.writestr('zipped2/zipped_contents2.py', 'def call_in_zip2():\n    return 1')
+    zip_file.close()
+
+    with case_setup.test_file('_debugger_case_zip_files.py', get_environ=get_environ) as writer:
+        writer.write_add_breakpoint(
+            2,
+            'None',
+            filename=os.path.join(str(tmpdir.join('myzip.zip')), 'zipped', 'zipped_contents.py')
+        )
+
+        writer.write_add_breakpoint(
+            2,
+            'None',
+            filename=os.path.join(str(tmpdir.join('myzip2.egg!')), 'zipped2', 'zipped_contents2.py')
+        )
+
+        writer.write_make_initial_run()
+        hit = writer.wait_for_breakpoint_hit()
+        assert hit.name == 'call_in_zip'
+        writer.write_run_thread(hit.thread_id)
+
+        hit = writer.wait_for_breakpoint_hit()
+        assert hit.name == 'call_in_zip2'
+        writer.write_run_thread(hit.thread_id)
+
+        writer.finished_ok = True
 
-    def test_case_6(self):
-        self.check_case(WriterThreadCase6)
-
-    def test_case_7(self):
-        if IS_IRONPYTHON:
-            # This test checks that we start without variables and at each step a new var is created, but on ironpython,
-            # the variables exist all at once (with None values), so, we can't test it properly.
-            pytest.skip("Different behavior on IronPython")
-
-        self.check_case(WriterThreadCase7)
-
-    def test_case_8(self):
-        self.check_case(WriterThreadCase8)
-
-    def test_case_9(self):
-        self.check_case(WriterThreadCase9)
-
-    def test_case_10(self):
-        self.check_case(WriterThreadCase10)
-
-    def test_case_11(self):
-        self.check_case(WriterThreadCase11)
-
-    def test_case_12(self):
-        self.check_case(WriterThreadCase12)
-
-    @pytest.mark.skipif(IS_IRONPYTHON, reason='Failing on IronPython (needs to be investigated).')
-    def test_case_13(self):
-        self.check_case(WriterThreadCase13)
-
-    def test_case_14(self):
-        self.check_case(WriterThreadCase14)
-
-    def test_case_15(self):
-        self.check_case(WriterThreadCase15)
-
-    def test_case_16(self):
-        try:
-            import numpy
-        except ImportError:
-            pytest.skip('numpy not available')
-
-        self.check_case(WriterThreadCase16)
-
-    def test_case_17(self):
-        self.check_case(WriterThreadCase17)
-
-    def test_case_17a(self):
-        self.check_case(WriterThreadCase17a)
-
-    def test_case_18(self):
-        if IS_IRONPYTHON or IS_JYTHON:
-            pytest.skip('Unsupported assign to local')
-
-        self.check_case(WriterThreadCase18)
-
-    def test_case_19(self):
-        self.check_case(WriterThreadCase19)
-
-    @pytest.mark.skipif(IS_JYTHON, reason='Monkey-patching related to starting threads not done on Jython.')
-    def test_case_20(self):
-        self.check_case(WriterThreadCase20)
-
-    if TEST_DJANGO:
-        def test_case_django(self):
-            self.check_case(WriterThreadCaseDjango)
-
-        def test_case_django2(self):
-            self.check_case(WriterThreadCaseDjango2)
-
-
-    if TEST_CYTHON:
-        def test_cython(self):
-            from _pydevd_bundle import pydevd_cython
-            assert pydevd_cython.trace_dispatch is not None
-
-    def _has_qt(self):
-        try:
-            from PySide import QtCore  # @UnresolvedImport
-            return True
-        except:
-            try:
-                from PyQt4 import QtCore
-                return True
-            except:
-                try:
-                    from PyQt5 import QtCore
-                    return True
-                except:
-                    pass
-        return False
-
-    def test_case_qthread1(self):
-        if self._has_qt():
-            self.check_case(WriterThreadCaseQThread1)
-
-    def test_case_qthread2(self):
-        if self._has_qt():
-            self.check_case(WriterThreadCaseQThread2)
-
-    def test_case_qthread3(self):
-        if self._has_qt():
-            self.check_case(WriterThreadCaseQThread3)
-
-    def test_case_qthread4(self):
-        if self._has_qt():
-            self.check_case(WriterThreadCaseQThread4)
-
-    def test_m_switch(self):
-        self.check_case(WriterThreadCaseMSwitch)
-
-    def test_module_entry_point(self):
-        self.check_case(WriterThreadCaseModuleWithEntryPoint)
-
-    @pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
-    def test_unhandled_exceptions_basic(self):
-        self.check_case(WriterThreadCaseUnhandledExceptionsBasic)
-        
-    @pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
-    def test_unhandled_exceptions_in_top_level(self):
-        self.check_case(WriterThreadCaseUnhandledExceptionsOnTopLevel)
-        
-    @pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
-    def test_unhandled_exceptions_in_top_level2(self):
-        self.check_case(WriterThreadCaseUnhandledExceptionsOnTopLevel2)
-        
-    @pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
-    def test_unhandled_exceptions_in_top_level3(self):
-        self.check_case(WriterThreadCaseUnhandledExceptionsOnTopLevel3)
-        
-    @pytest.mark.skipif(IS_JYTHON, reason='Failing on Jython -- needs to be investigated).')
-    def test_unhandled_exceptions_in_top_level4(self):
-        self.check_case(WriterThreadCaseUnhandledExceptionsOnTopLevel4)
-
-    @pytest.mark.skipif(not IS_CPYTHON or (IS_PY36 and not IS_WINDOWS), reason='Only for Python (failing on 3.6 on travis (linux) -- needs to be investigated).')
-    def test_case_set_next_statement(self):
-        self.check_case(WriterThreadCaseSetNextStatement)
-
-    @pytest.mark.skipif(not IS_CPYTHON, reason='Only for Python.')
-    def test_case_get_next_statement_targets(self):
-        self.check_case(WriterThreadCaseGetNextStatementTargets)
-
-    @pytest.mark.skipif(IS_IRONPYTHON or IS_JYTHON, reason='Failing on IronPython and Jython (needs to be investigated).')
-    def test_case_type_ext(self):
-        self.check_case(WriterThreadCaseTypeExt)
-
-    @pytest.mark.skipif(IS_IRONPYTHON or IS_JYTHON, reason='Failing on IronPython and Jython (needs to be investigated).')
-    def test_case_event_ext(self):
-        self.check_case(WriterThreadCaseEventExt)
-
-    @pytest.mark.skipif(IS_JYTHON, reason='Jython does not seem to be creating thread started inside tracing (investigate).')
-    def test_case_writer_thread_creation_deadlock(self):
-        self.check_case(WriterThreadCaseThreadCreationDeadlock)
-
-    def test_case_skip_breakpoints_in_exceptions(self):
-        self.check_case(WriterThreadCaseSkipBreakpointInExceptions)
-
-    def test_case_handled_exceptions0(self):
-        self.check_case(WriterThreadCaseHandledExceptions0)
-        
-    @pytest.mark.skipif(IS_JYTHON, reason='Not working on Jython (needs to be investigated).')
-    def test_case_handled_exceptions1(self):
-        self.check_case(WriterThreadCaseHandledExceptions1)
-        
-    def test_case_handled_exceptions2(self):
-        self.check_case(WriterThreadCaseHandledExceptions2)
-        
-    def test_case_handled_exceptions3(self):
-        self.check_case(WriterThreadCaseHandledExceptions3)
-        
-    def test_case_handled_exceptions4(self):
-        self.check_case(WriterThreadCaseHandledExceptions4)
-        
-    def test_case_settrace(self):
-        self.check_case(WriterCaseSetTrace)
-        
-    @pytest.mark.skipif(IS_PY26 or IS_JYTHON, reason='scapy only supports 2.7 onwards, not available for jython.')
-    def test_case_scapy(self):
-        self.check_case(WriterThreadCaseScapy)
-
-    @pytest.mark.skipif(IS_APPVEYOR or IS_JYTHON, reason='Flaky on appveyor / Jython encoding issues (needs investigation).')
-    def test_redirect_output(self):
-        self.check_case(WriterThreadCaseRedirectOutput)
-
-    def test_path_translation(self):
-        self.check_case(WriterThreadCasePathTranslation)
-
-    def test_evaluate_errors(self):
-        self.check_case(WriterThreadCaseEvaluateErrors)
-
-    def test_list_threads(self):
-        self.check_case(WriterThreadCaseListThreads)
-
-    def test_case_print(self):
-        self.check_case(WriterCasePrint)
-
-    @pytest.mark.skipif(IS_JYTHON, reason='Not working on Jython (needs to be investigated).')
-    def test_case_lamdda(self):
-        self.check_case(WriterCaseLamda)
-        
-    @pytest.fixture(autouse=True)
-    def setup_fixtures(self, tmpdir):
-        self.tmpdir = tmpdir
-        
-    @pytest.mark.skipif(IS_JYTHON, reason='Not working properly on Jython (needs investigation).')
-    def test_debug_zip_files(self):
-        self.check_case(WriterDebugZipFiles(self.tmpdir))
-
-    @pytest.mark.skipif(IS_JYTHON, reason='Not working properly on Jython (needs investigation).')
-    def test_case_suspension_policy(self):
-        self.check_case(WriterCaseBreakpointSuspensionPolicy)
-
-    def test_case_get_thread_stack(self):
-        self.check_case(WriterCaseGetThreadStack)
-
-    def test_case_dump_threads_to_stderr(self):
-        self.check_case(WriterCaseDumpThreadsToStderr)
-        
-    def test_stop_on_start_regular(self):
-        self.check_case(WriterCaseStopOnStartRegular)
-        
-    def test_stop_on_start_m_switch(self):
-        self.check_case(WriterCaseStopOnStartMSwitch)
-        
-    def test_stop_on_start_entry_point(self):
-        self.check_case(WriterCaseStopOnStartEntryPoint)
 
 @pytest.mark.skipif(not IS_CPYTHON, reason='CPython only test.')
-class TestPythonRemoteDebugger(unittest.TestCase, debugger_unittest.DebuggerRunner):
+def test_remote_debugger_basic(case_setup_remote):
+    with case_setup_remote.test_file('_debugger_case_remote.py') as writer:
+        writer.log.append('making initial run')
+        writer.write_make_initial_run()
 
-    def get_command_line(self):
-        return [sys.executable, '-u']
+        writer.log.append('waiting for breakpoint hit')
+        hit = writer.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
 
-    def add_command_line_args(self, args):
-        writer_thread = self.writer_thread
+        writer.log.append('run thread')
+        writer.write_run_thread(hit.thread_id)
 
-        ret = args + [self.writer_thread.TEST_FILE]
-        ret = writer_thread.update_command_line_args(ret)  # Provide a hook for the writer
-        return ret
+        writer.log.append('asserting')
+        try:
+            assert 5 == writer._sequence, 'Expected 5. Had: %s' % writer._sequence
+        except:
+            writer.log.append('assert failed!')
+            raise
+        writer.log.append('asserted')
 
-    def test_remote_debugger(self):
-        self.check_case(WriterThreadCaseRemoteDebugger)
-
-    def test_remote_debugger2(self):
-        self.check_case(WriterThreadCaseRemoteDebuggerMultiProc)
-
-    def test_remote_unhandled_exceptions(self):
-        self.check_case(WriterThreadCaseRemoteDebuggerUnhandledExceptions)
-
-    def test_remote_unhandled_exceptions2(self):
-        self.check_case(WriterThreadCaseRemoteDebuggerUnhandledExceptions2)
-
-        
-def get_java_location():
-    from java.lang import System  # @UnresolvedImport
-    jre_dir = System.getProperty("java.home")
-    for f in [os.path.join(jre_dir, 'bin', 'java.exe'), os.path.join(jre_dir, 'bin', 'java')]:
-        if os.path.exists(f):
-            return f
-    raise RuntimeError('Unable to find java executable')
-
-def get_jython_jar():
-    from java.lang import ClassLoader  # @UnresolvedImport
-    cl = ClassLoader.getSystemClassLoader()
-    paths = map(lambda url: url.getFile(), cl.getURLs())
-    for p in paths:
-        if 'jython.jar' in p:
-            return p
-    raise RuntimeError('Unable to find jython.jar')
+        writer.finished_ok = True
 
 
-def get_location_from_line(line):
-    loc = line.split('=')[1].strip()
-    if loc.endswith(';'):
-        loc = loc[:-1]
-    if loc.endswith('"'):
-        loc = loc[:-1]
-    if loc.startswith('"'):
-        loc = loc[1:]
-    return loc
+@pytest.mark.skipif(not IS_CPYTHON, reason='CPython only test.')
+def test_remote_debugger_multi_proc(case_setup_remote):
+
+    class _SecondaryMultiProcProcessWriterThread(debugger_unittest.AbstractWriterThread):
+
+        FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
+
+        def __init__(self, server_socket):
+            debugger_unittest.AbstractWriterThread.__init__(self)
+            self.server_socket = server_socket
+
+        def run(self):
+            print('waiting for second process')
+            self.sock, addr = self.server_socket.accept()
+            print('accepted second process')
+
+            from tests_python.debugger_unittest import ReaderThread
+            self.reader_thread = ReaderThread(self.sock)
+            self.reader_thread.start()
+
+            self._sequence = -1
+            # initial command is always the version
+            self.write_version()
+            self.log.append('start_socket')
+            self.write_make_initial_run()
+            time.sleep(.5)
+            self.finished_ok = True
+
+    def do_kill(writer):
+        debugger_unittest.AbstractWriterThread.do_kill(writer)
+        if hasattr(writer, 'secondary_multi_proc_process_writer'):
+            writer.secondary_multi_proc_process_writer.do_kill()
+
+    with case_setup_remote.test_file('_debugger_case_remote_1.py', do_kill=do_kill) as writer:
+
+        # It seems sometimes it becomes flaky on the ci because the process outlives the writer thread...
+        # As we're only interested in knowing if a second connection was received, just kill the related
+        # process.
+        assert hasattr(writer, 'FORCE_KILL_PROCESS_WHEN_FINISHED_OK')
+        writer.FORCE_KILL_PROCESS_WHEN_FINISHED_OK = True
+
+        writer.log.append('making initial run')
+        writer.write_make_initial_run()
+
+        writer.log.append('waiting for breakpoint hit')
+        hit = writer.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
+
+        writer.secondary_multi_proc_process_writer = secondary_multi_proc_process_writer = \
+            _SecondaryMultiProcProcessWriterThread(writer.server_socket)
+        secondary_multi_proc_process_writer.start()
+
+        writer.log.append('run thread')
+        writer.write_run_thread(hit.thread_id)
+
+        for _i in xrange(400):
+            if secondary_multi_proc_process_writer.finished_ok:
+                break
+            time.sleep(.1)
+        else:
+            writer.log.append('Secondary process not finished ok!')
+            raise AssertionError('Secondary process not finished ok!')
+
+        writer.log.append('Secondary process finished!')
+        try:
+            assert 5 == writer._sequence, 'Expected 5. Had: %s' % writer._sequence
+        except:
+            writer.log.append('assert failed!')
+            raise
+        writer.log.append('asserted')
+
+        writer.finished_ok = True
 
 
-def split_line(line):
-    if '=' not in line:
-        return None, None
-    var = line.split('=')[0].strip()
-    return var, get_location_from_line(line)
+@pytest.mark.skipif(not IS_CPYTHON, reason='CPython only test.')
+def test_remote_unhandled_exceptions(case_setup_remote):
+
+    def check_test_suceeded_msg(writer, stdout, stderr):
+        return 'TEST SUCEEDED' in ''.join(stderr)
+
+    def additional_output_checks(writer, stdout, stderr):
+        # Don't call super as we have an expected exception
+        assert 'ValueError: TEST SUCEEDED' in stderr
+
+    with case_setup_remote.test_file(
+        '_debugger_case_remote_unhandled_exceptions.py',
+        additional_output_checks=additional_output_checks,
+        check_test_suceeded_msg=check_test_suceeded_msg) as writer:
+
+        writer.log.append('making initial run')
+        writer.write_make_initial_run()
+
+        writer.log.append('waiting for breakpoint hit')
+        hit = writer.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
+
+        writer.write_add_exception_breakpoint_with_policy('Exception', '0', '1', '0')
+
+        writer.log.append('run thread')
+        writer.write_run_thread(hit.thread_id)
+
+        writer.log.append('waiting for uncaught exception')
+        hit = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+        writer.write_run_thread(hit.thread_id)
+
+        writer.log.append('finished ok')
+        writer.finished_ok = True
 
 
+@pytest.mark.skipif(not IS_CPYTHON, reason='CPython only test.')
+def test_remote_unhandled_exceptions2(case_setup_remote):
 
+    def check_test_suceeded_msg(writer, stdout, stderr):
+        return 'TEST SUCEEDED' in ''.join(stderr)
+
+    def additional_output_checks(writer, stdout, stderr):
+        # Don't call super as we have an expected exception
+        assert 'ValueError: TEST SUCEEDED' in stderr
+
+    with case_setup_remote.test_file(
+        '_debugger_case_remote_unhandled_exceptions2.py',
+        additional_output_checks=additional_output_checks,
+        check_test_suceeded_msg=check_test_suceeded_msg) as writer:
+
+        writer.log.append('making initial run')
+        writer.write_make_initial_run()
+
+        writer.log.append('waiting for breakpoint hit')
+        hit = writer.wait_for_breakpoint_hit(REASON_THREAD_SUSPEND)
+
+        writer.write_add_exception_breakpoint_with_policy('ValueError', '0', '1', '0')
+
+        writer.log.append('run thread')
+        writer.write_run_thread(hit.thread_id)
+
+        writer.log.append('waiting for uncaught exception')
+        for _ in range(3):
+            # Note: this isn't ideal, but in the remote attach case, if the
+            # exception is raised at the topmost frame, we consider the exception to
+            # be an uncaught exception even if it'll be handled at that point.
+            # See: https://github.com/Microsoft/ptvsd/issues/580
+            # To properly fix this, we'll need to identify that this exception
+            # will be handled later on with the information we have at hand (so,
+            # no back frame but within a try..except block).
+            hit = writer.wait_for_breakpoint_hit(REASON_UNCAUGHT_EXCEPTION)
+            writer.write_run_thread(hit.thread_id)
+
+        writer.log.append('finished ok')
+        writer.finished_ok = True
+
+# Jython needs some vars to be set locally.
+# set JAVA_HOME=c:\bin\jdk1.8.0_172
+# set PATH=%PATH%;C:\bin\jython2.7.0\bin
+# set PATH=%PATH%;%JAVA_HOME%\bin
 # c:\bin\jython2.7.0\bin\jython.exe -m py.test tests_python

--- a/tests/resources/system_tests/test_break_into_debugger/attach_test_breakpoint.py
+++ b/tests/resources/system_tests/test_break_into_debugger/attach_test_breakpoint.py
@@ -1,0 +1,36 @@
+import sys
+import ptvsd
+import os
+import time
+
+ptvsd.enable_attach((sys.argv[1], sys.argv[2]))
+
+
+loopy = False
+if os.getenv('PTVSD_WAIT_FOR_ATTACH', None) is not None:
+    print('waiting for attach')
+    ptvsd.wait_for_attach()
+elif os.getenv('PTVSD_IS_ATTACHED', None) is not None:
+    print('checking is attached')
+    while not ptvsd.is_attached():
+        time.sleep(0.1)
+else:
+    loopy = True
+
+
+def main():
+    if loopy:
+        count = 0
+        while count < 50:
+            print('one')
+            breakpoint()  # noqa
+            time.sleep(0.1)
+            print('two')
+            count += 1
+    else:
+        print('one')
+        breakpoint()  # noqa
+        print('two')
+
+
+main()

--- a/tests/resources/system_tests/test_break_into_debugger/launch_test_breakpoint.py
+++ b/tests/resources/system_tests/test_break_into_debugger/launch_test_breakpoint.py
@@ -1,0 +1,9 @@
+
+
+def main():
+    print('one')
+    breakpoint()  # noqa
+    print('two')
+
+
+main()

--- a/tests/resources/system_tests/test_break_into_debugger/mypkg_launch_breakpoint/__main__.py
+++ b/tests/resources/system_tests/test_break_into_debugger/mypkg_launch_breakpoint/__main__.py
@@ -1,0 +1,9 @@
+
+
+def main():
+    print('one')
+    breakpoint()  # noqa
+    print('two')
+
+
+main()

--- a/tests/resources/system_tests/test_break_into_debugger/mypkg_reattach_breakpoint/__main__.py
+++ b/tests/resources/system_tests/test_break_into_debugger/mypkg_reattach_breakpoint/__main__.py
@@ -1,0 +1,28 @@
+import sys
+import ptvsd
+import os
+import time
+
+ptvsd.enable_attach((sys.argv[1], sys.argv[2]))
+
+
+def main():
+    count = 0
+    while count < 50:
+        if os.getenv('PTVSD_WAIT_FOR_ATTACH', None) is not None:
+            print('waiting for attach')
+            ptvsd.wait_for_attach()
+        elif os.getenv('PTVSD_IS_ATTACHED', None) is not None:
+            print('checking is attached')
+            while not ptvsd.is_attached():
+                time.sleep(0.1)
+        else:
+            pass
+        print('one')
+        breakpoint()  # noqa
+        time.sleep(0.5)
+        print('two')
+        count += 1
+
+
+main()

--- a/tests/resources/system_tests/test_break_into_debugger/reattach_test_breakpoint.py
+++ b/tests/resources/system_tests/test_break_into_debugger/reattach_test_breakpoint.py
@@ -1,0 +1,28 @@
+import sys
+import ptvsd
+import os
+import time
+
+ptvsd.enable_attach((sys.argv[1], sys.argv[2]))
+
+
+def main():
+    count = 0
+    while count < 50:
+        if os.getenv('PTVSD_WAIT_FOR_ATTACH', None) is not None:
+            print('waiting for attach')
+            ptvsd.wait_for_attach()
+        elif os.getenv('PTVSD_IS_ATTACHED', None) is not None:
+            print('checking is attached')
+            while not ptvsd.is_attached():
+                time.sleep(0.1)
+        else:
+            pass
+        print('one')
+        breakpoint()  # noqa
+        time.sleep(0.5)
+        print('two')
+        count += 1
+
+
+main()

--- a/tests/system_tests/test_break_into_debugger.py
+++ b/tests/system_tests/test_break_into_debugger.py
@@ -97,19 +97,20 @@ class BreakIntoDebuggerTests(LifecycleTestsBase):
 
 class LaunchFileBreakIntoDebuggerTests(BreakIntoDebuggerTests):
     def test_launch_and_break(self):
-        filename = TEST_FILES.resolve('launch_test.py')
-        cwd = os.path.dirname(filename)
-        debug_info = DebugInfo(filename=filename, cwd=cwd)
-        self.run_test_attach_or_launch(debug_info)
+        for filename in ('launch_test.py', 'launch_test_breakpoint.py'):
+            filename = TEST_FILES.resolve(filename)
+            cwd = os.path.dirname(filename)
+            debug_info = DebugInfo(filename=filename, cwd=cwd)
+            self.run_test_attach_or_launch(debug_info)
 
 
 class LaunchModuleBreakIntoDebuggerTests(BreakIntoDebuggerTests):
     def test_launch_and_break(self):
-        module_name = 'mypkg_launch'
-        env = TEST_FILES.env_with_py_path()
-        cwd = TEST_FILES.parent.root
-        self.run_test_attach_or_launch(
-            DebugInfo(modulename=module_name, env=env, cwd=cwd))
+        for module_name in ('mypkg_launch', 'mypkg_launch_breakpoint'):
+            env = TEST_FILES.env_with_py_path()
+            cwd = TEST_FILES.parent.root
+            self.run_test_attach_or_launch(
+                DebugInfo(modulename=module_name, env=env, cwd=cwd))
 
 
 class ServerAttachBreakIntoDebuggerTests(BreakIntoDebuggerTests):
@@ -186,17 +187,18 @@ class PTVSDAttachBreakIntoDebuggerTests(BreakIntoDebuggerTests):
     def test_reattach_enable_wait_and_break(self):
         # Uses enable_attach followed by wait_for_attach
         # before calling break_into_debugger
-        filename = TEST_FILES.resolve('reattach_test.py')
-        cwd = os.path.dirname(filename)
-        debug_info = DebugInfo(
-            filename=filename,
-            cwd=cwd,
-            argv=['localhost', str(PORT)],
-            env={'PTVSD_WAIT_FOR_ATTACH': 'True'},
-            starttype='attach',
-            attachtype='import',
-            )
-        self.run_test_reattach(debug_info)
+        for filename in ('reattach_test.py', 'reattach_test_breakpoint.py'):
+            filename = TEST_FILES.resolve(filename)
+            cwd = os.path.dirname(filename)
+            debug_info = DebugInfo(
+                filename=filename,
+                cwd=cwd,
+                argv=['localhost', str(PORT)],
+                env={'PTVSD_WAIT_FOR_ATTACH': 'True'},
+                starttype='attach',
+                attachtype='import',
+                )
+            self.run_test_reattach(debug_info)
 
     def test_reattach_enable_check_and_break(self):
         # Uses enable_attach followed by a loop that checks if the
@@ -299,19 +301,19 @@ class PTVSDAttachModuleBreakIntoDebuggerTests(BreakIntoDebuggerTests):
     def test_reattach_enable_check_and_break(self):
         # Uses enable_attach followed by a loop that checks if the
         # debugger is attached before calling break_into_debugger
-        module_name = 'mypkg_reattach'
-        env = TEST_FILES.env_with_py_path()
-        env['PTVSD_IS_ATTACHED'] = 'True'
-        cwd = TEST_FILES.root
-        debug_info = DebugInfo(
-            modulename=module_name,
-            env=env,
-            cwd=cwd,
-            argv=['localhost', str(PORT)],
-            starttype='attach',
-            attachtype='import',
-            )
-        self.run_test_reattach(debug_info)
+        for module_name in ('mypkg_reattach', 'mypkg_reattach_breakpoint'):
+            env = TEST_FILES.env_with_py_path()
+            env['PTVSD_IS_ATTACHED'] = 'True'
+            cwd = TEST_FILES.root
+            debug_info = DebugInfo(
+                modulename=module_name,
+                env=env,
+                cwd=cwd,
+                argv=['localhost', str(PORT)],
+                starttype='attach',
+                attachtype='import',
+                )
+            self.run_test_reattach(debug_info)
 
     def test_reattach_enable_and_break(self):
         # Uses enable_attach followed by break_into_debugger


### PR DESCRIPTION
Some notes:

The `breakpoint()` builtin maps to `ptvsd.break_into_debugger()`. It's binds to `sys.breakpointhook` in Python 3.7 and to a `breakpoint()` builtin on earlier versions.

I decided not using the environment variable to be able to provide a fallback on earlier versions (and to work even if the PYTHONPATH is changed and no longer has access to the debugger).

Note that the version on `pydevd` connects to a host to do remote debugging if it's still not connected, but for `ptvsd` it's a requirement that the user is already connected (so, either he should've started with debugging or the `ptvsd.enable_attach`, `ptvsd.wait_for_attach` needs to be used -- as is expected from `ptvsd.break_into_debugger()`).

-- also, this pull request also adds a reorganization I did to use less scaffolding on tests.