### PR TITLE
Fix #984: Remote debugging not working with multiproc

### DIFF
--- a/ptvsd/__main__.py
+++ b/ptvsd/__main__.py
@@ -216,10 +216,10 @@ def _parse_args(prog, argv):
     args = parser.parse_args(argv)
     ns = vars(args)
 
-    host = ns.pop('host', None)
-    port = ns.pop('port')
-    client = ns.pop('client')
-    args.address = (Address.as_client if client else Address.as_server)(host, port) # noqa
+    options.host = ns.pop('host', None)
+    options.port = ns.pop('port')
+    options.client = ns.pop('client')
+    args.address = (Address.as_client if options.client else Address.as_server)(options.host, options.port) # noqa
 
     if ns['multiprocess']:
         options.multiprocess = True

--- a/ptvsd/multiproc.py
+++ b/ptvsd/multiproc.py
@@ -243,7 +243,7 @@ def patch_args(args):
     from ptvsd import __main__
     args[i:i] = [
         __main__.__file__,
-        '--host', 'localhost',
+        '--host', options.host,
         '--port', '0',
         '--wait',
         '--multiprocess',

--- a/ptvsd/options.py
+++ b/ptvsd/options.py
@@ -8,22 +8,36 @@ from __future__ import print_function, with_statement, absolute_import
 """ptvsd command-line options that need to be globally available.
 """
 
+client = None
+"""If True, this instance of ptvsd is operating in client mode - i.e. it connects
+to the IDE, instead of waiting for an incoming connection from the IDE.
+"""
+
+host = None
+"""Name or IP address of the network interface used by ptvsd. If runing in server
+mode, this is the interface on which it listens for incoming connections. If running
+in client mode, this is the interface to which it connects.
+"""
+
+port = None
+"""Port number used by ptvsd. If running in server mode, this is the port on which it
+listens for incoming connections. If running in client mode, this is port to which it
+connects.
+"""
+
 code = None
 """When running with -c, specifies the code that needs to be run.
 """
-
 
 multiprocess = False
 """Whether this ptvsd instance is running in multiprocess mode, detouring creation
 of new processes and enabling debugging for them.
 """
 
-
 subprocess_of = None
 """If not None, the process ID of the parent process (running in multiprocess mode)
 that spawned this subprocess.
 """
-
 
 subprocess_notify = None
 """The port number of the subprocess listener. If specified, a 'ptvsd_subprocess'

--- a/pytests/helpers/session.py
+++ b/pytests/helpers/session.py
@@ -223,10 +223,10 @@ class DebugSession(object):
 
         self.wait_for_disconnect(close=False)
 
-        if sys.version_info < (3,) or Event('exited') in self:
+        if Event('exited') in self:
             self.expect_realized(Event('exited', {'exitCode': self.expected_returncode}))
 
-        if sys.version_info < (3,) or Event('terminated') in self:
+        if Event('terminated') in self:
             self.expect_realized(Event('exited') >> Event('terminated', {}))
 
         self.timeline.close()


### PR DESCRIPTION
Use parent's --host when spawning child processes.