### PR TITLE
Fix #878: Propagate parent process information in child process events 

### DIFF
--- a/ptvsd/messaging.py
+++ b/ptvsd/messaging.py
@@ -134,6 +134,14 @@ class RequestFailure(Exception):
     def __init__(self, message):
         self.message = message
 
+    def __eq__(self, other):
+        if isinstance(other, RequestFailure) and other.message == self.message:
+            return True
+        return NotImplemented
+
+    def __ne__(self, other):
+        return not self == other
+
 
 class Request(object):
     """Represents a request that was sent to the other party, and is awaiting or has

--- a/ptvsd/multiproc.py
+++ b/ptvsd/multiproc.py
@@ -36,7 +36,7 @@ subprocess_queue = queue.Queue()
 initial_request = None
 
 # Process ID of the first process in the current process tree.
-initial_pid = None
+initial_pid = os.getpid()
 
 
 def enable():

--- a/ptvsd/pydevd_hooks.py
+++ b/ptvsd/pydevd_hooks.py
@@ -78,7 +78,14 @@ def get_python_c_args(host, port, indC, args, setup):
 import sys
 sys.path.append(r'{ptvsd_syspath}')
 from ptvsd import multiproc
-multiproc.init_subprocess({parent_port}, {first_port}, {last_port}, {pydevd_setup})
+multiproc.init_subprocess(
+    {initial_pid},
+    {initial_request},
+    {parent_pid},
+    {parent_port},
+    {first_port},
+    {last_port},
+    {pydevd_setup})
 {rest}
 '''
 
@@ -88,6 +95,9 @@ multiproc.init_subprocess({parent_port}, {first_port}, {last_port}, {pydevd_setu
     ptvsd_syspath = os.path.join(ptvsd.__file__, '../..')
 
     return runner.format(
+        initial_pid=multiproc.initial_pid,
+        initial_request=multiproc.initial_request,
+        parent_pid=os.getpid(),
         parent_port=multiproc.listener_port,
         first_port=first_port,
         last_port=last_port,

--- a/ptvsd/wrapper.py
+++ b/ptvsd/wrapper.py
@@ -1108,14 +1108,22 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
         self.send_event('initialized')
 
     def on_attach(self, request, args):
-        # TODO: docstring
+        if not multiproc.initial_request:
+            multiproc.initial_request = {
+                'command': 'attach',
+                'arguments': args
+            }
         self.start_reason = 'attach'
         self._set_debug_options(args)
         self._handle_attach(args)
         self.send_response(request)
 
     def on_launch(self, request, args):
-        # TODO: docstring
+        if not multiproc.initial_request:
+            multiproc.initial_request = {
+                'command': 'launch',
+                'arguments': args
+            }
         self.start_reason = 'launch'
         self._set_debug_options(args)
         self._notify_launch()
@@ -1180,6 +1188,7 @@ class VSCLifecycleMsgProcessor(VSCodeMessageProcessorBase):
                 return
             self._debuggerstopped = True
         if not self._restart_debugger:
+            multiproc.initial_request = None
             self.send_event('terminated')
 
     def _wait_until_exiting(self, timeout):

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 testpaths=pytests
-timeout=5
+timeout=15

--- a/pytests/func/test_multiproc.py
+++ b/pytests/func/test_multiproc.py
@@ -9,16 +9,18 @@ import pytest
 
 from ..helpers.pattern import ANY, Pattern
 from ..helpers.session import DebugSession
-from ..helpers.timeline import Event
+from ..helpers.timeline import Event, Request
 
 
-@pytest.mark.timeout(20)
+@pytest.mark.timeout(40)
 @pytest.mark.skipif(platform.system() != 'Windows',
                     reason='Debugging multiprocessing module only works on Windows')
 def test_multiprocessing(debug_session, pyfile):
     @pyfile
     def code_to_debug():
         import multiprocessing
+        import platform
+        import sys
 
         def child_of_child(q):
             print('entering child of child')
@@ -38,7 +40,11 @@ def test_multiprocessing(debug_session, pyfile):
 
         if __name__ == '__main__':
             import pytests.helpers.backchannel as backchannel
-            multiprocessing.set_start_method('spawn')
+            if sys.version_info >= (3, 4):
+                multiprocessing.set_start_method('spawn')
+            else:
+                assert platform.system() == 'Windows'
+
             q = multiprocessing.Queue()
             p = multiprocessing.Process(target=child, args=(q,))
             p.start()
@@ -50,37 +56,53 @@ def test_multiprocessing(debug_session, pyfile):
             assert q.get() == 4
             q.close()
 
-    debug_session.setup_backchannel()
     debug_session.multiprocess = True
-    debug_session.prepare_to_run(filename=code_to_debug)
-    debug_session.start_debugging()
+    debug_session.prepare_to_run(filename=code_to_debug, backchannel=True)
+    start = debug_session.start_debugging()
+
+    with debug_session.timeline.frozen():
+        initial_request, = debug_session.timeline.all_occurrences_of(Request('launch') | Request('attach'))
+    initial_process = (start >> Event('process')).wait()
+    initial_pid = int(initial_process.body['systemProcessId'])
 
     child_pid = debug_session.backchannel.read_json()
 
-    child_subprocess = debug_session.wait_until(Event('ptvsd_subprocess'))
-    assert child_subprocess.body in Pattern({
+    child_subprocess = (start >> Event('ptvsd_subprocess')).wait()
+    assert child_subprocess.body == Pattern({
+        'initialProcessId': initial_pid,
+        'parentProcessId': initial_pid,
         'processId': child_pid,
         'port': ANY.int,
+        'initialRequest': {
+            'command': initial_request.command,
+            'arguments': initial_request.arguments,
+        }
     })
     child_port = child_subprocess.body['port']
 
     child_session = DebugSession(method='attach_socket', ptvsd_port=child_port)
     child_session.connect()
     child_session.handshake()
-    child_session.start_debugging()
+    child_start = child_session.start_debugging()
 
-    child_child_subprocess = child_session.wait_until(Event('ptvsd_subprocess'))
-    assert child_child_subprocess.body in Pattern({
+    child_child_subprocess = (child_start >> Event('ptvsd_subprocess')).wait()
+    assert child_child_subprocess.body == Pattern({
+        'initialProcessId': initial_pid,
+        'parentProcessId': child_pid,
         'processId': ANY.int,
         'port': ANY.int,
+        'initialRequest': {
+            'command': initial_request.command,
+            'arguments': initial_request.arguments,
+        }
     })
     child_child_port = child_child_subprocess.body['port']
 
     child_child_session = DebugSession(method='attach_socket', ptvsd_port=child_child_port)
     child_child_session.connect()
     child_child_session.handshake()
-    child_child_session.start_debugging()
-    child_child_session.wait_until(Event('process'))
+    child_child_start = child_child_session.start_debugging()
+    (child_child_start >> Event('process')).wait()
 
     debug_session.backchannel.write_json('continue')
 

--- a/pytests/helpers/__init__.py
+++ b/pytests/helpers/__init__.py
@@ -11,13 +11,29 @@ import time
 import traceback
 
 
+if sys.version_info >= (3, 3):
+    clock = time.perf_counter
+else:
+    clock = time.clock
+
+
+timestamp_zero = clock()
+
+def timestamp():
+    return clock() - timestamp_zero
+
+
 print_lock = threading.Lock()
 real_print = print
 
 def print(*args, **kwargs):
-    """Like builtin print(), but synchronized using a global lock.
+    """Like builtin print(), but synchronized using a global lock,
+    and adds a timestamp
     """
