### PR TITLE
Fix #1272: Launch a SubModule

### DIFF
--- a/ptvsd.code-workspace
+++ b/ptvsd.code-workspace
@@ -8,5 +8,11 @@
         "python.linting.enabled": true,
         "python.linting.pylintEnabled": false,
         "python.envFile": "${workspaceFolder}/.env",
-    }
+        "files.exclude": {
+            "**/*.pyc": true,
+            "**/__pycache__": true,
+            ".tox": true,
+            "src/ptvsd.egg-info": true,
+        }
+    },
 }

--- a/src/ptvsd/__main__.py
+++ b/src/ptvsd/__main__.py
@@ -213,6 +213,10 @@ def setup_connection():
     elif opts.target_kind == 'file':
         sys.argv[0] = opts.target
     elif opts.target_kind == 'module':
+        # Add current directory to path, like Python itself does for -m. This must
+        # be in place before trying to use find_spec below to resolve submodules.
+        sys.path.insert(0, '')
+
         # We want to do the same thing that run_module() would do here, without
         # actually invoking it. On Python 3, it's exposed as a public API, but
         # on Python 2, we have to invoke a private function in runpy for this.
@@ -279,9 +283,6 @@ def run_module():
         target = target.encode(sys.getfilesystemencoding())
 
     ptvsd.log.info('Running module {0}', target)
-
-    # Add current directory to path, like Python itself does for -m.
-    sys.path.insert(0, '')
 
     # Docs say that runpy.run_module is equivalent to -m, but it's not actually
     # the case for packages - -m sets __name__ to '__main__', but run_module sets

--- a/tests/func/test_run.py
+++ b/tests/func/test_run.py
@@ -11,6 +11,7 @@ import re
 import ptvsd
 
 from tests.helpers import print
+from tests.helpers.pathutils import get_test_root
 from tests.helpers.pattern import ANY, Regex
 from tests.helpers.session import DebugSession
 from tests.helpers.timeline import Event
@@ -46,6 +47,20 @@ def test_run(pyfile, run_as, start_method):
         expected_ptvsd_path = os.path.abspath(ptvsd.__file__)
         assert re.match(re.escape(expected_ptvsd_path) + r'(c|o)?$', ptvsd_path)
 
+        session.wait_for_exit()
+
+
+def test_run_submodule():
+    cwd = get_test_root('testpkgs')
+    with DebugSession() as session:
+        session.initialize(
+            target=('module', 'pkg1.sub'),
+            start_method='launch',
+            ignore_unobserved=[Event('continued')],
+            cwd=cwd,
+        )
+        session.start_debugging()
+        session.wait_for_next(Event('output', ANY.dict_with({'category': 'stdout', 'output': 'three'})))
         session.wait_for_exit()
 
 

--- a/tests/func/testfiles/testpkgs/pkg1/sub/__main__.py
+++ b/tests/func/testfiles/testpkgs/pkg1/sub/__main__.py
@@ -1,0 +1,3 @@
+print('one')
+print('two')
+print('three')


### PR DESCRIPTION
Add sys.path entry for current directory before using runpy/importlib to resolve the module.