### PR TITLE
Fix #874, #1064

### DIFF
--- a/pytests/func/test_breakpoints.py
+++ b/pytests/func/test_breakpoints.py
@@ -13,7 +13,7 @@ import re
 from pytests.helpers.pathutils import get_test_root
 from pytests.helpers.session import DebugSession
 from pytests.helpers.timeline import Event
-from pytests.helpers.pattern import ANY
+from pytests.helpers.pattern import ANY, Path
 
 
 BP_TEST_ROOT = get_test_root('bp')
@@ -33,7 +33,7 @@ def test_path_with_ampersand(run_as, start_method):
         session.start_debugging()
         hit = session.wait_for_thread_stopped('breakpoint')
         frames = hit.stacktrace.body['stackFrames']
-        assert frames[0]['source']['path'] == ANY.path(testfile)
+        assert frames[0]['source']['path'] == Path(testfile)
 
         session.send_request('continue').wait_for_response(freeze=False)
         session.wait_for_exit()
@@ -54,7 +54,7 @@ def test_path_with_unicode(run_as, start_method):
         session.start_debugging()
         hit = session.wait_for_thread_stopped('breakpoint')
         frames = hit.stacktrace.body['stackFrames']
-        assert frames[0]['source']['path'] == ANY.path(testfile)
+        assert frames[0]['source']['path'] == Path(testfile)
         assert u'ಏನಾದರೂ_ಮಾಡು' == frames[0]['name']
 
         session.send_request('continue').wait_for_response(freeze=False)
@@ -159,13 +159,13 @@ def test_crossfile_breakpoint(pyfile, run_as, start_method):
         hit = session.wait_for_thread_stopped()
         frames = hit.stacktrace.body['stackFrames']
         assert bp_script2_line == frames[0]['line']
-        assert frames[0]['source']['path'] == ANY.path(script2)
+        assert frames[0]['source']['path'] == Path(script2)
 
         session.send_request('continue').wait_for_response(freeze=False)
         hit = session.wait_for_thread_stopped()
         frames = hit.stacktrace.body['stackFrames']
         assert bp_script1_line == frames[0]['line']
-        assert frames[0]['source']['path'] == ANY.path(script1)
+        assert frames[0]['source']['path'] == Path(script1)
 
         session.send_request('continue').wait_for_response(freeze=False)
         session.wait_for_exit()

--- a/pytests/func/test_django.py
+++ b/pytests/func/test_django.py
@@ -8,7 +8,7 @@ import os.path
 import pytest
 import sys
 
-from pytests.helpers.pattern import ANY
+from pytests.helpers.pattern import ANY, Path
 from pytests.helpers.session import DebugSession
 from pytests.helpers.timeline import Event
 from pytests.helpers.pathutils import get_test_root
@@ -65,7 +65,7 @@ def test_django_breakpoint_no_multiproc(bp_target, start_method):
             'name': bp_name,
             'source': {
                 'sourceReference': ANY,
-                'path': ANY.path(bp_file),
+                'path': Path(bp_file),
             },
             'line': bp_line,
             'column': 1,
@@ -155,7 +155,7 @@ def test_django_exception_no_multiproc(ex_type, start_method):
             'details': {
                 'message': 'Hello',
                 'typeName': ANY.such_that(lambda s: s.endswith('ArithmeticError')),
-                'source': ANY.path(DJANGO1_MANAGE),
+                'source': Path(DJANGO1_MANAGE),
                 'stackTrace': ANY.such_that(lambda s: True),
             }
         }
@@ -170,7 +170,7 @@ def test_django_exception_no_multiproc(ex_type, start_method):
             'name': 'bad_route_' + ex_type,
             'source': {
                 'sourceReference': ANY,
-                'path': ANY.path(DJANGO1_MANAGE),
+                'path': Path(DJANGO1_MANAGE),
             },
             'line': ex_line,
             'column': 1,
