### PR TITLE
Refactor timeline

### DIFF
--- a/ptvsd/compat.py
+++ b/ptvsd/compat.py
@@ -7,17 +7,22 @@
 
 try:
     import builtins
-except:
-    import __builtin__ as builtins
+except ImportError:
+    import __builtin__ as builtins # noqa
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue # noqa
 
 try:
     unicode = builtins.unicode
     bytes = builtins.str
-except:
+except AttributeError:
     unicode = builtins.str
     bytes = builtins.bytes
 
 try:
     xrange = builtins.xrange
-except:
+except AttributeError:
     xrange = builtins.range

--- a/pytests/__init__.py
+++ b/pytests/__init__.py
@@ -4,6 +4,14 @@
 
 __doc__ = """pytest-based ptvsd tests."""
 
+import colorama
 import pytest
 
+# This is only imported to ensure that the module is actually installed and the
+# timeout setting in pytest.ini is active, since otherwise most timeline-based
+# tests will hang indefinitely.
+import pytest_timeout # noqa
+
+
+colorama.init()
 pytest.register_assert_rewrite('pytests.helpers')

--- a/pytests/conftest.py
+++ b/pytests/conftest.py
@@ -10,7 +10,6 @@ import threading
 import types
 
 from . import helpers
-from .helpers import print
 from .helpers.session import DebugSession
 
 
@@ -30,8 +29,7 @@ def pytest_runtest_makereport(item, call):
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)
 def pytest_pyfunc_call(pyfuncitem):
     # Resets the timestamp zero for every new test.
-    print('Timestamp clock reset to zero.', timestamped=False)
-    helpers.timestamp_zero = helpers.timestamp()
+    helpers.timestamp_zero = helpers.clock()
     yield
 
 

--- a/pytests/helpers/__init__.py
+++ b/pytests/helpers/__init__.py
@@ -11,8 +11,8 @@ import time
 import traceback
 
 
-if sys.version_info >= (3, 3):
-    clock = time.perf_counter
+if sys.version_info >= (3, 5):
+    clock = time.monotonic
 else:
     clock = time.clock
 
@@ -30,10 +30,14 @@ def print(*args, **kwargs):
     """Like builtin print(), but synchronized using a global lock,
     and adds a timestamp
     """
+    from . import colors
     timestamped = kwargs.pop('timestamped', True)
     with print_lock:
         if timestamped:
-            real_print('@%09.6f: ' % timestamp(), end='')
+            t = timestamp()
+            real_print(colors.LIGHT_BLACK, end='')
+            real_print('@%09.6f: ' % t, end='')
+            real_print(colors.RESET, end='')
         real_print(*args, **kwargs)
 
 

--- a/pytests/helpers/colors.py
+++ b/pytests/helpers/colors.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See LICENSE in the project root
+# for license information.
+
+from __future__ import print_function, with_statement, absolute_import
+
+from colorama import Fore
+from pygments import highlight, lexers, formatters, token
+
+
+# Colors that are commented out don't work with PowerShell.
+RESET = Fore.RESET
+BLACK = Fore.BLACK
+BLUE = Fore.BLUE
+CYAN = Fore.CYAN
+GREEN = Fore.GREEN
+# MAGENTA = Fore.MAGENTA
+RED = Fore.RED
+WHITE = Fore.WHITE
+# YELLOW = Fore.YELLOW
+LIGHT_BLACK = Fore.LIGHTBLACK_EX
+LIGHT_BLUE = Fore.LIGHTBLUE_EX
+LIGHT_CYAN = Fore.LIGHTCYAN_EX
+LIGHT_GREEN = Fore.LIGHTGREEN_EX
+LIGHT_MAGENTA = Fore.LIGHTMAGENTA_EX
+LIGHT_RED = Fore.LIGHTRED_EX
+LIGHT_WHITE = Fore.LIGHTWHITE_EX
+LIGHT_YELLOW = Fore.LIGHTYELLOW_EX
+
+
+color_scheme = {
+    token.Token: ('white', 'white'),
+    token.Punctuation: ('', ''),
+    token.Operator: ('', ''),
+    token.Literal: ('brown', 'brown'),
+    token.Keyword: ('brown', 'brown'),
+    token.Name: ('white', 'white'),
+    token.Name.Constant: ('brown', 'brown'),
+    token.Name.Attribute: ('brown', 'brown'),
+    # token.Name.Tag: ('white', 'white'),
+    # token.Name.Function: ('white', 'white'),
+    # token.Name.Variable: ('white', 'white'),
+}
+
+formatter = formatters.TerminalFormatter(colorscheme=color_scheme)
+json_lexer = lexers.JsonLexer()
+python_lexer = lexers.PythonLexer()
+
+
+def colorize_json(s):
+    return highlight(s, json_lexer, formatter).rstrip()
+
+
+def color_repr(obj):
+    return highlight(repr(obj), python_lexer, formatter).rstrip()
+
+

