### PR TITLE
Fix #200: Local attach

### DIFF
--- a/ptvsd/_attach.py
+++ b/ptvsd/_attach.py
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
+import os.path
+import sys
+
+import ptvsd
+import pydevd
+
+
+def attach_main(address, pid, *extra, **kwargs):
+    hostname, port_num = address
+
+    ptvsd_path = os.path.join(ptvsd.__file__, '../..')
+    pydevd_attach_to_process_path = os.path.join(
+        os.path.dirname(pydevd.__file__),
+        'pydevd_attach_to_process')
+    sys.path.append(pydevd_attach_to_process_path)
+    from add_code_to_python_process import run_python_code
+
+    # The code must not contain single quotes. Also, it might be running on
+    # a different Python version once it's injected. Encoding string literals
+    # as raw UTF-8 byte values takes care of both.
+    code = '''
+ptvsd_path = bytearray({ptvsd_path}).decode("utf-8")
+hostname = bytearray({hostname}).decode("utf-8")
+
+import sys
+sys.path.insert(0, ptvsd_path)
+import ptvsd
+del sys.path[0]
+
+from ptvsd._remote import attach
+attach((hostname, {port_num}))
+'''
+
+    code = code.format(
+        ptvsd_path=repr(list(ptvsd_path.encode('utf-8'))),
+        hostname=repr(list(hostname.encode('utf-8'))),
+        port_num=port_num)
+    run_python_code(pid, code, connect_debugger_tracing=True)

--- a/ptvsd/_remote.py
+++ b/ptvsd/_remote.py
@@ -83,3 +83,21 @@ def enable_attach(address, redirect_output=True,
                      stderrToServer=redirect_output,
                      port=port,
                      suspend=False)
+
+
+def attach(address,
+           redirect_output=True,
+           _pydevd=pydevd,
+           _install=install,
+           **kwargs):
+
+    host, port = address
+    _install(_pydevd,
+             address,
+             singlesession=False,
+             **kwargs)
+    _pydevd.settrace(host=host,
+                     port=port,
+                     stdoutToServer=redirect_output,
+                     stderrToServer=redirect_output,
+                     suspend=False)

--- a/ptvsd/attach_server.py
+++ b/ptvsd/attach_server.py
@@ -3,7 +3,9 @@
 # for license information.
 
 from ptvsd._remote import (
-    enable_attach as ptvsd_enable_attach, _pydevd_settrace,
+    attach as ptvsd_attach,
+    enable_attach as ptvsd_enable_attach,
+    _pydevd_settrace,
 )
 from ptvsd.wrapper import debugger_attached
 
@@ -69,6 +71,31 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=True):
         address,
         redirect_output=redirect_output,
     )
+
+
+def attach(address, redirect_output=True):
+    """Attaches this process to the debugger listening on a given address.
+
+    Parameters
+    ----------
+    address : (str, int), optional
+        Specifies the interface and port on which the debugger is listening
+        for TCP connections. It is in the same format as used for
+        regular sockets of the `socket.AF_INET` family, i.e. a tuple of
+        ``(hostname, port)``.
+    redirect_output : bool, optional
+        Specifies whether any output (on both `stdout` and `stderr`) produced
+        by this program should be sent to the debugger. Default is ``True``.
+    """
+    if is_attached():
+        return
+    debugger_attached.clear()
+
+    # Ensure port is int
+    port = address[1]
+    address = (address[0], port if type(port) is int else int(port))
+
+    ptvsd_attach(address, redirect_output=redirect_output)
 
 
 # TODO: Add disable_attach()?


### PR DESCRIPTION
Add --pid option to ptvsd command line. When used, injects the debugger into the process with the specified ID, such that it connects back to the specified host/port.