### PR TITLE
Set SIO_LOOPBACK_FAST_PATH while creating socket in windows

### DIFF
--- a/ptvsd/socket.py
+++ b/ptvsd/socket.py
@@ -75,14 +75,14 @@ def create_server(host, port, timeout=None):
     if host is None:
         host = 'localhost'
     server = _new_sock()
-    server.bind((host, port))
-
-    # _, listener_port = server.getsockname()
-    # print('Listening on', listener_port)
-
-    if timeout is not None:
-        server.settimeout(timeout)
-    server.listen(1)
+    try:
+        server.bind((host, port))
+        if timeout is not None:
+            server.settimeout(timeout)
+        server.listen(1)
+    except Exception:
+        server.close()
+        raise
     return server
 
 
@@ -209,7 +209,6 @@ def close_socket(sock):
     try:
         shut_down(sock)
     except Exception:
-        # TODO: Log errors?
         pass
     sock.close()
 

--- a/ptvsd/socket.py
+++ b/ptvsd/socket.py
@@ -96,14 +96,15 @@ def _new_sock():
                          socket.SOCK_STREAM,
                          socket.IPPROTO_TCP)
     if platform.system() == 'Windows':
-        if hasattr(socket, 'SIO_LOOPBACK_FAST_PATH'):
-            try:
-                sock.ioctl(socket.SIO_LOOPBACK_FAST_PATH, True)
-            except OSError as ose:
-                if ose.winerror == 10045:  # Not supported by OS
-                    pass
-                else:
-                    raise
+        try:
+            sock.ioctl(socket.SIO_LOOPBACK_FAST_PATH, True)
+        except AttributeError:
+            pass  # Not supported in python 2.* or <3.6
+        except OSError as ose:
+            if ose.winerror == 10045:  # Not supported by OS
+                pass
+            else:
+                raise
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
     else:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/ptvsd/socket.py
+++ b/ptvsd/socket.py
@@ -96,6 +96,14 @@ def _new_sock():
                          socket.SOCK_STREAM,
                          socket.IPPROTO_TCP)
     if platform.system() == 'Windows':
+        if hasattr(socket, 'SIO_LOOPBACK_FAST_PATH'):
+            try:
+                sock.ioctl(socket.SIO_LOOPBACK_FAST_PATH, True)
+            except OSError as ose:
+                if ose.winerror == 10045:  # Not supported by OS
+                    pass
+                else:
+                    raise
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
     else:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/pytests/test_socket.py
+++ b/pytests/test_socket.py
@@ -3,7 +3,7 @@
 # for license information.
 
 import pytest
-from ptvsd.socket import create_server, shut_down
+from ptvsd.socket import create_server, close_socket
 
 
 class TestSocketServerReuse(object):
@@ -18,7 +18,7 @@ class TestSocketServerReuse(object):
                 create_server(self.HOST1, self.PORT1)
             assert sock1.getsockname() == (self.HOST1, self.PORT1)
         finally:
-            shut_down(sock1)
+            close_socket(sock1)
 
     def test_reuse_same_port(self):
         try:
@@ -27,5 +27,5 @@ class TestSocketServerReuse(object):
             assert sock1.getsockname() == (self.HOST1, self.PORT1)
             assert sock2.getsockname() == (self.HOST2, self.PORT1)
         finally:
-            shut_down(sock1)
-            shut_down(sock2)
+            close_socket(sock1)
+            close_socket(sock2)


### PR DESCRIPTION
Fixes #912, #949

@int19h is the try/catch the right way to do this? Do we need to create a new socket in place of `pass`?