### PR TITLE
Fix #1227: subprocess arguments incorrectly escaped inside the debugger

### DIFF
--- a/src/ptvsd/log.py
+++ b/src/ptvsd/log.py
@@ -109,10 +109,8 @@ def escaped_exceptions(f):
         try:
             return f(*args, **kwargs)
         except:
-            try:
-                name = f.__qualname__
-            except AttributeError:
-                name = f.__name__
+            # Must not use try/except here to avoid overwriting the caught exception.
+            name = f.__qualname__ if hasattr(f, '__qualname__') else f.__name__
             exception('Exception escaped from {0}', name)
             raise
     return g

--- a/tests/func/test_multiproc.py
+++ b/tests/func/test_multiproc.py
@@ -228,6 +228,8 @@ def test_autokill(pyfile, run_as, start_method):
             parent_session.wait_for_exit()
 
 
+@pytest.mark.skipif(sys.version_info < (3, 0) and (platform.system() != 'Windows'),
+                    reason='Bug #935')
 def test_argv_quoting(pyfile, run_as, start_method):
     @pyfile
     def args():


### PR DESCRIPTION
Re-implement argument quoting on Windows in accordance with
https://docs.microsoft.com/en-us/windows/desktop/api/shellapi/nf-shellapi-commandlinetoargvw