+    timestamped = kwargs.pop('timestamped', True)
     with print_lock:
+        if timestamped:
+            real_print('@%09.6f: ' % timestamp(), end='')
         real_print(*args, **kwargs)
 
 

--- a/pytests/helpers/backchannel.py
+++ b/pytests/helpers/backchannel.py
@@ -14,6 +14,7 @@ import socket
 from ptvsd.messaging import JsonIOStream
 
 port = int(os.getenv('PTVSD_BACKCHANNEL_PORT'))
+# print('Connecting to bchan#%d' % port)
 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 sock.connect(('localhost', port))
 stream = JsonIOStream.from_socket(sock)

--- a/pytests/helpers/pattern.py
+++ b/pytests/helpers/pattern.py
@@ -116,12 +116,14 @@ class Maybe(BasePattern):
     """A pattern that matches if condition is True.
     """
 
+    name = None
+
     def __init__(self, pattern, condition):
         self.pattern = pattern
         self.condition = condition
 
     def __repr__(self):
-        return 'Maybe(%r)' % self.pattern
+        return self.name or 'Maybe(%r)' % self.pattern
 
     def __eq__(self, value):
         return self.condition(value) and value == self.pattern
@@ -159,7 +161,15 @@ SUCCESS = Success(True)
 FAILURE = Success(False)
 
 ANY = Any()
