### PR TITLE
Fix #206: Validate breakpoint targets

### DIFF
--- a/src/ptvsd/_util.py
+++ b/src/ptvsd/_util.py
@@ -8,6 +8,7 @@ import contextlib
 import os
 import threading
 import time
+import types
 import sys
 
 
@@ -413,3 +414,18 @@ def _allow_debug_break(enabled=True):
 
 def _is_debug_break_allowed():
     return _enable_debug_break
+
+
+try:
+    import dis
+except ImportError:
+    def get_code_lines(code):
+        return None
+else:
+    def get_code_lines(code):
+        for _, lineno in dis.findlinestarts(code):
+            yield lineno
+        for const in code.co_consts:
+            if isinstance(const, types.CodeType) and const.co_filename == code.co_filename:
+                for lineno in get_code_lines(const):
+                    yield lineno

--- a/src/ptvsd/_util.py
+++ b/src/ptvsd/_util.py
@@ -423,8 +423,14 @@ except ImportError:
         return None
 else:
     def get_code_lines(code):
+        # First, get all line starts for this code object. This does not include
+        # bodies of nested class and function definitions, as they have their
+        # own objects.
         for _, lineno in dis.findlinestarts(code):
             yield lineno
+
+        # For nested class and function definitions, their respective code objects
+        # are constants referenced by this object.
         for const in code.co_consts:
             if isinstance(const, types.CodeType) and const.co_filename == code.co_filename:
                 for lineno in get_code_lines(const):

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ requests
 flask
 psutil
 pygments
-pytest
+pytest<5
 pytest-cov
 pytest-timeout
 pytest-xdist

--- a/tests/func/test_breakpoints.py
+++ b/tests/func/test_breakpoints.py
@@ -392,8 +392,8 @@ def test_add_and_remove_breakpoint(pyfile, run_as, start_method):
         session.set_breakpoints(code_to_debug, [])
         session.send_request('continue').wait_for_response(freeze=False)
 
-        session.write_json('done')
         session.wait_for_next(Event('output', ANY.dict_with({'category': 'stdout', 'output': '9'})))
+        session.write_json('done')
         session.wait_for_exit()
 
         output = session.all_occurrences_of(Event('output', ANY.dict_with({'category': 'stdout'})))

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -83,7 +83,7 @@ def get_marked_line_numbers(path):
     with open(path) as f:
         lines = {}
         for i, line in enumerate(f):
-            match = re.search(r'#@(.*?)\s*$', line)
+            match = re.search(r'#@\s*(.*?)\s*$', line)
             if match:
                 marker = match.group(1)
                 lines[marker] = i + 1

--- a/tests/helpers/session.py
+++ b/tests/helpers/session.py
@@ -581,10 +581,10 @@ class DebugSession(object):
             thread.join()
 
     def set_breakpoints(self, path, lines=()):
-        self.send_request('setBreakpoints', arguments={
+        return self.send_request('setBreakpoints', arguments={
                 'source': {'path': path},
                 'breakpoints': [{'line': bp_line} for bp_line in lines],
-            }).wait_for_response()
+            }).wait_for_response().body.get('breakpoints', None)
 
     def wait_for_thread_stopped(self, reason=ANY):
         thread_stopped = self.wait_for_next(Event('stopped', ANY.dict_with({'reason': reason})))


### PR DESCRIPTION
When setting breakpoints, validate line numbers against dis.findlinestarts() for the given file.