### PR TITLE
Ignore any file starting with '<' in the debugger. Fixes #1071

### DIFF
--- a/src/ptvsd/_vendored/pydevd/pydevd.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd.py
@@ -534,9 +534,10 @@ class PyDB(object):
                 If it's a regular user file which should be traced.
         '''
         basename = abs_real_path_and_basename[-1]
-        if basename.startswith('<frozen '):
+        if basename.startswith('<'):
             # In Python 3.7 "<frozen ..." appear multiple times during import and should be
-            # ignored for the user.
+            # ignored for the user and <string> is commonly used for dummy files, so, consider
+            # any file starting with '<' as invisible for the debugger.
             return self.PYDEV_FILE
         return self._dont_trace_get_file_type(basename)
 

--- a/src/ptvsd/_vendored/pydevd/tests_python/debug_constants.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/debug_constants.py
@@ -7,6 +7,7 @@ TEST_JYTHON = os.getenv('PYDEVD_TEST_JYTHON', None) == 'YES'
 
 IS_PY3K = sys.version_info[0] >= 3
 IS_PY36_OR_GREATER = sys.version_info[0:2] >= (3, 6)
+IS_PY37_OR_GREATER = sys.version_info[0:2] >= (3, 7)
 IS_CPYTHON = platform.python_implementation() == 'CPython'
 
 IS_PY2 = False
@@ -15,6 +16,5 @@ if sys.version_info[0] == 2:
 
 IS_PY26 = sys.version_info[:2] == (2, 6)
 IS_PY34 = sys.version_info[:2] == (3, 4)
-IS_PY36 = False
-if sys.version_info[0] == 3 and sys.version_info[1] == 6:
-    IS_PY36 = True
+IS_PY36 = sys.version_info[:2] == (3, 6)
+IS_PY37 = sys.version_info[:2] == (3, 7)

--- a/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_dataclasses.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_dataclasses.py
@@ -1,0 +1,16 @@
+import typing
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Thing:
+    a: typing.Any
+    b: typing.Any
+    c: typing.Any = field(init=False, repr=False)
+
+    def __post_init__(self):
+        self.c = self.a + self.b  # break here
+
+
+Thing(a=1, b=2)
+print('TEST SUCEEDED!')

--- a/src/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
@@ -863,6 +863,22 @@ def test_case_20(case_setup):
         writer.finished_ok = True
 
 
+@pytest.mark.skipif(not IS_PY37_OR_GREATER, reason='Py37 only test')
+def test_case_invalid_string_dataclasses(case_setup):
+    with case_setup.test_file('_debugger_case_dataclasses.py') as writer:
+        writer.write_make_initial_run()
+
+        writer.write_add_breakpoint(writer.get_line_index_with_content('break here'))
+        writer.write_make_initial_run()
+        hit = writer.wait_for_breakpoint_hit()
+
+        writer.write_step_in(hit.thread_id)
+        hit = writer.wait_for_breakpoint_hit(reason=REASON_STEP_INTO, file=writer.get_main_filename(), name='<module>')
+
+        writer.write_step_in(hit.thread_id)
+        writer.finished_ok = True
+
+
 @pytest.mark.skipif(not TEST_FLASK, reason='No flask available')
 def test_case_flask(case_setup_flask):
     with case_setup_flask.test_file(EXPECTED_RETURNCODE='any') as writer:


### PR DESCRIPTION
This didn't work out well because tests will launch files with `<string>` paths.

Apparently this is because when calling Python with `-c` Python itself will use `<string>` to run code.

i.e.: 
```
>>> python -c "import sys;print(sys._getframe().f_code.co_filename)"
<string>
```

So, I'm not entirely sure on the best way to proceed -- note that in that case, the user wouldn't be able to get to the `<string>` contents either and it'd fail with the same issue reported on #1071... a way out could be create a temporary file for the tests and run that temporary file instead of relying on `-c` which would result in the filename mapping to `<string>`.

Suggestions @int19h @karthiknadig ?

-- note: I got this issue because I thought it was very simple to fix... if it's going to be much more work it may need to be postponed.