### PR TITLE
Enable discovery of ptvsd tests in VSCode

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=./src

--- a/.gitignore
+++ b/.gitignore
@@ -80,9 +80,6 @@ celerybeat-schedule
 # SageMath parsed files
 *.sage.py
 
-# dotenv
-.env
-
 # virtualenv
 .venv
 venv/

--- a/ptvsd.code-workspace
+++ b/ptvsd.code-workspace
@@ -7,5 +7,6 @@
     "settings": {
         "python.linting.enabled": true,
         "python.linting.pylintEnabled": false,
+        "python.envFile": "${workspaceFolder}/.env",
     }
 }


### PR DESCRIPTION
With these changes, VSC test discovery works on ptvsd tests, provided that all the test requirements are manually installed (`pip install -r test_requirements.txt`) for the selected Python interpreter.
