### PR TITLE
More Unicode fixes: #1037, #1066

### DIFF
--- a/src/ptvsd/pathutils.py
+++ b/src/ptvsd/pathutils.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import print_function, with_statement, absolute_import
+from __future__ import print_function, with_statement, absolute_import, unicode_literals
 
 from glob import glob
 import os.path


### PR DESCRIPTION
Fix #1037: Setting breakpoint fails on Python files containing non-ASCII characters

Fix #1066: Fetching remote source for a file with a Unicode name fails on 2.7