### PR TITLE
Fix #1165: Detaching sometimes throws ValueError: I/O operation on closed file

### DIFF
--- a/src/ptvsd/__main__.py
+++ b/src/ptvsd/__main__.py
@@ -369,7 +369,7 @@ else:
 
 
 def main(argv=sys.argv):
-    saved_argv = argv
+    saved_argv = list(argv)
     try:
         sys.argv[:] = [argv[0]] + list(parse(argv[1:]))
     except Exception as ex:

--- a/src/ptvsd/_vendored/pydevd/pydevd.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd.py
@@ -1596,8 +1596,17 @@ class PyDB(object):
         return globals
 
     def exiting(self):
-        sys.stdout.flush()
-        sys.stderr.flush()
+        # Either or both standard streams can be closed at this point,
+        # in which case flush() will fail.
+        try:
+            sys.stdout.flush()
+        except:
+            pass
+        try:
+            sys.stderr.flush()
+        except:
+            pass
+
         self.check_output_redirect()
         cmd = self.cmd_factory.make_exit_message()
         self.writer.add_command(cmd)


### PR DESCRIPTION
Gracefully handle failures when flushing potentially closed standard streams on exit.

Add more multiprocess logging, and fix sys.argv logging.