@@ -240,7 +240,7 @@ def test_django_breakpoint_multiproc(start_method):
                 'name': 'home',
                 'source': {
                     'sourceReference': ANY.int,
-                    'path': ANY.path(DJANGO1_MANAGE),
+                    'path': Path(DJANGO1_MANAGE),
                 },
                 'line': bp_line,
                 'column': 1,

--- a/pytests/func/test_exception.py
+++ b/pytests/func/test_exception.py
@@ -8,7 +8,7 @@ import pytest
 
 from pytests.helpers.session import DebugSession
 from pytests.helpers.timeline import Event
-from pytests.helpers.pattern import ANY
+from pytests.helpers.pattern import ANY, Path
 
 
 @pytest.mark.parametrize('raised', ['raisedOn', 'raisedOff'])
@@ -47,7 +47,7 @@ def test_vsc_exception_options_raise_with_except(pyfile, run_as, start_method, r
             'details': ANY.dict_with({
                 'typeName': ANY.such_that(lambda s: s.endswith('ArithmeticError')),
                 'message': 'bad code',
-                'source': ANY.path(code_to_debug),
+                'source': Path(code_to_debug),
             }),
         })
 
@@ -102,7 +102,7 @@ def test_vsc_exception_options_raise_without_except(pyfile, run_as, start_method
             'details': ANY.dict_with({
                 'typeName': ANY.such_that(lambda s: s.endswith('ArithmeticError')),
                 'message': 'bad code',
-                'source': ANY.path(code_to_debug),
+                'source': Path(code_to_debug),
             }),
         })
 

--- a/pytests/func/test_flask.py
+++ b/pytests/func/test_flask.py
@@ -9,7 +9,7 @@ import platform
 import pytest
 import sys
 
-from pytests.helpers.pattern import ANY
+from pytests.helpers.pattern import ANY, Path
 from pytests.helpers.session import DebugSession
 from pytests.helpers.timeline import Event
 from pytests.helpers.webhelper import get_web_content, wait_for_connection
@@ -84,7 +84,7 @@ def test_flask_breakpoint_no_multiproc(bp_target, start_method):
             'name': bp_name,
             'source': {
                 'sourceReference': ANY.int,
-                'path': ANY.path(bp_file),
+                'path': Path(bp_file),
             },
             'line': bp_line,
             'column': 1,
@@ -165,7 +165,7 @@ def test_flask_exception_no_multiproc(ex_type, start_method):
             'details': {
                 'message': 'Hello',
                 'typeName': ANY.such_that(lambda s: s.endswith('ArithmeticError')),
-                'source': ANY.path(FLASK1_APP),
+                'source': Path(FLASK1_APP),
                 'stackTrace': ANY.such_that(lambda s: True)
             }
         }
@@ -180,7 +180,7 @@ def test_flask_exception_no_multiproc(ex_type, start_method):
             'name': 'bad_route_' + ex_type,
             'source': {
                 'sourceReference': ANY.int,
-                'path': ANY.path(FLASK1_APP),
+                'path': Path(FLASK1_APP),
             },
             'line': ex_line,
             'column': 1,
@@ -258,7 +258,7 @@ def test_flask_breakpoint_multiproc(start_method):
                 'name': 'home',
                 'source': {
                     'sourceReference': ANY.int,
-                    'path': ANY.path(FLASK1_APP),
+                    'path': Path(FLASK1_APP),
                 },
                 'line': bp_line,
                 'column': 1,

--- a/pytests/func/test_path_mapping.py
+++ b/pytests/func/test_path_mapping.py
@@ -6,7 +6,7 @@ from __future__ import print_function, with_statement, absolute_import
 
 import os
 from shutil import copyfile
-from pytests.helpers.pattern import ANY
+from pytests.helpers.pattern import Path
 from pytests.helpers.session import DebugSession
 from pytests.helpers.timeline import Event
 
@@ -46,10 +46,10 @@ def test_with_path_mappings(pyfile, tmpdir, run_as, start_method):
         session.start_debugging()
         hit = session.wait_for_thread_stopped('breakpoint')
         frames = hit.stacktrace.body['stackFrames']
-        assert frames[0]['source']['path'] == ANY.path(path_local)
+        assert frames[0]['source']['path'] == Path(path_local)
 
         remote_code_path = session.read_json()
