### PR TITLE
Attempt to fix exceptions thrown while debugging

### DIFF
--- a/src/ptvsd/_local.py
+++ b/src/ptvsd/_local.py
@@ -139,5 +139,8 @@ def _run(argv, addr, _pydevd=pydevd, _install=install, **kwargs):
     try:
         _pydevd.main()
     except SystemExit as ex:
-        daemon.exitcode = 0 if ex.code is None else int(ex.code)
+        try:
+            daemon.exitcode = 0 if ex.code is None else int(ex.code)
+        except ValueError:
+            daemon.exitcode = 1
         raise

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_io.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_io.py
@@ -34,7 +34,10 @@ class IORedirector:
 
     def flush(self):
         for r in self._redirect_to:
-            r.flush()
+            try:
+                r.flush()
+            except OSError:
+                pass
 
     def __getattr__(self, name):
         for r in self._redirect_to:
@@ -56,7 +59,7 @@ class IOBuf:
         b = self.buflist
         self.buflist = []  # clear it
         return ''.join(b)  # bytes on py2, str on py3.
-    
+
     def write(self, s):
         if not IS_PY3K:
             if isinstance(s, unicode):


### PR DESCRIPTION
This PR includes two attempts at fixing exceptions I have seen while debugging a Python CLI application in VS Code. 

The change to `_local.py` is for instances when `ex.code` is not an integer. According to the [docs here](https://docs.python.org/3/library/exceptions.html#SystemExit.code), the value might be an error message. Some libraries do return the usage message such as [Docopt](https://github.com/docopt/docopt/blob/master/docopt.py#L29).

The change to `pydevd_io.py` is for an `OSError: [WinError 87] The parameter is incorrect` exception that is thrown when trying to debug code that includes code line `print("", end="", flush=True)`. I don't fully understand what causes this exception to be thrown. The try-catch prevents the exception from interrupting the debug session but further investigation may be warranted. I am running Python 3.6.2 on Windows 10 Home version 1803.