### PR TITLE
Fix #355: Add 'remote launch' - launch a program for remote debugging but continue running the user code

### DIFF
--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -136,7 +136,7 @@ def _group_args(argv):
             if nextarg is not None:
                 supported.append(nextarg)
             skip += 1
-        elif arg in ('--single-session',):
+        elif arg in ('--single-session', '--wait'):
             supported.append(arg)
         elif not arg.startswith('-'):
             supported.append(arg)
@@ -166,6 +166,8 @@ def _parse_args(prog, argv):
     target.add_argument('filename', nargs='?')
 
     parser.add_argument('--single-session', action='store_true')
+    parser.add_argument('--wait', action='store_true')
+
     parser.add_argument('-V', '--version', action='version')
     parser.version = __version__
 
@@ -208,4 +210,4 @@ def main(addr, name, kind, extra=(), nodebug=False, **kwargs):
 if __name__ == '__main__':
     args, extra = parse_args()
     main(args.address, args.name, args.kind, extra, nodebug=args.nodebug,
-         singlesession=args.single_session)
+         singlesession=args.single_session, wait=args.wait)

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -1,3 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
 import pydevd
 import time
 

--- a/ptvsd/_util.py
+++ b/ptvsd/_util.py
@@ -1,3 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
 from __future__ import print_function
 
 import contextlib

--- a/ptvsd/daemon.py
+++ b/ptvsd/daemon.py
@@ -1,3 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
 import contextlib
 import sys
 import threading

--- a/ptvsd/exit_handlers.py
+++ b/ptvsd/exit_handlers.py
@@ -1,3 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
 import atexit
 import os
 import platform

--- a/ptvsd/pydevd_hooks.py
+++ b/ptvsd/pydevd_hooks.py
@@ -1,3 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
 import sys
 
 from _pydevd_bundle import pydevd_comm

--- a/ptvsd/session.py
+++ b/ptvsd/session.py
@@ -1,3 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
 from .socket import is_socket, close_socket
 from .wrapper import VSCodeMessageProcessor
 from ._util import TimeoutError, ClosedError, Closeable, Startable, debug

--- a/ptvsd/socket.py
+++ b/ptvsd/socket.py
@@ -1,3 +1,7 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
 from __future__ import absolute_import
 
 from collections import namedtuple

--- a/tests/helpers/debugadapter.py
+++ b/tests/helpers/debugadapter.py
@@ -198,6 +198,8 @@ class DebugAdapter(Closeable):
         argv = []
         if server:
             argv += ['--server']
+            if kwargs.pop('wait', True):
+                argv += ['--wait']
         if kind == 'script':
             argv += [name]
         elif kind == 'module':

--- a/tests/helpers/debugclient.py
+++ b/tests/helpers/debugclient.py
@@ -139,7 +139,12 @@ class _LifecycleClient(Closeable):
         if wait_for_connect:
             wait_for_connect()
         else:
-            wait_for_socket_server(addr)
+            try:
+                wait_for_socket_server(addr)
+            except Exception:
+                # If we fail to connect, print out the adapter output.
+                self._adapter.VERBOSE = True
+                raise
             self._attach(addr, **kwargs)
 
     def _attach(self, addr, **kwargs):
@@ -243,6 +248,8 @@ class EasyDebugClient(DebugClient):
         ] + list(argv)
         if kwargs.pop('nodebug', False):
             argv.insert(0, '--nodebug')
+        if kwargs.pop('wait', True):
+            argv.insert(0, '--wait')
         self._launch(argv, **kwargs)
         return self._adapter, self._session
 

--- a/tests/ptvsd/test___main__.py
+++ b/tests/ptvsd/test___main__.py
@@ -22,6 +22,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server(None, 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -39,6 +40,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server('10.0.1.1', 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -56,6 +58,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client(None, 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -72,6 +75,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server(None, 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -89,6 +93,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server('10.0.1.1', 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -106,6 +111,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client(None, 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -123,6 +129,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client('1.2.3.4', 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -140,6 +147,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client('localhost', 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -158,6 +166,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client('1.2.3.4', 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -175,6 +184,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server('localhost', 8888),
             'nodebug': False,
             'single_session': True,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -193,6 +203,26 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server('1.2.3.4', 8888),
             'nodebug': False,
             'single_session': True,
+            'wait': False,
+        })
+        self.assertEqual(extra, self.EXPECTED_EXTRA)
+
+    def test_remote_wait(self):
+        args, extra = parse_args([
+            'eggs',
+            '--host', '1.2.3.4',
+            '--port', '8888',
+            '--wait',
+            'spam.py',
+        ])
+
+        self.assertEqual(vars(args), {
+            'kind': 'script',
+            'name': 'spam.py',
+            'address': Address.as_client('1.2.3.4', 8888),
+            'nodebug': False,
+            'single_session': False,
+            'wait': True,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -218,6 +248,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server(None, 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, [
             '--DEBUG',
@@ -254,6 +285,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client(None, 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, [
             '--DEBUG',
@@ -281,6 +313,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server('', 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -308,6 +341,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client('1.2.3.4', 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -326,6 +360,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client('1.2.3.4', 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -343,6 +378,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server(None, 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -361,6 +397,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client(None, 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -377,6 +414,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server(None, 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -394,6 +432,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client(None, 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, self.EXPECTED_EXTRA)
 
@@ -411,6 +450,7 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_server(None, 8888),
             'nodebug': False,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, ['--module'] + self.EXPECTED_EXTRA)
 
@@ -429,5 +469,6 @@ class ParseArgsTests(unittest.TestCase):
             'address': Address.as_client(None, 8888),
             'nodebug': True,
             'single_session': False,
+            'wait': False,
         })
         self.assertEqual(extra, ['--module'] + self.EXPECTED_EXTRA)

--- a/tests/system_tests/test_connection.py
+++ b/tests/system_tests/test_connection.py
@@ -114,6 +114,7 @@ class RawConnectionTests(unittest.TestCase):
         self.addCleanup(lambda: os.close(wpipe))
         proc = Proc.start_python_module('ptvsd', [
             '--server',
+            '--wait',
             '--port', '5678',
             '--file', filename,
         ], env={


### PR DESCRIPTION
Add --wait command line argument, and don't block code execution if it is not specified.