--- a/pytests/helpers/messaging.py
+++ b/pytests/helpers/messaging.py
@@ -5,8 +5,9 @@
 from __future__ import print_function, with_statement, absolute_import
 
 import itertools
+import json
 
-from . import print
+from . import print, colors
 
 
 class JsonMemoryStream(object):
@@ -49,11 +50,11 @@ class LoggingJsonStream(object):
 
     def read_json(self):
         value = self.stream.read_json()
-        print('%s --> %r' % (self.id, value))
+        s = colors.colorize_json(json.dumps(value))
+        print('%s%s --> %s%s' % (colors.LIGHT_CYAN, self.id, colors.RESET, s))
         return value
 
     def write_json(self, value):
-        print('%s <-- %r' % (self.id, value))
+        s = colors.colorize_json(json.dumps(value))
+        print('%s%s <-- %s%s' % (colors.LIGHT_CYAN, self.id, colors.RESET, s))
         self.stream.write_json(value)
-
-

--- a/pytests/helpers/pattern.py
+++ b/pytests/helpers/pattern.py
@@ -107,7 +107,7 @@ class Any(BasePattern):
         """
         class AnyDictWith(defaultdict):
             def __repr__(self):
-                return repr(items)[:-1] + ', ...}'
+                return repr(dict(items))[:-1] + ', ...}'
         items = AnyDictWith(lambda: ANY, items)
         return items
 

--- a/pytests/helpers/session.py
+++ b/pytests/helpers/session.py
@@ -160,7 +160,6 @@ class DebugSession(object):
             'output': 'ptvsd',
             'data': {'version': ptvsd.__version__}
         })
-        self.proceed()
 
         if perform_handshake:
             return self.handshake()
@@ -285,7 +284,6 @@ class DebugSession(object):
 
         self.send_request('initialize', {'adapterID': 'test'}).wait_for_response()
         self.wait_for_next(Event('initialized', {}))
-        self.proceed()
 
         request = 'launch' if self.method == 'launch' else 'attach'
         self.send_request(request, {'debugOptions': self.debug_options}).wait_for_response()

--- a/pytests/helpers/test_timeline.py
+++ b/pytests/helpers/test_timeline.py
@@ -15,9 +15,9 @@ from .timeline import Timeline, Mark, Event, Request, Response
 
 
 @pytest.fixture
-def make_timeline():
+def make_timeline(request):
     """Provides a timeline factory. All timelines created by this factory