-        assert path_remote == ANY.path(remote_code_path)
+        assert path_remote == Path(remote_code_path)
 
         session.send_request('continue').wait_for_response(freeze=False)
         session.wait_for_exit()

--- a/pytests/func/test_vs_specific.py
+++ b/pytests/func/test_vs_specific.py
@@ -7,7 +7,7 @@ from __future__ import print_function, with_statement, absolute_import
 import pytest
 from pytests.helpers.session import DebugSession
 from pytests.helpers.timeline import Event
-from pytests.helpers.pattern import ANY
+from pytests.helpers.pattern import Path
 
 
 @pytest.mark.parametrize('module', [True, False])
@@ -87,9 +87,9 @@ def test_module_events(pyfile, run_as, start_method):
         modules = session.all_occurrences_of(Event('module'))
         modules = [(m.body['module']['name'], m.body['module']['path']) for m in modules]
         assert modules[:3] == [
-            ('module2', ANY.path(module2)),
-            ('module1', ANY.path(module1)),
-            ('__main__', ANY.path(test_code)),
+            ('module2', Path(module2)),
+            ('module1', Path(module1)),
+            ('__main__', Path(test_code)),
         ]
 
         session.send_request('continue').wait_for_response(freeze=False)

--- a/pytests/helpers/pathutils.py
+++ b/pytests/helpers/pathutils.py
@@ -3,6 +3,10 @@
 # for license information.
 
 import os.path
+import sys
+
+import ptvsd.compat
+
 
 def get_test_root(name):
     pytests_dir = os.path.dirname(os.path.dirname(__file__))
@@ -11,10 +15,18 @@ def get_test_root(name):
         return p
     return None
 
+
 def compare_path(left, right, show=True):
+    # If there's a unicode/bytes mismatch, make both unicode.
+    if isinstance(left, ptvsd.compat.unicode):
+        if not isinstance(right, ptvsd.compat.unicode):
+            right = right.decode(sys.getfilesystemencoding())
+    elif isinstance(right, ptvsd.compat.unicode):
+        left = right.decode(sys.getfilesystemencoding())
+
     n_left = os.path.normcase(left)
     n_right = os.path.normcase(right)
     if show:
         print('LEFT : ' + n_left)
         print('RIGHT: ' + n_right)
-    return str(n_left) == str(n_right)
+    return n_left == n_right

--- a/pytests/helpers/pattern.py
+++ b/pytests/helpers/pattern.py
@@ -63,15 +63,6 @@ class Any(BasePattern):
         items = dict(items)
         return AnyDictWith(items)
 
-    @staticmethod
-    def path(p):
-        class AnyStrPath(str):
-            def __eq__(self, other):
-                return compare_path(self, other, show=False)
-            def __ne__(self, other):
-                return not (self == other)
-        return AnyStrPath(p)
-
 
 class Maybe(BasePattern):
     """A pattern that matches if condition is True.
@@ -116,6 +107,26 @@ class Is(BasePattern):
 
     def __eq__(self, value):
         return self.obj is value
+
+
+class Path(object):
+    """A pattern that matches strings as path, using os.path.normcase before comparison,
+    and sys.getfilesystemencoding() to compare Unicode and non-Unicode strings.
+    """
+
+    def __init__(self, s):
+        self.s = s
+
+    def __repr__(self):
+        return 'Path(%r)' % (self.s,)
+
+    def __eq__(self, other):
+        if not (isinstance(other, bytes) or isinstance(other, unicode)):
+            return NotImplemented
+        return compare_path(self.s, other, show=False)
+
+    def __ne__(self, other):
+        return not (self == other)
 
 
 SUCCESS = Success(True)


### PR DESCRIPTION
Fix #874: Watch window freezes the system when Name contains non-ASCII symbols

Fix #1064: test_module_events is failing on Windows

Use Unicode literals throughout wrapper.py, and fix pathname handling.

Add evaluation test for Unicode character in an expression.

Fix path pattern such that its __eq__ is used deterministically.