### PR TITLE
fix json comments syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ while True:
 
 ## Custom Protocol arguments
 ### Launch request arguments
-```json
+```js
 {
     "debugOptions":  [
             "RedirectOutput",       // Whether to redirect stdout and stderr (see pydevd_comm.CMD_REDIRECT_OUTPUT)
@@ -86,7 +86,7 @@ while True:
 ```
 
 ### Attach request arguments
-```json
+```js
 {
     "debugOptions":  [
             "RedirectOutput",       // Whether to redirect stdout and stderr (see pydevd_comm.CMD_REDIRECT_OUTPUT)


### PR DESCRIPTION
this fixes the json comments being highlighted as error in README.md 