### PR TITLE
Fix #1296 SyntaxError for breakpoints with empty condition

### DIFF
--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_breakpoints.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_breakpoints.py
@@ -59,10 +59,10 @@ class LineBreakpoint(object):
 
     @property
     def has_condition(self):
-        return self.condition is not None or self.hit_condition is not None
+        return bool(self.condition) or bool(self.hit_condition)
 
     def handle_hit_condition(self, frame):
-        if self.hit_condition is None:
+        if not self.hit_condition:
             return False
         ret = False
         with self._hit_condition_lock:

--- a/src/ptvsd/_vendored/pydevd/pydevd.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd.py
@@ -500,7 +500,7 @@ class PyDB(object):
             if pybreakpoint.handle_hit_condition(new_frame):
                 return True
 
-            if condition is None:
+            if not condition:
                 return False
 
             return eval(condition, new_frame.f_globals, new_frame.f_locals)


### PR DESCRIPTION
Treat breakpoints with `condition: ""` as non-conditional.