+
 ANY.bool = ANY.such_that(lambda x: x is True or x is False)
+ANY.bool.name = 'ANY.bool'
+
 ANY.str = ANY.such_that(lambda x: isinstance(x, unicode))
+ANY.str.name = 'ANY.str'
+
 ANY.num = ANY.such_that(lambda x: isinstance(x, numbers.Real))
+ANY.num.name = 'ANY.num'
+
 ANY.int = ANY.such_that(lambda x: isinstance(x, numbers.Integral))
+ANY.int.name = 'ANY.int'

--- a/pytests/helpers/test_pattern.py
+++ b/pytests/helpers/test_pattern.py
@@ -1,5 +1,5 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See LICENSE in the project root
+# Licensed under the MIT License. See LICENSE == the project root
 # for license information.
 
 from __future__ import print_function, with_statement, absolute_import
@@ -25,33 +25,33 @@ VALUES = [
 
 @pytest.mark.parametrize('x', VALUES)
 def test_eq(x):
-    assert x in Pattern(x)
+    assert x == Pattern(x)
 
 
 @pytest.mark.parametrize('xy', zip(VALUES[1:], VALUES[:-1]))
 def test_ne(xy):
     x, y = xy
     if x != y:
-        assert x not in Pattern(y)
+        assert x != Pattern(y)
 
 @pytest.mark.parametrize('x', VALUES)
 def test_any(x):
-    assert x in ANY
+    assert x == ANY
 
 
 def test_lists():
-    assert [1, 2, 3] not in Pattern([1, 2, 3, 4])
-    assert [1, 2, 3, 4] not in Pattern([1, 2, 3])
-    assert [2, 3, 1] not in Pattern([1, 2, 3])
-    assert [1, 2, 3] in Pattern([1, ANY, 3])
-    assert [1, 2, 3, 4] not in Pattern([1, ANY, 4])
+    assert [1, 2, 3] != Pattern([1, 2, 3, 4])
+    assert [1, 2, 3, 4] != Pattern([1, 2, 3])
+    assert [2, 3, 1] != Pattern([1, 2, 3])
+    assert [1, 2, 3] == Pattern([1, ANY, 3])
+    assert [1, 2, 3, 4] != Pattern([1, ANY, 4])
 
 
 def test_dicts():
-    assert {'a': 1, 'b': 2} not in Pattern({'a': 1, 'b': 2, 'c': 3})
-    assert {'a': 1, 'b': 2, 'c': 3} not in Pattern({'a': 1, 'b': 2})
-    assert {'a': 1, 'b': 2} in Pattern({'a': ANY, 'b': 2})
-    assert {'a': 1, 'b': 2} in Pattern(ANY.dict_with({'a': 1}))
+    assert {'a': 1, 'b': 2} != Pattern({'a': 1, 'b': 2, 'c': 3})
+    assert {'a': 1, 'b': 2, 'c': 3} != Pattern({'a': 1, 'b': 2})
+    assert {'a': 1, 'b': 2} == Pattern({'a': ANY, 'b': 2})
+    assert {'a': 1, 'b': 2} == Pattern(ANY.dict_with({'a': 1}))
 
 
 def test_maybe():
@@ -59,25 +59,25 @@ def test_maybe():
         return x != 0
 
     pattern = Pattern(1).such_that(nonzero)
-    assert 0 not in pattern
-    assert 1 in pattern
-    assert 2 not in pattern
+    assert 0 != pattern
+    assert 1 == pattern
+    assert 2 != pattern
 
     pattern = ANY.such_that(nonzero)
-    assert 0 not in pattern
-    assert 1 in pattern
-    assert 2 in pattern
+    assert 0 != pattern
+    assert 1 == pattern
+    assert 2 == pattern
 
 
 def test_success():
-    assert {} in SUCCESS
-    assert {} not in FAILURE
+    assert {} == SUCCESS
+    assert {} != FAILURE
 
 
 def test_failure():
     error = RequestFailure('error!')
-    assert error not in SUCCESS
-    assert error in FAILURE
+    assert error != SUCCESS
+    assert error == FAILURE
 
 
 class DataObject(object):
@@ -90,8 +90,8 @@ class DataObject(object):
 
 def test_data():
     something = DataObject(('Something', {'a': 1}))
-    assert something in Pattern(something.data)
-    assert something not in Pattern(('Another', {'b': 2}))
+    assert something == Pattern(something.data)
+    assert something != Pattern(('Another', {'b': 2}))
 
 
 def test_recursive():
@@ -107,7 +107,7 @@ def test_recursive():
             'bd': True,
             'be': [],
         }
