### PR TITLE
Fix debugging on Python 3.3.5

### DIFF
--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -616,7 +616,7 @@ class ModulesManager(object):
 
                     module = {
                         'id': module_id,
-                        'package': value.__package__,
+                        'package': value.__package__ if hasattr(value, '__package__') else None,
                         'path': module_path,
                     }
 


### PR DESCRIPTION
I don't know if this solves all the compatibility issues for this issue #210.
But with this fix, this problem is solved, and I was able to fully debug my code in Python version 3.3.5 https://github.com/Microsoft/ptvsd/issues/828