-    are automatically frozen and checked for basic consistency after the
+    are automatically finalized and checked for basic consistency after the
     end of the test.
     """
 
@@ -26,193 +26,147 @@ def make_timeline():
     def factory():
         timeline = Timeline()
         timelines.append(timeline)
-        return timeline
+        with timeline.frozen():
+            assert timeline.beginning is not None
+            initial_history = [Is(timeline.beginning)]
+            assert timeline.history() == Pattern(initial_history)
+        return timeline, initial_history
 
     yield factory
 
-    for timeline in timelines:
+    try:
+        failed = request.node.call_result.failed
+    except AttributeError:
+        pass
+    else:
+        if not failed:
+            for timeline in timelines:
+                timeline.finalize()
+                history = timeline.history()
+                history.sort(key=lambda occ: occ.timestamp)
+                assert history == timeline.history()
+                assert history[-1] == Mark('finalized')
+                timeline.close()
+
+
+@pytest.mark.timeout(1)
+def test_occurrences(make_timeline):
+    timeline, initial_history = make_timeline()
+
+    mark1 = timeline.mark('dum')
+    mark2 = timeline.mark('dee')
+    mark3 = timeline.mark('dum')
+
+    assert mark1 == Mark('dum')
+    assert mark1.id == 'dum'
+    assert mark2 == Mark('dee')
+    assert mark2.id == 'dee'
+    assert mark3 == Mark('dum')
+    assert mark3.id == 'dum'
+
+    with timeline.frozen():
+        assert timeline.history() == Pattern(initial_history + [Is(mark1), Is(mark2), Is(mark3)])
         timeline.finalize()
-        history = timeline.history()
-        history.sort(key=lambda occ: occ.timestamp)
-        assert history == timeline.history()
+
+    assert timeline.all_occurrences_of(Mark('dum')) == Pattern((Is(mark1), Is(mark3)))
+    assert timeline.all_occurrences_of(Mark('dee')) == Pattern((Is(mark2),))
+
+    assert timeline[:].all_occurrences_of(Mark('dum')) == Pattern((Is(mark1), Is(mark3)))
+
+    # Lower boundary is inclusive.
+    assert timeline[mark1:].all_occurrences_of(Mark('dum')) == Pattern((Is(mark1), Is(mark3)))
+    assert timeline[mark2:].all_occurrences_of(Mark('dum')) == Pattern((Is(mark3),))
+    assert timeline[mark3:].all_occurrences_of(Mark('dum')) == Pattern((Is(mark3),))
+
+    # Upper boundary is exclusive.
+    assert timeline[:mark1].all_occurrences_of(Mark('dum')) == ()
+    assert timeline[:mark2].all_occurrences_of(Mark('dum')) == Pattern((Is(mark1),))
+    assert timeline[:mark3].all_occurrences_of(Mark('dum')) == Pattern((Is(mark1),))
 
 
-def history_data(timeline):
+def test_event(make_timeline):
+    timeline, initial_history = make_timeline()
+
+    event = timeline.record_event('stopped', {'reason': 'pause'})
+    assert event.circumstances == ('Event', 'stopped', {'reason': 'pause'})
+
     with timeline.frozen():
-        return [occ.__data__() for occ in timeline.history()]
+        assert timeline.last is event
+        assert timeline.history() == Pattern(initial_history + [Is(event)])
+        timeline.expect_realized(Event('stopped', {'reason': 'pause'}))
 
 
-def test_simple_1thread(make_timeline):
-    timeline = make_timeline()
-    expected_history = history_data(timeline)
-
-    with timeline.frozen():
-        assert timeline.all_occurrences_of(Mark('tada')) == ()
-        assert not Mark('tada').has_been_realized_in(timeline)
-
-    mark = timeline.mark('tada')
-    expected_history += [('Mark', 'tada')]
-
-    assert mark.circumstances == ('Mark', 'tada')
-    assert mark.id == 'tada'
-    with timeline.frozen():
-        assert timeline.history() == Pattern(expected_history)
-        assert timeline.all_occurrences_of(Mark('tada')) == Pattern((Is(mark),))
-        assert timeline.last is mark
-        assert Mark('tada').has_been_realized_in(timeline)
+@pytest.mark.parametrize('outcome', ['success', 'failure'])
+def test_request_response(make_timeline, outcome):
+    timeline, initial_history = make_timeline()
 
     request = timeline.record_request('next', {'threadId': 3})
-    expected_history += [('Request', 'next', {'threadId': 3})]
+    request_expectation = Request('next', {'threadId': 3})
 
+    assert request == request_expectation
     assert request.circumstances == ('Request', 'next', {'threadId': 3})
     assert request.command == 'next'
     assert request.arguments == {'threadId': 3}
+
     with timeline.frozen():
-        assert timeline.history() == Pattern(expected_history)
         assert timeline.last is request
-        assert Request('next', {'threadId': 3}).has_been_realized_in(timeline)
-        assert timeline.all_occurrences_of(Request('next', {'threadId': 3})) == Pattern((Is(request),))
+        assert timeline.history() == Pattern(initial_history + [Is(request)])
+        timeline.expect_realized(Request('next'))
+        timeline.expect_realized(Request('next', {'threadId': 3}))
 
-    response = timeline.record_response(request, {})
-    expected_history += [('Response', Is(request), {})]
+    response_body = {} if outcome == 'success' else RequestFailure('error!')
+    response = timeline.record_response(request, response_body)
 
-    assert response.circumstances == Pattern(('Response', Is(request), {}))
+    assert response == Response(request, response_body)
+    assert response == Response(request, ANY)
+    if outcome == 'success':
+        assert response == Response(request, SUCCESS)
+        assert response != Response(request, FAILURE)
+    else:
+        assert response != Response(request, SUCCESS)
+        assert response == Response(request, FAILURE)
+
+    assert response == Response(request_expectation, response_body)
+    assert response == Response(request_expectation, ANY)
+    if outcome == 'success':
+        assert response == Response(request_expectation, SUCCESS)
+        assert response != Response(request_expectation, FAILURE)
+    else:
+        assert response != Response(request_expectation, SUCCESS)
+        assert response == Response(request_expectation, FAILURE)
+
+    assert response.circumstances == Pattern(('Response', Is(request), response_body))
     assert response.request is request
-    assert response.body == {}
-    assert response.success
-    expectations = [
-        Response(request, {}),
-        Response(request, SUCCESS),
-        Response(request),
-        Response(Request('next', {'threadId': 3}), {}),
-        Response(Request('next', {'threadId': 3}), SUCCESS),
-        Response(Request('next', {'threadId': 3})),
-    ]
+    assert response.body == response_body
+    if outcome == 'success':
+        assert response.success
+    else:
+        assert not response.success
+
     with timeline.frozen():
-        assert timeline.history() == Pattern(expected_history)
         assert timeline.last is response
-        for exp in expectations:
-            print(exp)
-            assert exp.has_been_realized_in(timeline)
-            print(timeline.all_occurrences_of(exp))
-            assert timeline.all_occurrences_of(exp) == Pattern((Is(response),))
-
-    event = timeline.record_event('stopped', {'reason': 'pause'})
-    expected_history += [('Event', 'stopped', {'reason': 'pause'})]
-
-    assert event.circumstances == ('Event', 'stopped', {'reason': 'pause'})
-    with timeline.frozen():
-        assert timeline.last is event
-        assert timeline.history() == Pattern(expected_history)
-        assert Event('stopped', {'reason': 'pause'}).has_been_realized_in(timeline)
-        assert timeline.all_occurrences_of(Event('stopped', {'reason': 'pause'})) == Pattern((Is(event),))
-
-    request2 = timeline.record_request('next', {'threadId': 6})
-    expected_history += [('Request', 'next', {'threadId': 6})]
-    response2 = timeline.record_response(request2, RequestFailure('error!'))
-    expected_history += [('Response', Is(request2), FAILURE)]
-
-    assert response2.circumstances == Pattern(('Response', Is(request2), FAILURE))
-    assert response2.request is request2
-    assert isinstance(response2.body, RequestFailure) and response2.body.message == 'error!'
-    assert not response2.success
-    expectations = [
-        Response(request2, RequestFailure('error!')),
-        Response(request2, FAILURE),
-        Response(request2),
-        Response(Request('next', {'threadId': 6}), RequestFailure('error!')),
-        Response(Request('next', {'threadId': 6}), FAILURE),
-        Response(Request('next', {'threadId': 6})),
-    ]
-    with timeline.frozen():
-        for exp in expectations:
-            print(exp)
-            assert exp.has_been_realized_in(timeline)
-            assert timeline.all_occurrences_of(exp) == Pattern((Is(response2),))
-        assert timeline.all_occurrences_of(Response(Request('next'))) == Pattern((Is(response), Is(response2)))
-
-
-@pytest.mark.parametrize('occurs_before_wait', (True, False))
-def test_simple_mthread(make_timeline, daemon, occurs_before_wait):
-    timeline = make_timeline()
-    expected_history = history_data(timeline)
-    thev = threading.Event()
-    occurrences = []
-
-    @daemon
-    def worker():
-        thev.wait()
-        thev.clear()
-        mark = timeline.mark('tada')
-        occurrences.append(mark)
-
-        thev.wait()
-        thev.clear()
-        request = timeline.record_request('next', {'threadId': 3})
-        occurrences.append(request)
-
-        thev.wait()
-        thev.clear()
-        response = timeline.record_response(request, {})
-        occurrences.append(response)
-
-        thev.wait()
-        thev.clear()
-        event = timeline.record_event('stopped', {'reason': 'pause'})
-        occurrences.append(event)
-
-    def advance_worker():
-        if occurs_before_wait:
-            thev.set()
+        assert timeline.history() == Pattern(initial_history + [Is(request), Is(response)])
+        timeline.expect_realized(Response(request, response_body))
+        timeline.expect_realized(Response(request, ANY))
+        if outcome == 'success':
+            timeline.expect_realized(Response(request, SUCCESS))
+            timeline.expect_not_realized(Response(request, FAILURE))
         else:
-            def set_later():
-                time.sleep(0.1)
-                thev.set()
-            threading.Thread(target=set_later).start()
+            timeline.expect_not_realized(Response(request, SUCCESS))
+            timeline.expect_realized(Response(request, FAILURE))
 
-    t = timeline.beginning
-
-    advance_worker()
-    expectation = Mark('tada')
-    expected_history += [('Mark', 'tada')]
-    t = (t >> expectation).wait()
-
-    with timeline.frozen():
-        assert expectation.has_been_realized_in(timeline)
-        assert timeline.history() == Pattern(expected_history)
-
-    advance_worker()
-    expected_history += [('Request', 'next', {'threadId': 3})]
-    expectation = Request('next', {'threadId': 3})
-    t = (t >> expectation).wait()
-
-    with timeline.frozen():
-        assert expectation.has_been_realized_in(timeline)
-        assert timeline.history() == Pattern(expected_history)
-        request = occurrences[-1]
-        assert request is t
-
-    advance_worker()
-    expected_history += [('Response', request, {})]
-    expectation = Response(request, {}) & Response(Request('next', {'threadId': 3}), {})
-    t = (t >> expectation).wait()
-
-    with timeline.frozen():
-        assert expectation.has_been_realized_in(timeline)
-        assert timeline.history() == Pattern(expected_history)
-
-    advance_worker()
-    expected_history += [('Event', 'stopped', {'reason': 'pause'})]
-    expectation = Event('stopped', {'reason': 'pause'})
-
-    with timeline.frozen():
-        t = (t >> expectation).wait()
-        assert expectation.has_been_realized_in(timeline)
-        assert timeline.history() == Pattern(expected_history)
+        timeline.expect_realized(Response(request_expectation, response_body))
+        timeline.expect_realized(Response(request_expectation, ANY))
+        if outcome == 'success':
+            timeline.expect_realized(Response(request_expectation, SUCCESS))
+            timeline.expect_not_realized(Response(request_expectation, FAILURE))
+        else:
+            timeline.expect_not_realized(Response(request_expectation, SUCCESS))
+            timeline.expect_realized(Response(request_expectation, FAILURE))
 
 
 def test_after(make_timeline):
-    timeline = make_timeline()
+    timeline, _ = make_timeline()
     first = timeline.mark('first')
 
     second_exp = first >> Mark('second')
@@ -225,7 +179,7 @@ def test_after(make_timeline):
 
 
 def test_before(make_timeline):
-    timeline = make_timeline()
+    timeline, _ = make_timeline()
     t = timeline.beginning
 
     first = timeline.mark('first')
@@ -244,27 +198,12 @@ def test_before(make_timeline):
         assert Mark('second') >> third in timeline
 
 
-def test_not(make_timeline):
-    timeline = make_timeline()
-    timeline.mark('other')
-
-    with timeline.frozen():
-        assert timeline.beginning >> ~Mark('something') in timeline
-        t = timeline.last
-
-    timeline.mark('something')
-
-    with timeline.frozen():
-        assert timeline.beginning >> ~Mark('something') in timeline
-        assert t >> ~Mark('something') not in timeline
-
-
 def test_and(make_timeline):
     eggs_exp = Mark('eggs')
     ham_exp = Mark('ham')
     cheese_exp = Mark('cheese')
 
-    timeline = make_timeline()
+    timeline, _ = make_timeline()
     t = timeline.beginning
 
     with timeline.frozen():
@@ -296,7 +235,7 @@ def test_or(make_timeline):
     ham_exp = Mark('ham')
     cheese_exp = Mark('cheese')
 
-    timeline = make_timeline()
+    timeline, _ = make_timeline()
     t = timeline.beginning
 
     with timeline.frozen():
@@ -335,7 +274,7 @@ def test_xor(make_timeline):
     ham_exp = Mark('ham')
     cheese_exp = Mark('cheese')
 
-    timeline = make_timeline()
+    timeline, _ = make_timeline()
     t1 = timeline.beginning
 
     with timeline.frozen():
@@ -366,14 +305,151 @@ def test_conditional(make_timeline):
 
     something = Event('something', ANY)
     something_exciting = something.when(is_exciting)
-    timeline = make_timeline()
+    timeline, _ = make_timeline()
     t = timeline.beginning
 
     timeline.record_event('something', 'boring')
     with timeline.frozen():
-        assert t >> something in timeline
-        assert t >> something_exciting not in timeline
+        timeline.expect_realized(t >> something)
+        timeline.expect_not_realized(t >> something_exciting)
 
     timeline.record_event('something', 'exciting')
     with timeline.frozen():
-        assert t >> something_exciting in timeline
+        timeline.expect_realized(t >> something_exciting)
+
+
+@pytest.mark.timeout(1)
+def test_frozen(make_timeline, daemon):
+    timeline, initial_history = make_timeline()
+    assert not timeline.is_frozen
+
+    timeline.freeze()
+    assert timeline.is_frozen
+
+    timeline.unfreeze()
+    assert not timeline.is_frozen
+
+    with timeline.frozen():
+        assert timeline.is_frozen
+    assert not timeline.is_frozen
+
+    timeline.mark('dum')
+
+    timeline.freeze()
+    assert timeline.is_frozen
+
+    worker_started = threading.Event()
+    worker_can_proceed = threading.Event()
+    worker_done = threading.Event()
+
+    @daemon
+    def worker():
+        worker_started.set()
+        worker_can_proceed.wait()
+        timeline.mark('dee')
+        worker_done.set()
+
+    worker_started.wait()
+
+    assert Mark('dum') in timeline
+    assert Mark('dee') not in timeline
+
+    with timeline.unfrozen():
+        worker_can_proceed.set()
+        worker_done.wait()
+
+    assert Mark('dee') in timeline
+
+
+@pytest.mark.timeout(1)
+def test_unobserved(make_timeline, daemon):
+    timeline, initial_history = make_timeline()
+
+    event_recorded = threading.Event()
+    worker_can_proceed = threading.Event()
+
+    @daemon
+    def worker():
+        worker_can_proceed.wait()
+        timeline.record_event('dum', {})
+        print('dum')
+
+        worker_can_proceed.clear()
+        worker_can_proceed.wait()
+        timeline.record_event('dee', {})
+        print('dee')
+
+        timeline.record_event('dum', {})
+        print('dum')
+        event_recorded.set()
+
+    timeline.freeze()
+    assert timeline.is_frozen
+
+    timeline.proceed()
+    assert not timeline.is_frozen
+    worker_can_proceed.set()
+
+    dum = timeline.wait_for_next(Event('dum'))
+    assert timeline.is_frozen
+    assert dum.observed
+
+    # Should be fine since we observed 'dum' by waiting for it.
+    timeline.proceed()
+    assert not timeline.is_frozen
+
+    worker_can_proceed.set()
+    event_recorded.wait()
+
+    dum2 = timeline.wait_for_next(Event('dum'), freeze=False)
+    assert not timeline.is_frozen
+    assert dum2.observed
+
+    timeline.wait_until_realized(Event('dum') >> Event('dum'), freeze=True)
+    assert timeline.is_frozen
+
+    dee = dum.next
+    assert not dee.observed
+
+    # Should complain since 'dee' is unobserved.
+    with pytest.raises(Exception):
+        timeline.proceed()
+
+    # Observe it!
+    timeline.expect_realized(Event('dee'))
+    assert dee.observed
+
+    # Should be good now.
+    timeline.proceed()
+
+
+@pytest.mark.timeout(1)
+@pytest.mark.parametrize('order', ['mark_then_wait', 'wait_then_mark'])
+def test_concurrency(make_timeline, daemon, order):
+    timeline, initial_history = make_timeline()
+
+    occurrences = []
+    worker_can_proceed = threading.Event()
+    worker_done = threading.Event()
+
+    @daemon
+    def worker():
+        worker_can_proceed.wait()
+        mark = timeline.mark('tada')
+        occurrences.append(mark)
+        worker_done.set()
+
+    if order == 'mark_then_wait':
+        worker_can_proceed.set()
+    else:
+        @daemon
+        def unblock_worker_later():
+            time.sleep(0.1)
+            worker_can_proceed.set()
+
+    mark = timeline.wait_for_next(Mark('tada'), freeze=True)
+
+    worker_done.wait()
+    assert mark is occurrences[0]
+    assert timeline.last is mark
+    assert timeline.history() == Pattern(initial_history + occurrences)

--- a/pytests/helpers/watchdog.py
+++ b/pytests/helpers/watchdog.py
@@ -17,14 +17,13 @@ def create(pid):
 
 
 def watch(test_pid, ptvsd_pid):
-    print('Watchdog created for ptvsd process %d' % ptvsd_pid)
     test_process = psutil.Process(test_pid)
     ptvsd_process = psutil.Process(ptvsd_pid)
 
     test_process.wait()
 
     if ptvsd_process.is_running():
-        print('Child ptvsd process %d still running after test process exited! Killing it.' % ptvsd_pid)
+        print('ptvsd(pid=%d) still running after test process exited! Killing it.' % ptvsd_pid)
         procs = [ptvsd_process]
         try:
             procs += ptvsd_process.children(recursive=True)

--- a/pytests/requirements.txt
+++ b/pytests/requirements.txt
@@ -1,3 +1,0 @@
-pytest>=3.8
-pytest-timeout>=1.3
-psutil>=5.4

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,16 @@ if __name__ == '__main__':
         url='https://aka.ms/ptvs',
         python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
         setup_requires=['pytest_runner>=4.2'],
-        tests_require=['pytest>=3.8', 'pytest-timeout>=1.3', 'psutil>=5.4'],
+        tests_require=[
+            'pytest>=3.8',
+            'pytest-timeout>=1.3',
+            'psutil>=5.4',
+            'requests',
+            'flask',
+            'django',
+            'pygments>=2.2',
+            'colorama>=0.3',
+        ],
         classifiers=[
             'Development Status :: 5 - Production/Stable',
             'Programming Language :: Python :: 2.7',

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,3 +6,5 @@ django
 pytest>=3.8
 pytest-timeout>=1.3
 psutil>=5.4
+pygments>=2.2
+colorama>=0.3


### PR DESCRIPTION
- implicit freezing on wait
- wait_for_next() and expect_new()
- unobserved occurrences checking
- timeline slicing into intervals
- queue-based timeline for accurate timestamps
- finer-grained timeline tests
- capture ptvsd stderr/stdout and timestamp it
- tighten up ptvsd tests (check more)
- pretty colors!