### PR TITLE
Added handling of unhandled exception generated when VS Code disconnects

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -890,6 +890,15 @@ class VSCodeMessageProcessorBase(ipcjson.SocketIO, ipcjson.IpcChannel):
                     _util.lock_release(self._listening)
                     _util.lock_release(self._connected)
                 self.close()
+            except socket.error as exc:
+                if exc.errno == errno.ECONNRESET:
+                    debug('client socket forcibly closed')
+                    with self._connlock:
+                        _util.lock_release(self._listening)
+                        _util.lock_release(self._connected)
+                    self.close()
+                else:
+                    raise exc
         self.server_thread = _util.new_hidden_thread(
             target=process_messages,
             name=threadname,


### PR DESCRIPTION
Detaching from a VSCode debug session via localhost:3000 on Windows 10 using the debug 'disconnect' button results in an unhandled exception in wrapper.py.

The specific unhandled error is errno.ECONNRESET (10054)

When this exception is not handled correctly, the instance of ptvsd becomes unresponsive and does not allow the debugger to connect again.

Notes:
This change fixes this issue but I can see that convert_eof() in socket.py should be handling this error and raising an EOFError exception - but for some reason it's not and a socket.error with errno == 10054 is raised instead.
 