-    ] in Pattern([
+    ] == Pattern([
             ANY,
             True,
             ('Something', {'a': 1}),

--- a/pytests/helpers/test_timeline.py
+++ b/pytests/helpers/test_timeline.py
@@ -10,7 +10,7 @@ import time
 
 from ptvsd.messaging import RequestFailure
 
-from .pattern import Pattern, ANY, SUCCESS, FAILURE
+from .pattern import Pattern, ANY, SUCCESS, FAILURE, Is
 from .timeline import Timeline, Mark, Event, Request, Response
 
 
@@ -25,87 +25,111 @@ def make_timeline():
 
     def factory():
         timeline = Timeline()
-        assert Mark(Pattern('begin')) in timeline
-        assert timeline.history() in Pattern([('Mark', 'begin',)])
         timelines.append(timeline)
         return timeline
 
     yield factory
 
     for timeline in timelines:
-        timeline.freeze()
-        history = list(timeline.history())
+        timeline.finalize()
+        history = timeline.history()
         history.sort(key=lambda occ: occ.timestamp)
         assert history == timeline.history()
 
 
 def history_data(timeline):
-    return [occ.__data__() for occ in timeline.history()]
+    with timeline.frozen():
+        return [occ.__data__() for occ in timeline.history()]
 
 
 def test_simple_1thread(make_timeline):
     timeline = make_timeline()
     expected_history = history_data(timeline)
-    expectations = []
+
+    with timeline.frozen():
+        assert timeline.all_occurrences_of(Mark('tada')) == ()
+        assert not Mark('tada').has_been_realized_in(timeline)
 
     mark = timeline.mark('tada')
+    expected_history += [('Mark', 'tada')]
+
     assert mark.circumstances == ('Mark', 'tada')
     assert mark.id == 'tada'
-    expectations += [Mark('tada')]
-    assert expectations in timeline
-    expected_history += [('Mark', 'tada')]
-    assert timeline.history() in Pattern(expected_history)
+    with timeline.frozen():
+        assert timeline.history() == Pattern(expected_history)
+        assert timeline.all_occurrences_of(Mark('tada')) == Pattern((Is(mark),))
+        assert timeline.last is mark
+        assert Mark('tada').has_been_realized_in(timeline)
 
     request = timeline.record_request('next', {'threadId': 3})
+    expected_history += [('Request', 'next', {'threadId': 3})]
+
     assert request.circumstances == ('Request', 'next', {'threadId': 3})
     assert request.command == 'next'
     assert request.arguments == {'threadId': 3}
-    expectations += [Request('next', {'threadId': 3})]
-    assert expectations in timeline
-    expected_history += [('Request', 'next', {'threadId': 3})]
-    assert timeline.history() in Pattern(expected_history)
+    with timeline.frozen():
+        assert timeline.history() == Pattern(expected_history)
+        assert timeline.last is request
+        assert Request('next', {'threadId': 3}).has_been_realized_in(timeline)
+        assert timeline.all_occurrences_of(Request('next', {'threadId': 3})) == Pattern((Is(request),))
 
     response = timeline.record_response(request, {})
-    assert response.circumstances == ('Response', request, {})
+    expected_history += [('Response', Is(request), {})]
+
+    assert response.circumstances == Pattern(('Response', Is(request), {}))
     assert response.request is request
     assert response.body == {}
     assert response.success
-    expectations += [
+    expectations = [
         Response(request, {}),
         Response(request, SUCCESS),
+        Response(request),
         Response(Request('next', {'threadId': 3}), {}),
         Response(Request('next', {'threadId': 3}), SUCCESS),
+        Response(Request('next', {'threadId': 3})),
     ]
-    assert expectations in timeline
-    expected_history += [('Response', request, {})]
-    assert timeline.history() in Pattern(expected_history)
+    with timeline.frozen():
+        assert timeline.history() == Pattern(expected_history)
+        assert timeline.last is response
+        for exp in expectations:
+            print(exp)
+            assert exp.has_been_realized_in(timeline)
+            print(timeline.all_occurrences_of(exp))
+            assert timeline.all_occurrences_of(exp) == Pattern((Is(response),))
 
     event = timeline.record_event('stopped', {'reason': 'pause'})
-    assert event.circumstances == ('Event', 'stopped', {'reason': 'pause'})
-    expectations += [Event('stopped', {'reason': 'pause'})]
-    assert expectations in timeline
     expected_history += [('Event', 'stopped', {'reason': 'pause'})]
-    assert timeline.history() in Pattern(expected_history)
 
-    request = timeline.record_request('next', {'threadId': 6})
+    assert event.circumstances == ('Event', 'stopped', {'reason': 'pause'})
+    with timeline.frozen():
+        assert timeline.last is event
+        assert timeline.history() == Pattern(expected_history)
+        assert Event('stopped', {'reason': 'pause'}).has_been_realized_in(timeline)
+        assert timeline.all_occurrences_of(Event('stopped', {'reason': 'pause'})) == Pattern((Is(event),))
+
+    request2 = timeline.record_request('next', {'threadId': 6})
     expected_history += [('Request', 'next', {'threadId': 6})]
+    response2 = timeline.record_response(request2, RequestFailure('error!'))
+    expected_history += [('Response', Is(request2), FAILURE)]
 
-    response = timeline.record_response(request, RequestFailure('error!'))
-    assert response.circumstances in Pattern((
-        'Response',
-        request,
-        ANY.such_that(lambda err: isinstance(err, RequestFailure) and err.message == 'error!')
-    ))
-    assert response.request is request
-    assert isinstance(response.body, RequestFailure) and response.body.message == 'error!'
-    assert not response.success
-    expectations += [
-        Response(request, FAILURE),
+    assert response2.circumstances == Pattern(('Response', Is(request2), FAILURE))
+    assert response2.request is request2
+    assert isinstance(response2.body, RequestFailure) and response2.body.message == 'error!'
+    assert not response2.success
+    expectations = [
+        Response(request2, RequestFailure('error!')),
+        Response(request2, FAILURE),
+        Response(request2),
+        Response(Request('next', {'threadId': 6}), RequestFailure('error!')),
         Response(Request('next', {'threadId': 6}), FAILURE),
+        Response(Request('next', {'threadId': 6})),
     ]
-    assert expectations in timeline
-    expected_history += [('Response', request, FAILURE)]
-    assert timeline.history() in Pattern(expected_history)
+    with timeline.frozen():
+        for exp in expectations:
+            print(exp)
+            assert exp.has_been_realized_in(timeline)
+            assert timeline.all_occurrences_of(exp) == Pattern((Is(response2),))
+        assert timeline.all_occurrences_of(Response(Request('next'))) == Pattern((Is(response), Is(response2)))
 
 
 @pytest.mark.parametrize('occurs_before_wait', (True, False))
@@ -146,34 +170,93 @@ def test_simple_mthread(make_timeline, daemon, occurs_before_wait):
                 thev.set()
             threading.Thread(target=set_later).start()
 
+    t = timeline.beginning
+
     advance_worker()
     expectation = Mark('tada')
-    timeline.wait_until(expectation)
-    assert expectation in timeline
     expected_history += [('Mark', 'tada')]
-    assert timeline.history() in Pattern(expected_history)
+    t = t.await_following(expectation)
+
+    with timeline.frozen():
+        assert expectation.has_been_realized_in(timeline)
+        assert timeline.history() == Pattern(expected_history)
 
     advance_worker()
-    expectation = Request('next', {'threadId': 3})
-    timeline.wait_until(expectation)
-    assert expectation in timeline
     expected_history += [('Request', 'next', {'threadId': 3})]
-    assert timeline.history() in Pattern(expected_history)
-    request = occurrences[-1]
+    expectation = Request('next', {'threadId': 3})
+    t = t.await_following(expectation)
+
+    with timeline.frozen():
+        assert expectation.has_been_realized_in(timeline)
+        assert timeline.history() == Pattern(expected_history)
+        request = occurrences[-1]
+        assert request is t
 
     advance_worker()
-    expectation = Response(request, {}) & Response(Request('next', {'threadId': 3}), {})
-    timeline.wait_until(expectation)
-    assert expectation in timeline
     expected_history += [('Response', request, {})]
-    assert timeline.history() in Pattern(expected_history)
+    expectation = Response(request, {}) & Response(Request('next', {'threadId': 3}), {})
+    t = t.await_following(expectation)
+
+    with timeline.frozen():
+        assert expectation.has_been_realized_in(timeline)
+        assert timeline.history() == Pattern(expected_history)
 
     advance_worker()
-    expectation = Event('stopped', {'reason': 'pause'})
-    timeline.wait_until(expectation)
-    assert expectation in timeline
     expected_history += [('Event', 'stopped', {'reason': 'pause'})]
-    assert timeline.history() in Pattern(expected_history)
+    expectation = Event('stopped', {'reason': 'pause'})
+
+    with timeline.frozen():
+        t = t.await_following(expectation)
+        assert expectation.has_been_realized_in(timeline)
+        assert timeline.history() == Pattern(expected_history)
+
+
+def test_after(make_timeline):
+    timeline = make_timeline()
+    first = timeline.mark('first')
+
+    second_exp = first >> Mark('second')
+    with timeline.frozen():
+        assert second_exp not in timeline
+
+    timeline.mark('second')
+    with timeline.frozen():
+        assert second_exp in timeline
+
+
+def test_before(make_timeline):
+    timeline = make_timeline()
+    t = timeline.beginning
+
+    first = timeline.mark('first')
+    timeline.mark('second')
+
+    with timeline.frozen():
+        assert t >> Mark('second') >> Mark('first') not in timeline
+        assert Mark('second') >> first not in timeline
+
+    third = timeline.mark('third')
+
+    with timeline.frozen():
+        assert t >> Mark('second') >> Mark('first') not in timeline
+        assert Mark('second') >> first not in timeline
+        assert t >> Mark('second') >> Mark('third') in timeline
+        assert Mark('second') >> third in timeline
+
+
+def test_not(make_timeline):
+    timeline = make_timeline()
+    timeline.mark('other')
+
+    with timeline.frozen():
+        assert timeline.beginning >> ~Mark('something') in timeline
+        t = timeline.last
+
+    timeline.mark('something')
+
+    with timeline.frozen():
+        assert timeline.beginning >> ~Mark('something') in timeline
+        assert t >> ~Mark('something') not in timeline
 
 
 def test_and(make_timeline):
@@ -182,24 +265,30 @@ def test_and(make_timeline):
     cheese_exp = Mark('cheese')
 
     timeline = make_timeline()
-    assert eggs_exp & ham_exp not in timeline
-    assert ham_exp & eggs_exp not in timeline
-    assert cheese_exp & ham_exp & eggs_exp not in timeline
+    t = timeline.beginning
+
+    with timeline.frozen():
+        assert t >> (eggs_exp & ham_exp) not in timeline
+        assert t >> (ham_exp & eggs_exp) not in timeline
+        assert t >> (cheese_exp & ham_exp & eggs_exp) not in timeline
 
     timeline.mark('eggs')
-    assert eggs_exp & ham_exp not in timeline
-    assert ham_exp & eggs_exp not in timeline
-    assert cheese_exp & ham_exp & eggs_exp not in timeline
+    with timeline.frozen():
+        assert t >> (eggs_exp & ham_exp) not in timeline
+        assert t >> (ham_exp & eggs_exp) not in timeline
+        assert t >> (cheese_exp & ham_exp & eggs_exp) not in timeline
 
     timeline.mark('ham')
-    assert eggs_exp & ham_exp in timeline
-    assert ham_exp & eggs_exp in timeline
-    assert cheese_exp & ham_exp & eggs_exp not in timeline
+    with timeline.frozen():
+        assert t >> (eggs_exp & ham_exp) in timeline
+        assert t >> (ham_exp & eggs_exp) in timeline
+        assert t >> (cheese_exp & ham_exp & eggs_exp) not in timeline
 
     timeline.mark('cheese')
-    assert eggs_exp & ham_exp in timeline
-    assert ham_exp & eggs_exp in timeline
-    assert cheese_exp & ham_exp & eggs_exp in timeline
+    with timeline.frozen():
+        assert t >> (eggs_exp & ham_exp) in timeline
+        assert t >> (ham_exp & eggs_exp) in timeline
+        assert t >> (cheese_exp & ham_exp & eggs_exp) in timeline
 
 
 def test_or(make_timeline):
@@ -208,33 +297,37 @@ def test_or(make_timeline):
     cheese_exp = Mark('cheese')
 
     timeline = make_timeline()
-    assert eggs_exp | ham_exp not in timeline
-    assert ham_exp | eggs_exp not in timeline
-    assert cheese_exp | ham_exp | eggs_exp not in timeline
+    t = timeline.beginning
+
+    with timeline.frozen():
+        assert t >> (eggs_exp | ham_exp) not in timeline
+        assert t >> (ham_exp | eggs_exp) not in timeline
+        assert t >> (cheese_exp | ham_exp | eggs_exp) not in timeline
 
     timeline.mark('eggs')
-    assert eggs_exp | ham_exp in timeline
-    assert ham_exp | eggs_exp in timeline
-    assert cheese_exp | ham_exp | eggs_exp in timeline
+    with timeline.frozen():
+        assert t >> (eggs_exp | ham_exp) in timeline
+        assert t >> (ham_exp | eggs_exp) in timeline
+        assert t >> (cheese_exp | ham_exp | eggs_exp) in timeline
 
     timeline.mark('cheese')
-    assert eggs_exp | ham_exp in timeline
-    assert ham_exp | eggs_exp in timeline
-    assert cheese_exp | ham_exp | eggs_exp in timeline
-
-    timeline = make_timeline()
+    with timeline.frozen():
+        assert t >> (eggs_exp | ham_exp) in timeline
+        assert t >> (ham_exp | eggs_exp) in timeline
+        assert t >> (cheese_exp | ham_exp | eggs_exp) in timeline
 
     timeline.mark('ham')
-    assert eggs_exp | ham_exp in timeline
-    assert ham_exp | eggs_exp in timeline
-    assert cheese_exp | ham_exp | eggs_exp in timeline
-
-    timeline = make_timeline()
+    with timeline.frozen():
+        assert t >> (eggs_exp | ham_exp) in timeline
+        assert t >> (ham_exp | eggs_exp) in timeline
+        assert t >> (cheese_exp | ham_exp | eggs_exp) in timeline
+        t = timeline.last
 
     timeline.mark('cheese')
-    assert eggs_exp | ham_exp not in timeline
-    assert ham_exp | eggs_exp not in timeline
-    assert cheese_exp | ham_exp | eggs_exp in timeline
+    with timeline.frozen():
+        assert t >> (eggs_exp | ham_exp) not in timeline
+        assert t >> (ham_exp | eggs_exp) not in timeline
+        assert t >> (cheese_exp | ham_exp | eggs_exp) in timeline
 
 
 def test_xor(make_timeline):
@@ -243,60 +336,44 @@ def test_xor(make_timeline):
     cheese_exp = Mark('cheese')
 
     timeline = make_timeline()
-    assert eggs_exp ^ ham_exp not in timeline
-    assert ham_exp ^ eggs_exp not in timeline
-    assert cheese_exp ^ ham_exp ^ eggs_exp not in timeline
+    t1 = timeline.beginning
+
+    with timeline.frozen():
+        assert t1 >> (eggs_exp ^ ham_exp) not in timeline
+        assert t1 >> (ham_exp ^ eggs_exp) not in timeline
+        assert t1 >> (cheese_exp ^ ham_exp ^ eggs_exp) not in timeline
 
     timeline.mark('eggs')
-    assert eggs_exp ^ ham_exp in timeline
-    assert ham_exp ^ eggs_exp in timeline
-    assert cheese_exp ^ ham_exp ^ eggs_exp in timeline
+    with timeline.frozen():
+        assert t1 >> (eggs_exp ^ ham_exp) in timeline
+        assert t1 >> (ham_exp ^ eggs_exp) in timeline
+        assert t1 >> (cheese_exp ^ ham_exp ^ eggs_exp) in timeline
+        t2 = timeline.last
 
     timeline.mark('ham')
-    assert eggs_exp ^ ham_exp not in timeline
-    assert ham_exp ^ eggs_exp not in timeline
-    assert cheese_exp ^ ham_exp ^ eggs_exp not in timeline
+    with timeline.frozen():
+        assert t1 >> (eggs_exp ^ ham_exp) in timeline
+        assert t2 >> (eggs_exp ^ ham_exp) not in timeline
+        assert t1 >> (ham_exp ^ eggs_exp) in timeline
+        assert t2 >> (ham_exp ^ eggs_exp) not in timeline
+        assert t1 >> (cheese_exp ^ ham_exp ^ eggs_exp) in timeline
+        assert t2 >> (cheese_exp ^ ham_exp ^ eggs_exp) not in timeline
 
 
 def test_conditional(make_timeline):
     def is_exciting(occ):
-        return occ.circumstances in Pattern(('Event', ANY, 'exciting'))
+        return occ.circumstances == Pattern(('Event', ANY, 'exciting'))
 
     something = Event('something', ANY)
     something_exciting = something.when(is_exciting)
     timeline = make_timeline()
+    t = timeline.beginning
 
     timeline.record_event('something', 'boring')
-    assert something in timeline
-    assert something_exciting not in timeline
+    with timeline.frozen():
+        assert t >> something in timeline
+        assert t >> something_exciting not in timeline
 
     timeline.record_event('something', 'exciting')
-    assert something_exciting in timeline
-
-
-def test_after(make_timeline):
-    timeline = make_timeline()
-    first = timeline.mark('first')
-
-    second_exp = first >> Mark('second')
-    assert second_exp not in timeline
-
-    timeline.mark('second')
-    assert second_exp in timeline
-
-
-def test_before(make_timeline):
-    timeline = make_timeline()
-    first = timeline.mark('first')
-
-    timeline.mark('second')
-    assert Mark('second') >> Mark('first') not in timeline
-    assert Mark('second') >> first not in timeline
-
-    third = timeline.mark('third')
-    assert Mark('second') >> Mark('first') not in timeline
-    assert Mark('second') >> first not in timeline
-    assert Mark('second') >> Mark('third') in timeline
-    assert Mark('second') >> third in timeline
-
-
+    with timeline.frozen():
+        assert t >> something_exciting in timeline

--- a/pytests/helpers/timeline.py
+++ b/pytests/helpers/timeline.py
@@ -52,16 +52,6 @@ class Timeline(object):
         )
         return expectation.has_been_realized_in(self)
 
-    def __getitem__(self, index):
-        assert index is slice
-        assert index.step is None
-        start = index.start or self.beginning
-        stop = index.stop
-        if stop is None:
-            assert self._is_frozen
-            stop = self._last
-        return self.Interval(self, start, stop)
-
     def wait_until(self, condition):
         with self._cvar:
             while True:
@@ -156,27 +146,6 @@ class Timeline(object):
         occ.event = event
         occ.body = body
         return occ
-
-    class Interval(tuple):
-        def __init__(self, timeline, start, stop):
-            assert isinstance(start, Occurrence)
-            assert isinstance(stop, Occurrence)
-
-            if start is stop:
-                occs = ()
-            else:
-                assert start < stop
-                occs = tuple(self.start.and_following(until=self.stop))
-            super(Timeline.Interval, self).__init__(occs)
-
-            self.timeline = timeline
-            self.start = start
-            self.stop = stop
-
-        def __contains__(self, expectation):
-            occs = [occ for occ in self if expectation.is_realized_by(occ)]
-            occs.reverse()
-            return tuple(occs)
 
 
 class Expectation(object):


### PR DESCRIPTION
Plus a major test framework refactoring to deal with various issues discovered while writing a test for this.