### PR TITLE
PyDev console hooks causes incompatibility with imports matplotlib and pylab. Fix for PyDev-975

### DIFF
--- a/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_import_hook.py
+++ b/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_import_hook.py
@@ -2,9 +2,16 @@
 import sys
 import traceback
 from types import ModuleType
+from _pydevd_bundle.pydevd_constants import DebugInfoHolder
+
+if sys.version_info[0] >= 3:
+    import builtins  # py3
+else:
+    import __builtin__ as builtins
 
 
 class ImportHookManager(ModuleType):
+
     def __init__(self, name, system_import):
         ModuleType.__init__(self, name)
         self._system_import = system_import
@@ -14,25 +21,23 @@ class ImportHookManager(ModuleType):
         self._modules_to_patch[module_name] = activate_function
 
     def do_import(self, name, *args, **kwargs):
-        activate_func = None
-        if name in self._modules_to_patch:
-            activate_func = self._modules_to_patch.pop(name)
-
         module = self._system_import(name, *args, **kwargs)
         try:
+            activate_func = self._modules_to_patch.pop(name, None)
             if activate_func:
-                activate_func() #call activate function
+                activate_func()  # call activate function
         except:
-            sys.stderr.write("Matplotlib support failed\n")
-            traceback.print_exc()
+            if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 2:
+                traceback.print_exc()
+
+        # Restore normal system importer to reduce performance impact
+        # of calling this method every time an import statement is invoked
+        if not self._modules_to_patch:
+            builtins.__import__ = self._system_import
+
         return module
 
-if sys.version_info[0] >= 3:
-    import builtins # py3
-else:
-    import __builtin__ as builtins
 
 import_hook_manager = ImportHookManager(__name__ + '.import_hook', builtins.__import__)
 builtins.__import__ = import_hook_manager.do_import
 sys.modules[import_hook_manager.__name__] = import_hook_manager
-del builtins

--- a/src/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/test_debugger.py
@@ -3010,7 +3010,14 @@ def test_matplotlib_activation(case_setup):
     except ImportError:
         return
 
-    with case_setup.test_file('_debugger_case_matplotlib.py') as writer:
+    def get_environ(writer):
+        env = os.environ.copy()
+        env.update({
+            'IPYTHONENABLE': 'True',
+        })
+        return env
+
+    with case_setup.test_file('_debugger_case_matplotlib.py', get_environ=get_environ) as writer:
         writer.write_add_breakpoint(writer.get_line_index_with_content('break here'))
         writer.write_make_initial_run()
         for _ in range(3):


### PR DESCRIPTION
This is a backport of the fix for https://www.brainwy.com/tracker/PyDev/975 (it was a community-provided pull request for pydevd).