### PR TITLE
Fix #1173: Gracefully handle I/O errors when processing source request 

### DIFF
--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_filtering.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_filtering.py
@@ -223,12 +223,10 @@ class FilesFiltering(object):
             # roots if it's not found in site-packages (because we have defaults for those
             # and not the other way around).
             if filename.endswith('>'):
-                if filename.endswith('<string>'):
-                    # When `python -c <code>` is used, the filename
-                    # endswith <string>.
-                    in_project = True
-                else:
-                    in_project = False
+                # This is a dummy filename that is usually used for eval or exec. Assume
+                # that it is user code, with one exception: <frozen ...> is used in the
+                # standard library.
+                in_project = not filename.startswith('<frozen ')
             else:
                 in_project = not found_in_library
         else:
@@ -284,4 +282,3 @@ class FilesFiltering(object):
             if not exclude_filter.is_path:
                 self.require_module = True
                 break
-

--- a/src/ptvsd/_vendored/pydevd/pydevd_file_utils.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd_file_utils.py
@@ -240,6 +240,11 @@ def _NormPaths(filename):
 
 
 def _NormPath(filename, normpath):
+    if filename.startswith('<'):
+        # Not really a file, rather a synthetic name like <string> or <ipython-...>;
+        # shouldn't be normalized.
+        return filename
+
     r = normpath(filename)
     ind = r.find('.zip')
     if ind == -1:

--- a/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_source_reference.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_source_reference.py
@@ -1,0 +1,32 @@
+def foo():
+    return 1  # breakpoint
+
+
+def main():
+    import linecache
+    import time
+
+    code = 'foo()'
+
+    # Intermediate <string> stack frame will have no source.
+    eval(code)
+
+    co_filename = '<something>'
+    co = compile(code, co_filename, 'exec')
+
+    # Set up the source in linecache. Python doesn't have a public API for
+    # this, so we have to hack around it, similar to what IPython does.
+    linecache.cache[co_filename] = (
+        len(code),
+        time.time(),
+        [line + '\n' for line in code.splitlines()],
+        co_filename,
+    )
+
+    # Intermediate <something> stack frame will have source.
+    eval(co)
+
+
+if __name__ == '__main__':
+    main()
+    print('TEST SUCEEDED!')

--- a/src/ptvsd/_vendored/pydevd/tests_python/test_debugger_json.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/test_debugger_json.py
@@ -1009,6 +1009,71 @@ def test_path_translation_and_source_reference(case_setup):
         writer.finished_ok = True
 
 
+
+@pytest.mark.skipif(IS_JYTHON, reason='Flaky on Jython.')
+def test_source_reference_no_file(case_setup, tmpdir):
+
+    def get_environ(writer):
+        env = os.environ.copy()
+        # We need to set up path mapping to enable source references.
+        env["PATHS_FROM_ECLIPSE_TO_PYTHON"] = json.dumps([
+            (os.path.dirname(writer.TEST_FILE), os.path.dirname(writer.TEST_FILE))
+        ])
+        return env
+
+    with case_setup.test_file('_debugger_case_source_reference.py', get_environ=get_environ) as writer:
+        json_facade = JsonFacade(writer)
+        writer.write_set_protocol('http_json')
+        writer.write_add_breakpoint(writer.get_line_index_with_content('breakpoint'))
+        json_facade.write_make_initial_run()
+
+        # First hit is for breakpoint reached via a stack frame that doesn't have source.
+
+        hit = writer.wait_for_breakpoint_hit()
+        stack_trace_request = json_facade.write_request(
+            pydevd_schema.StackTraceRequest(pydevd_schema.StackTraceArguments(
+                threadId=hit.thread_id,
+                format={'module': True, 'line': True}
+        )))
+        stack_trace_response = json_facade.wait_for_response(stack_trace_request)
+        stack_trace_response_body = stack_trace_response.body
+        stack_frame = stack_trace_response_body.stackFrames[1]
+        assert stack_frame['source']['path'] == '<string>'
+        source_reference = stack_frame['source']['sourceReference']
+        assert source_reference != 0
+
+        response = json_facade.wait_for_response(json_facade.write_request(
+            pydevd_schema.SourceRequest(pydevd_schema.SourceArguments(source_reference))))
+        assert not response.success
+
+        writer.write_run_thread(hit.thread_id)
+
+        # First hit is for breakpoint reached via a stack frame that doesn't have source
+        # on disk, but which can be retrieved via linecache.
+
+        hit = writer.wait_for_breakpoint_hit()
+        stack_trace_request = json_facade.write_request(
+            pydevd_schema.StackTraceRequest(pydevd_schema.StackTraceArguments(
+                threadId=hit.thread_id,
+                format={'module': True, 'line': True}
+        )))
+        stack_trace_response = json_facade.wait_for_response(stack_trace_request)
+        stack_trace_response_body = stack_trace_response.body
+        stack_frame = stack_trace_response_body.stackFrames[1]
+        print(stack_frame['source']['path'])
+        assert stack_frame['source']['path'] == '<something>'
+        source_reference = stack_frame['source']['sourceReference']
+        assert source_reference != 0
+
+        response = json_facade.wait_for_response(json_facade.write_request(
+            pydevd_schema.SourceRequest(pydevd_schema.SourceArguments(source_reference))))
+        assert response.success
+        assert response.body.content == 'foo()\n'
+
+        writer.write_run_thread(hit.thread_id)
+        writer.finished_ok = True
+
+
 @pytest.mark.skipif(not TEST_DJANGO, reason='No django available')
 def test_case_django_no_attribute_exception_breakpoint(case_setup_django):
     django_version = [int(x) for x in django.get_version().split('.')][:2]
@@ -1055,4 +1120,3 @@ def test_case_django_no_attribute_exception_breakpoint(case_setup_django):
 
 if __name__ == '__main__':
     pytest.main(['-k', 'test_case_skipping_filters', '-s'])
-

--- a/src/ptvsd/_vendored/pydevd/tests_python/test_pydevd_filtering.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/test_pydevd_filtering.py
@@ -49,7 +49,8 @@ def test_in_project_roots(tmpdir):
         (site_packages_inside_project_dir, False),
         (project_dir, True),
         (project_dir_inside_site_packages, False),
-        (os.path.join(tmpdir, '<foo>'), False),
+        ('<foo>', True),
+        ('<frozen importlib._bootstrap>', False),
     ]
 
     for check_path, find in check:

--- a/src/ptvsd/wrapper.py
+++ b/src/ptvsd/wrapper.py
@@ -1557,8 +1557,10 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
                 pydevd_request,
                 is_json=True)
 
-            body = resp_args['body']
-            self.send_response(request, **body)
+            if resp_args.get('success', True):
+                self.send_response(request, **resp_args['body'])
+            else:
+                self.send_error_response(request, resp_args.get('message', 'Error retrieving source'))
 
     @async_handler
     def on_stackTrace(self, request, args):


### PR DESCRIPTION
Also adds `linecache` fallback and a different approach to handling `<...>` as discussed in #1232. 