### PR TITLE
fix incorrect exception raised while processing a list that exceeds M…

### DIFF
--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
@@ -290,7 +290,8 @@ class DictResolver:
             eval_key_str = self.key_to_str(key)  # do not format the key
             ret.append((key_as_str, val, '[%s]' % (eval_key_str,)))
             if i > MAX_ITEMS_TO_HANDLE:
-                ret.append((TOO_LARGE_ATTR, TOO_LARGE_MSG))
+                ret.append((TOO_LARGE_ATTR, TOO_LARGE_MSG, None))
+                
                 break
 
         ret.append(('__len__', len(dct), partial(_apply_evaluate_name, evaluate_name='len(%s)')))

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
@@ -291,7 +291,6 @@ class DictResolver:
             ret.append((key_as_str, val, '[%s]' % (eval_key_str,)))
             if i > MAX_ITEMS_TO_HANDLE:
                 ret.append((TOO_LARGE_ATTR, TOO_LARGE_MSG, None))
-                
                 break
 
         ret.append(('__len__', len(dct), partial(_apply_evaluate_name, evaluate_name='len(%s)')))


### PR DESCRIPTION
fix incorrect exception raised while processing a list that exceeds MAX_ITEMS_TO_HANDLE

Issue number is : #1301 

In VS Code, when expanding a list with more than MAX_ITEMS_TO_HANDLE(default is 300) items in the debugging window, an exception(ValueError) occurs and debugging stops.