### PR TITLE
Thread id from pydevd is now int32. Fixes #1331, #1339, #1332

### DIFF
--- a/src/ptvsd/_remote.py
+++ b/src/ptvsd/_remote.py
@@ -57,11 +57,16 @@ def enable_attach(address,
         debugger.ready_to_run = True
 
         while True:
-            session_not_bound.wait()
             try:
-                global_next_session()
-                on_attach()
-            except DaemonClosedError:
+                session_not_bound.wait()
+                try:
+                    global_next_session()
+                    on_attach()
+                except DaemonClosedError:
+                    return
+            except TypeError:
+                # May happen during interpreter shutdown
+                # (if some global -- such as global_next_session becomes None).
                 return
 
     def start_daemon():

--- a/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_log.py
+++ b/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_log.py
@@ -1,40 +1,98 @@
-import sys
 from _pydevd_bundle.pydevd_constants import DebugInfoHolder
 from _pydev_imps._pydev_saved_modules import threading
-currentThread = threading.currentThread
-
+from contextlib import contextmanager
 import traceback
+currentThread = threading.currentThread
 
 WARN_ONCE_MAP = {}
 
 
-def stderr_write(message):
-    sys.stderr.write(message)
-    sys.stderr.write("\n")
+@contextmanager
+def log_context(trace_level, stream):
+    '''
+    To be used to temporarily change the logging settings.
+    '''
+    original_trace_level = DebugInfoHolder.DEBUG_TRACE_LEVEL
+    original_stream = DebugInfoHolder.DEBUG_STREAM
+
+    DebugInfoHolder.DEBUG_TRACE_LEVEL = trace_level
+    DebugInfoHolder.DEBUG_STREAM = stream
+    try:
+        yield
+    finally:
+        DebugInfoHolder.DEBUG_TRACE_LEVEL = original_trace_level
+        DebugInfoHolder.DEBUG_STREAM = original_stream
 
 
-def debug(message):
-    if DebugInfoHolder.DEBUG_TRACE_LEVEL > 2:
-        stderr_write(message)
+def _pydevd_log(level, msg, *args):
+    '''
+    Levels are:
+
+    0 most serious warnings/errors (always printed)
+    1 warnings/significant events
+    2 informational trace
+    3 verbose mode
+    '''
+    if level <= DebugInfoHolder.DEBUG_TRACE_LEVEL:
+        # yes, we can have errors printing if the console of the program has been finished (and we're still trying to print something)
+        try:
+            try:
+                if args:
+                    msg = msg % args
+            except:
+                msg = '%s - %s' % (msg, args)
+            DebugInfoHolder.DEBUG_STREAM.write('%s\n' % (msg,))
+            DebugInfoHolder.DEBUG_STREAM.flush()
+        except:
+            pass
+        return True
 
 
-def warn(message):
-    if DebugInfoHolder.DEBUG_TRACE_LEVEL > 1:
-        stderr_write(message)
+def _pydevd_log_exception(msg='', *args):
+    if msg or args:
+        _pydevd_log(0, msg, *args)
+    try:
+        traceback.print_exc(file=DebugInfoHolder.DEBUG_STREAM)
+        DebugInfoHolder.DEBUG_STREAM.flush()
+    except:
+        raise
 
 
-def info(message):
-    stderr_write(message)
+def verbose(msg, *args):
+    if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 3:
+        _pydevd_log(3, msg, *args)
 
 
-def error(message, tb=False):
-    stderr_write(message)
-    if tb:
-        traceback.print_exc()
+def debug(msg, *args):
+    if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 2:
+        _pydevd_log(2, msg, *args)
 
 
-def error_once(message):
+def info(msg, *args):
+    if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 1:
+        _pydevd_log(1, msg, *args)
+
+
+warn = info
+
+
+def critical(msg, *args):
+    _pydevd_log(0, msg, *args)
+
+
+def exception(msg='', *args):
+    try:
+        _pydevd_log_exception(msg, *args)
+    except:
+        pass  # Should never fail (even at interpreter shutdown).
+
+
+error = exception
+
+
+def error_once(msg, *args):
+    message = msg % args
     if message not in WARN_ONCE_MAP:
         WARN_ONCE_MAP[message] = True
-        error(message)
+        critical(message)
 

--- a/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
+++ b/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_monkey.py
@@ -12,17 +12,9 @@ try:
 except:
     xrange = range
 
-
 #===============================================================================
 # Things that are dependent on having the pydevd debugger
 #===============================================================================
-def log_debug(msg):
-    pydev_log.debug(msg)
-
-
-def log_error_once(msg):
-    pydev_log.error_once(msg)
-
 
 pydev_src_dir = os.path.dirname(os.path.dirname(__file__))
 
@@ -148,7 +140,7 @@ def get_c_option_index(args):
 
 def patch_args(args):
     try:
-        log_debug("Patching args: %s" % str(args))
+        pydev_log.debug("Patching args: %s", args)
         args = remove_quotes_from_args(args)
 
         from pydevd import SetupHolder
@@ -183,13 +175,13 @@ def patch_args(args):
                         continue
 
                     if arg.rsplit('.')[-1] in ['zip', 'pyz', 'pyzw']:
-                        log_debug('Executing a PyZip, returning')
+                        pydev_log.debug('Executing a PyZip, returning')
                         return args
                     break
 
                 new_args.append(args[0])
         else:
-            log_debug("Process is not python, returning.")
+            pydev_log.debug("Process is not python, returning.")
             return args
 
         i = 1
@@ -227,7 +219,7 @@ def patch_args(args):
 
         return quote_args(new_args)
     except:
-        traceback.print_exc()
+        pydev_log.exception('Error patching args')
         return args
 
 
@@ -320,7 +312,7 @@ def patch_arg_str_win(arg_str):
     if not args or not is_python(args[0]):
         return arg_str
     arg_str = ' '.join(patch_args(args))
-    log_debug("New args: %s" % arg_str)
+    pydev_log.debug("New args: %s", arg_str)
     return arg_str
 
 
@@ -338,7 +330,7 @@ def monkey_patch_os(funcname, create_func):
 
 def warn_multiproc():
     pass  # TODO: Provide logging as messages to the IDE.
-    # log_error_once(
+    # pydev_log.error_once(
     #     "pydev debugger: New process is launching (breakpoints won't work in the new process).\n"
     #     "pydev debugger: To debug that process please enable 'Attach to subprocess automatically while debugging?' option in the debugger settings.\n")
     #

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/__main__pydevd_gen_debug_adapter_protocol.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/__main__pydevd_gen_debug_adapter_protocol.py
@@ -7,11 +7,15 @@ to download the latest version.
 
 
 def is_variable_to_translate(cls_name, var_name):
-    if var_name in ('variablesReference', 'frameId'):
+    if var_name in ('variablesReference', 'frameId', 'threadId'):
         return True
 
     if cls_name == 'StackFrame' and var_name == 'id':
         # It's frameId everywhere except on StackFrame.
+        return True
+
+    if cls_name == 'Thread' and var_name == 'id':
+        # It's threadId everywhere except on Thread.
         return True
 
     return False

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/pydevd_base_schema.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/pydevd_base_schema.py
@@ -17,6 +17,8 @@ class BaseSchema(object):
 
     @staticmethod
     def _translate_id_to_dap(obj_id):
+        if obj_id == '*':
+            return '*'
         # Note: we don't invalidate ids, so, if some object starts using the same id
         # of another object, the same id will be used.
         dap_id = BaseSchema._obj_id_to_dap_id.get(obj_id)
@@ -27,6 +29,8 @@ class BaseSchema(object):
 
     @staticmethod
     def _translate_id_from_dap(dap_id):
+        if dap_id == '*':
+            return '*'
         try:
             return BaseSchema._dap_id_to_obj_id[dap_id]
         except:

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/pydevd_schema.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/pydevd_schema.py
@@ -4002,15 +4002,32 @@ class ContinueArguments(BaseSchema):
         :param integer threadId: Continue execution for the specified thread (if possible). If the backend cannot continue on a single thread but will continue on all threads, it should set the 'allThreadsContinued' attribute in the response to true.
         """
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -4201,15 +4218,32 @@ class NextArguments(BaseSchema):
         :param integer threadId: Execute 'next' for this thread.
         """
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -4416,18 +4450,35 @@ class StepInArguments(BaseSchema):
         """
         self.threadId = threadId
         self.targetId = targetId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
         targetId = self.targetId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         if targetId is not None:
             dct['targetId'] = targetId
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -4619,15 +4670,32 @@ class StepOutArguments(BaseSchema):
         :param integer threadId: Execute 'stepOut' for this thread.
         """
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -4820,15 +4888,32 @@ class StepBackArguments(BaseSchema):
         :param integer threadId: Execute 'stepBack' for this thread.
         """
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -5018,15 +5103,32 @@ class ReverseContinueArguments(BaseSchema):
         :param integer threadId: Execute 'reverseContinue' for this thread.
         """
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -5445,17 +5547,34 @@ class GotoArguments(BaseSchema):
         """
         self.threadId = threadId
         self.targetId = targetId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
         targetId = self.targetId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
             'targetId': targetId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -5647,15 +5766,32 @@ class PauseArguments(BaseSchema):
         :param integer threadId: Pause execution for this thread.
         """
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -5865,14 +6001,25 @@ class StackTraceArguments(BaseSchema):
             self.format = StackFrameFormat()
         else:
             self.format = StackFrameFormat(update_ids_from_dap=update_ids_from_dap, **format) if format.__class__ !=  StackFrameFormat else format
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
         startFrame = self.startFrame
         levels = self.levels
         format = self.format  # noqa (assign to builtin)
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
@@ -5883,6 +6030,12 @@ class StackTraceArguments(BaseSchema):
         if format is not None:
             dct['format'] = format.to_dict(update_ids_to_dap=update_ids_to_dap)
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -9073,15 +9226,32 @@ class ExceptionInfoArguments(BaseSchema):
         :param integer threadId: Thread for which exception information should be retrieved.
         """
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -9912,17 +10082,34 @@ class Thread(BaseSchema):
         """
         self.id = id
         self.name = name
+        if update_ids_from_dap:
+            self.id = self._translate_id_from_dap(self.id)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'id' in dct:
+            dct['id'] = cls._translate_id_from_dap(dct['id'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         id = self.id  # noqa (assign to builtin)
         name = self.name
+        if update_ids_to_dap:
+            if id is not None:
+                id = self._translate_id_to_dap(id)  # noqa (assign to builtin)
         dct = {
             'id': id,
             'name': name,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'id' in dct:
+            dct['id'] = cls._translate_id_to_dap(dct['id'])
         return dct
 
 
@@ -11772,8 +11959,16 @@ class StoppedEventBody(BaseSchema):
         self.preserveFocusHint = preserveFocusHint
         self.text = text
         self.allThreadsStopped = allThreadsStopped
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         reason = self.reason
@@ -11782,6 +11977,9 @@ class StoppedEventBody(BaseSchema):
         preserveFocusHint = self.preserveFocusHint
         text = self.text
         allThreadsStopped = self.allThreadsStopped
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'reason': reason,
         }
@@ -11796,6 +11994,12 @@ class StoppedEventBody(BaseSchema):
         if allThreadsStopped is not None:
             dct['allThreadsStopped'] = allThreadsStopped
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -11828,18 +12032,35 @@ class ContinuedEventBody(BaseSchema):
         """
         self.threadId = threadId
         self.allThreadsContinued = allThreadsContinued
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         threadId = self.threadId
         allThreadsContinued = self.allThreadsContinued
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'threadId': threadId,
         }
         if allThreadsContinued is not None:
             dct['allThreadsContinued'] = allThreadsContinued
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 
@@ -11956,17 +12177,34 @@ class ThreadEventBody(BaseSchema):
         """
         self.reason = reason
         self.threadId = threadId
+        if update_ids_from_dap:
+            self.threadId = self._translate_id_from_dap(self.threadId)
         self.kwargs = kwargs
-
+    
+    
+    @classmethod
+    def update_dict_ids_from_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_from_dap(dct['threadId'])
+        return dct
 
     def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
         reason = self.reason
         threadId = self.threadId
+        if update_ids_to_dap:
+            if threadId is not None:
+                threadId = self._translate_id_to_dap(threadId)
         dct = {
             'reason': reason,
             'threadId': threadId,
         }
         dct.update(self.kwargs)
+        return dct    
+    
+    @classmethod
+    def update_dict_ids_to_dap(cls, dct):
+        if 'threadId' in dct:
+            dct['threadId'] = cls._translate_id_to_dap(dct['threadId'])
         return dct
 
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
@@ -66,7 +66,7 @@ class PyDevdAPI(object):
 
     def list_threads(self, py_db, seq):
         # Response is the command with the list of threads to be added to the writer thread.
-        return py_db.cmd_factory.make_list_threads_message(seq)
+        return py_db.cmd_factory.make_list_threads_message(py_db, seq)
 
     def request_suspend_thread(self, py_db, thread_id='*'):
         # Yes, thread suspend is done at this point, not through an internal command.
@@ -93,6 +93,17 @@ class PyDevdAPI(object):
             # Break here (even if it's suspend all) as py_db.set_suspend will
             # take care of suspending other threads.
             break
+
+    def set_enable_thread_notifications(self, py_db, enable):
+        '''
+        When disabled, no thread notifications (for creation/removal) will be
+        issued until it's re-enabled.
+
+        Note that when it's re-enabled, a creation notification will be sent for
+        all existing threads even if it was previously sent (this is meant to
+        be used on disconnect/reconnect).
+        '''
+        py_db.set_enable_thread_notifications(enable)
 
     def request_resume_thread(self, thread_id):
         threads = []

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
@@ -62,7 +62,7 @@ class PyDevdAPI(object):
                 # We should remove saved return values
                 py_db.remove_return_values_flag = True
             py_db.show_return_values = False
-        pydev_log.debug("Show return values: %s\n" % py_db.show_return_values)
+        pydev_log.debug("Show return values: %s", py_db.show_return_values)
 
     def list_threads(self, py_db, seq):
         # Response is the command with the list of threads to be added to the writer thread.
@@ -269,9 +269,8 @@ class PyDevdAPI(object):
         assert func_name.__class__ == str  # i.e.: bytes on py2 and str on py3
 
         if not pydevd_file_utils.exists(filename):
-            sys.stderr.write('pydev debugger: warning: trying to add breakpoint'\
+            pydev_log.critical('pydev debugger: warning: trying to add breakpoint'\
                 ' to file that does not exist: %s (will have no effect)\n' % (filename,))
-            sys.stderr.flush()
             return
 
         if breakpoint_type == 'python-line':
@@ -296,8 +295,7 @@ class PyDevdAPI(object):
             raise NameError(breakpoint_type)
 
         if DebugInfoHolder.DEBUG_TRACE_BREAKPOINTS > 0:
-            pydev_log.debug('Added breakpoint:%s - line:%s - func_name:%s\n' % (filename, line, func_name))
-            sys.stderr.flush()
+            pydev_log.debug('Added breakpoint:%s - line:%s - func_name:%s\n', filename, line, func_name)
 
         if filename in file_to_id_to_breakpoint:
             id_to_pybreakpoint = file_to_id_to_breakpoint[filename]
@@ -363,14 +361,14 @@ class PyDevdAPI(object):
                 breakpoints = result
 
         if file_to_id_to_breakpoint is None:
-            pydev_log.error('Error removing breakpoint. Cant handle breakpoint of type %s' % breakpoint_type)
+            pydev_log.critical('Error removing breakpoint. Cannot handle breakpoint of type %s', breakpoint_type)
 
         else:
             try:
                 id_to_pybreakpoint = file_to_id_to_breakpoint.get(filename, {})
                 if DebugInfoHolder.DEBUG_TRACE_BREAKPOINTS > 0:
                     existing = id_to_pybreakpoint[breakpoint_id]
-                    sys.stderr.write('Removed breakpoint:%s - line:%s - func_name:%s (id: %s)\n' % (
+                    pydev_log.info('Removed breakpoint:%s - line:%s - func_name:%s (id: %s)\n' % (
                         filename, existing.line, existing.func_name.encode('utf-8'), breakpoint_id))
 
                 del id_to_pybreakpoint[breakpoint_id]
@@ -379,8 +377,8 @@ class PyDevdAPI(object):
                     py_db.has_plugin_line_breaks = py_db.plugin.has_line_breaks()
 
             except KeyError:
-                pydev_log.error("Error removing breakpoint: Breakpoint id not found: %s id: %s. Available ids: %s\n" % (
-                    filename, breakpoint_id, dict_keys(id_to_pybreakpoint)))
+                pydev_log.info("Error removing breakpoint: Breakpoint id not found: %s id: %s. Available ids: %s\n",
+                    filename, breakpoint_id, dict_keys(id_to_pybreakpoint))
 
         py_db.on_breakpoints_changed(removed=True)
 
@@ -465,7 +463,7 @@ class PyDevdAPI(object):
             cp.pop(exception, None)
             py_db.break_on_caught_exceptions = cp
         except:
-            pydev_log.debug("Error while removing exception %s" % sys.exc_info()[0])
+            pydev_log.exception("Error while removing exception %s", sys.exc_info()[0])
 
         py_db.on_breakpoints_changed(removed=True)
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -97,6 +97,7 @@ import sys
 import traceback
 from _pydevd_bundle.pydevd_utils import quote_smart as quote, compare_object_attrs_key
 from _pydev_bundle import pydev_log
+from _pydev_bundle.pydev_log import exception as pydev_log_exception
 from _pydev_bundle import _pydev_completer
 
 from pydevd_tracing import get_exception_traceback_str
@@ -116,20 +117,6 @@ from _pydevd_bundle.pydevd_comm_constants import *  # @UnusedWildImport
 
 if IS_JYTHON:
     import org.python.core as JyCore  # @UnresolvedImport
-
-
-def pydevd_log(level, *args):
-    ''' levels are:
-        0 most serious warnings/errors
-        1 warnings/significant events
-        2 informational trace
-    '''
-    if level <= DebugInfoHolder.DEBUG_TRACE_LEVEL:
-        # yes, we can have errors printing if the console of the program has been finished (and we're still trying to print something)
-        try:
-            sys.stderr.write('%s\n' % (args,))
-        except:
-            pass
 
 
 class PyDBDaemonThread(threading.Thread):
@@ -161,8 +148,8 @@ class PyDBDaemonThread(threading.Thread):
                 self._stop_trace()
                 self._on_run()
             except:
-                if sys is not None and traceback is not None:
-                    traceback.print_exc()
+                if sys is not None and pydev_log_exception is not None:
+                    pydev_log_exception()
         finally:
             del created_pydb_daemon[self]
 
@@ -296,7 +283,7 @@ class ReaderThread(PyDBDaemonThread):
                             line = line[:-1]
                 except:
                     if not self.killReceived:
-                        traceback.print_exc()
+                        pydev_log_exception()
                         self.handle_except()
                     return  # Finished communication.
 
@@ -307,8 +294,7 @@ class ReaderThread(PyDBDaemonThread):
                     line = line.decode('utf-8')
 
                 if DebugInfoHolder.DEBUG_RECORD_SOCKET_READS:
-                    sys.stderr.write(u'debugger: received >>%s<<\n' % (line,))
-                    sys.stderr.flush()
+                    pydev_log.critical(u'debugger: received >>%s<<\n' % (line,))
 
                 args = line.split(u'\t', 2)
                 try:
@@ -316,15 +302,14 @@ class ReaderThread(PyDBDaemonThread):
                     pydev_log.debug('Received command: %s %s\n' % (ID_TO_MEANING.get(str(cmd_id), '???'), line,))
                     self.process_command(cmd_id, int(args[1]), args[2])
                 except:
-                    if traceback is not None and sys is not None:  # Could happen at interpreter shutdown
-                        traceback.print_exc()
-                        sys.stderr.write("Can't process net command: %s\n" % line)
-                        sys.stderr.flush()
+                    if sys is not None and pydev_log_exception is not None:  # Could happen at interpreter shutdown
+                        pydev_log_exception("Can't process net command: %s.", line)
 
         except:
             if not self.killReceived:
-                if traceback is not None:  # Could happen at interpreter shutdown
-                    traceback.print_exc()
+                if sys is not None and pydev_log_exception is not None:  # Could happen at interpreter shutdown
+                    pydev_log_exception()
+
             self.handle_except()
 
     def handle_except(self):
@@ -373,7 +358,7 @@ class WriterThread(PyDBDaemonThread):
                         else:
                             continue
                 except:
-                    # pydevd_log(0, 'Finishing debug communication...(1)')
+                    # pydev_log.info('Finishing debug communication...(1)')
                     # when liberating the thread here, we could have errors because we were shutting down
                     # but the thread was still not liberated
                     return
@@ -387,7 +372,7 @@ class WriterThread(PyDBDaemonThread):
         except Exception:
             GlobalDebuggerHolder.global_dbg.finish_debugging_session()
             if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 0:
-                traceback.print_exc()
+                pydev_log_exception()
 
     def empty(self):
         return self.cmdQueue.empty()
@@ -405,26 +390,24 @@ def start_server(port):
         s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
 
     s.bind(('', port))
-    pydevd_log(1, "Bound to port ", str(port))
+    pydev_log.info("Bound to port :%s", port)
 
     try:
         s.listen(1)
         newSock, _addr = s.accept()
-        pydevd_log(1, "Connection accepted")
+        pydev_log.info("Connection accepted")
         # closing server socket is not necessary but we don't need it
         s.shutdown(SHUT_RDWR)
         s.close()
         return newSock
 
     except:
-        sys.stderr.write("Could not bind to port: %s\n" % (port,))
-        sys.stderr.flush()
-        traceback.print_exc()
+        pydev_log.exception("Could not bind to port: %s\n", port)
 
 
 def start_client(host, port):
     ''' connects to a host/port '''
-    pydevd_log(1, "Connecting to ", host, ":", str(port))
+    pydev_log.info("Connecting to %s:%s", host, port)
 
     s = socket(AF_INET, SOCK_STREAM)
 
@@ -447,12 +430,10 @@ def start_client(host, port):
         s.settimeout(timeout)
         s.connect((host, port))
         s.settimeout(None)  # no timeout after connected
-        pydevd_log(1, "Connected.")
+        pydev_log.info("Connected.")
         return s
     except:
-        sys.stderr.write("Could not connect to %s: %s\n" % (host, port))
-        sys.stderr.flush()
-        traceback.print_exc()
+        pydev_log.exception("Could not connect to %s: %s", host, port)
         raise
 
 
@@ -1489,9 +1470,9 @@ def pydevd_find_thread_by_id(thread_id):
                 return i
 
         # This can happen when a request comes for a thread which was previously removed.
-        pydevd_log(1, "Could not find thread %s\n" % (thread_id,))
-        pydevd_log(1, "Available: %s\n" % ([get_thread_id(t) for t in threads],))
+        pydev_log.info("Could not find thread %s.", thread_id)
+        pydev_log.info("Available: %s.", ([get_thread_id(t) for t in threads],))
     except:
-        traceback.print_exc()
+        pydev_log.exception()
 
     return None

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -1118,9 +1118,8 @@ def build_exception_info_response(dbg, thread_id, request_seq, set_additional_th
 
                     # Never filter out plugin frames!
                     if not getattr(frame, 'IS_PLUGIN_FRAME', False):
-                        if not dbg.in_project_scope(original_filename):
-                            if not dbg.get_use_libraries_filter():
-                                continue
+                        if dbg.is_files_filter_enabled and dbg.apply_files_filter(frame, original_filename, False):
+                            continue
                     frames.append((filename_in_utf8, lineno, method_name, line_text))
         finally:
             topmost_frame = None

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_custom_frames.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_custom_frames.py
@@ -2,6 +2,7 @@ from _pydevd_bundle.pydevd_constants import get_current_thread_id, Null
 from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame
 from _pydev_imps._pydev_saved_modules import thread, threading
 import sys
+from _pydev_bundle import pydev_log
 
 DEBUG = False
 
@@ -101,7 +102,7 @@ def update_custom_frame(frame_custom_thread_id, frame, thread_id, name=None):
             old.thread_id = thread_id
         except:
             sys.stderr.write('Unable to get frame to replace: %s\n' % (frame_custom_thread_id,))
-            import traceback;traceback.print_exc()
+            pydev_log.exception()
 
         CustomFramesContainer._py_db_command_thread_event.set()
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_cython.pyx
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_cython.pyx
@@ -277,7 +277,7 @@ cdef class PyDBFrame:
                         if result:
                             should_stop, frame = result
                 except:
-                    traceback.print_exc()
+                    pydev_log.exception()
 
                 if not should_stop:
                     # It was not handled by any plugin, lets check exception breakpoints.
@@ -423,7 +423,7 @@ cdef class PyDBFrame:
                 self.do_wait_suspend(thread, frame, event, arg)
                 main_debugger.send_caught_exception_stack_proceeded(thread)
             except:
-                traceback.print_exc()
+                pydev_log.exception()
 
             main_debugger.set_trace_for_frame_and_parents(frame)
         finally:
@@ -449,7 +449,7 @@ cdef class PyDBFrame:
             else:
                 return func_name
         except:
-            traceback.print_exc()
+            pydev_log.exception()
             return func_name
 
     def show_return_values(self, frame, arg):
@@ -464,7 +464,7 @@ cdef class PyDBFrame:
                     name = self.get_func_name(frame)
                     return_values_dict[name] = arg
             except:
-                traceback.print_exc()
+                pydev_log.exception()
         finally:
             f_locals_back = None
 
@@ -479,7 +479,7 @@ cdef class PyDBFrame:
                 if f_locals_back is not None:
                     f_locals_back.pop(RETURN_VALUES_DICT, None)
             except:
-                traceback.print_exc()
+                pydev_log.exception()
         finally:
             f_locals_back = None
 
@@ -745,7 +745,7 @@ cdef class PyDBFrame:
                         frame_skips_cache[line_cache_key] = 0
 
             except:
-                traceback.print_exc()
+                pydev_log.exception()
                 raise
 
             # step handling. We stop when we hit the right frame
@@ -882,7 +882,7 @@ cdef class PyDBFrame:
                 raise
             except:
                 try:
-                    traceback.print_exc()
+                    pydev_log.exception()
                     info.pydev_step_cmd = -1
                 except:
                     return None if is_call else NO_FTRACE
@@ -1267,7 +1267,7 @@ cdef class ThreadTracer:
                         if py_db.output_checker_thread is None:
                             kill_all_pydev_threads()
                     except:
-                        traceback.print_exc()
+                        pydev_log.exception()
                     py_db._termination_event_set = True
                 return None if event == 'call' else NO_FTRACE
 
@@ -1371,7 +1371,7 @@ cdef class ThreadTracer:
             try:
                 if traceback is not None:
                     # This can actually happen during the interpreter shutdown in Python 2.7
-                    traceback.print_exc()
+                    pydev_log.exception()
             except:
                 # Error logging? We're really in the interpreter shutdown...
                 # (https://github.com/fabioz/PyDev.Debugger/issues/8)

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_extension_utils.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_extension_utils.py
@@ -1,15 +1,15 @@
 import pkgutil
 import sys
-import traceback
 from _pydev_bundle import pydev_log
 try:
     import pydevd_plugins.extensions as extensions
 except:
-    traceback.print_exc()
+    pydev_log.exception()
     extensions = None
 
+
 class ExtensionManager(object):
-    
+
     def __init__(self):
         self.loaded_extensions = None
         self.type_to_instance = {}
@@ -26,7 +26,7 @@ class ExtensionManager(object):
                         module = sys.modules[name]
                         self.loaded_extensions.append(module)
                     except ImportError:
-                        pydev_log.error('Unable to load extension ' + name)
+                        pydev_log.critical('Unable to load extension: %s', name)
 
     def _ensure_loaded(self):
         if self.loaded_extensions is None:
@@ -50,11 +50,12 @@ class ExtensionManager(object):
                 try:
                     handlers.append(attr())
                 except:
-                    pydev_log.error('Unable to load extension class' + attr_name, tb=True)
+                    pydev_log.exception('Unable to load extension class: %s', attr_name)
         return handlers
 
 
 EXTENSION_MANAGER_INSTANCE = ExtensionManager()
+
 
 def extensions_of_type(extension_type):
     """
@@ -63,5 +64,4 @@ def extensions_of_type(extension_type):
     :rtype: list[T]
     """
     return EXTENSION_MANAGER_INSTANCE.get_extension_classes(extension_type)
-
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_frame.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_frame.py
@@ -126,7 +126,7 @@ class PyDBFrame:
                         if result:
                             should_stop, frame = result
                 except:
-                    traceback.print_exc()
+                    pydev_log.exception()
 
                 if not should_stop:
                     # It was not handled by any plugin, lets check exception breakpoints.
@@ -272,7 +272,7 @@ class PyDBFrame:
                 self.do_wait_suspend(thread, frame, event, arg)
                 main_debugger.send_caught_exception_stack_proceeded(thread)
             except:
-                traceback.print_exc()
+                pydev_log.exception()
 
             main_debugger.set_trace_for_frame_and_parents(frame)
         finally:
@@ -298,7 +298,7 @@ class PyDBFrame:
             else:
                 return func_name
         except:
-            traceback.print_exc()
+            pydev_log.exception()
             return func_name
 
     def show_return_values(self, frame, arg):
@@ -313,7 +313,7 @@ class PyDBFrame:
                     name = self.get_func_name(frame)
                     return_values_dict[name] = arg
             except:
-                traceback.print_exc()
+                pydev_log.exception()
         finally:
             f_locals_back = None
 
@@ -328,7 +328,7 @@ class PyDBFrame:
                 if f_locals_back is not None:
                     f_locals_back.pop(RETURN_VALUES_DICT, None)
             except:
-                traceback.print_exc()
+                pydev_log.exception()
         finally:
             f_locals_back = None
 
@@ -594,7 +594,7 @@ class PyDBFrame:
                         frame_skips_cache[line_cache_key] = 0
 
             except:
-                traceback.print_exc()
+                pydev_log.exception()
                 raise
 
             # step handling. We stop when we hit the right frame
@@ -731,7 +731,7 @@ class PyDBFrame:
                 raise
             except:
                 try:
-                    traceback.print_exc()
+                    pydev_log.exception()
                     info.pydev_step_cmd = -1
                 except:
                     return None if is_call else NO_FTRACE

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_xml.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_xml.py
@@ -1,6 +1,5 @@
 import json
 import sys
-import traceback
 
 from _pydev_bundle.pydev_is_thread_alive import is_thread_alive
 from _pydev_imps._pydev_saved_modules import thread
@@ -27,6 +26,7 @@ from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame
 import pydevd_file_utils
 from pydevd_tracing import get_exception_traceback_str
 from _pydev_bundle._pydev_completer import completions_to_xml
+from _pydev_bundle import pydev_log
 
 if IS_IRONPYTHON:
 
@@ -205,7 +205,7 @@ class NetCommandFactory(object):
                 append('file="%s" line="%s">' % (quote(make_valid_xml_value(filename_in_utf8), '/>_= \t'), lineno))
                 append("</frame>")
         except:
-            traceback.print_exc()
+            pydev_log.exception()
 
         curr_frame = None  # Clear frame reference
         return ''.join(cmd_text_list)

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_xml.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_xml.py
@@ -73,7 +73,7 @@ class NetCommandFactory(object):
         frame_description = pydevd_xml.make_valid_xml_value(frame_description)
         return NetCommand(CMD_THREAD_CREATE, 0, '<xml><thread name="%s" id="%s"/></xml>' % (frame_description, frame_id))
 
-    def make_list_threads_message(self, seq):
+    def make_list_threads_message(self, py_db, seq):
         """ returns thread listing as XML """
         try:
             threads = get_non_pydevd_threads()
@@ -146,9 +146,9 @@ class NetCommandFactory(object):
         except:
             return self.make_error_message(seq, get_exception_traceback_str())
 
-    def make_thread_killed_message(self, id):
+    def make_thread_killed_message(self, tid):
         try:
-            return NetCommand(CMD_THREAD_KILL, 0, str(id))
+            return NetCommand(CMD_THREAD_KILL, 0, str(tid))
         except:
             return self.make_error_message(0, get_exception_traceback_str())
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
@@ -116,7 +116,12 @@ class _PyDevCommandProcessor(object):
         elif len(splitted) == 3:
             _local_version, ide_os, breakpoints_by = splitted
 
-        return self.api.set_ide_os_and_breakpoints_by(py_db, seq, ide_os, breakpoints_by)
+        version_msg = self.api.set_ide_os_and_breakpoints_by(py_db, seq, ide_os, breakpoints_by)
+
+        # Enable thread notifications after the version command is completed.
+        self.api.set_enable_thread_notifications(py_db, True)
+
+        return version_msg
 
     def cmd_thread_run(self, py_db, cmd_id, seq, text):
         return self.api.request_resume_thread(text.strip())

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 
 from _pydev_bundle import pydev_log
+from _pydev_bundle.pydev_log import exception as pydev_log_exception
 from _pydevd_bundle import pydevd_traceproperty, pydevd_dont_trace, pydevd_utils
 from _pydevd_bundle.pydevd_additional_thread_info import set_additional_thread_info
 from _pydevd_bundle.pydevd_breakpoints import get_exception_class
@@ -47,8 +48,8 @@ class _PyDevCommandProcessor(object):
             if cmd is not None:
                 py_db.writer.add_command(cmd)
         except:
-            if traceback is not None and sys is not None:
-                traceback.print_exc()
+            if traceback is not None and sys is not None and pydev_log_exception is not None:
+                pydev_log_exception()
 
                 stream = StringIO()
                 traceback.print_exc(file=stream)
@@ -269,7 +270,7 @@ class _PyDevCommandProcessor(object):
         try:
             breakpoint_id = int(breakpoint_id)
         except ValueError:
-            pydev_log.error('Error removing breakpoint. Expected breakpoint_id to be an int. Found: %s' % (breakpoint_id,))
+            pydev_log.critical('Error removing breakpoint. Expected breakpoint_id to be an int. Found: %s', breakpoint_id)
 
         else:
             self.api.remove_breakpoint(py_db, filename, breakpoint_type, breakpoint_id)

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -22,13 +22,15 @@ from _pydevd_bundle.pydevd_utils import convert_dap_log_message_to_expression
 import pydevd_file_utils
 from _pydevd_bundle._debug_adapter.pydevd_schema import CompletionsResponseBody
 
-
 try:
     import dis
 except ImportError:
+
     def _get_code_lines(code):
         raise NotImplementedError
+
 else:
+
     def _get_code_lines(code):
         if not isinstance(code, types.CodeType):
             path = code
@@ -52,6 +54,7 @@ else:
                         yield lineno
 
         return iterate()
+
 
 def _convert_rules_to_exclude_filters(rules, filename_to_server, on_error):
     exclude_filters = []
@@ -280,6 +283,7 @@ class _PyDevJsonCommandProcessor(object):
         '''
         :param LaunchRequest request:
         '''
+        self.api.set_enable_thread_notifications(py_db, True)
         self._set_debug_options(py_db, request.arguments.kwargs)
         response = pydevd_base_schema.build_response(request)
         return NetCommand(CMD_RETURN, 0, response, is_json=True)
@@ -288,6 +292,7 @@ class _PyDevJsonCommandProcessor(object):
         '''
         :param AttachRequest request:
         '''
+        self.api.set_enable_thread_notifications(py_db, True)
         self._set_debug_options(py_db, request.arguments.kwargs)
         response = pydevd_base_schema.build_response(request)
         return NetCommand(CMD_RETURN, 0, response, is_json=True)
@@ -408,6 +413,7 @@ class _PyDevJsonCommandProcessor(object):
         '''
         :param DisconnectRequest request:
         '''
+        self.api.set_enable_thread_notifications(py_db, False)
         self.api.remove_all_breakpoints(py_db, filename='*')
         self.api.remove_all_exception_breakpoints(py_db)
         self.api.request_resume_thread(thread_id='*')

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -1,5 +1,5 @@
-from functools import partial
 import bisect
+from functools import partial
 import itertools
 import json
 import linecache
@@ -10,8 +10,8 @@ from _pydevd_bundle._debug_adapter import pydevd_base_schema
 from _pydevd_bundle._debug_adapter.pydevd_schema import (SourceBreakpoint, ScopesResponseBody, Scope,
     VariablesResponseBody, SetVariableResponseBody, ModulesResponseBody, SourceResponseBody,
     GotoTargetsResponseBody, ExceptionOptions)
+from _pydevd_bundle._debug_adapter.pydevd_schema import CompletionsResponseBody
 from _pydevd_bundle.pydevd_api import PyDevdAPI
-from _pydevd_bundle.pydevd_comm import pydevd_log
 from _pydevd_bundle.pydevd_comm_constants import (
     CMD_RETURN, CMD_STEP_OVER_MY_CODE, CMD_STEP_OVER, CMD_STEP_INTO_MY_CODE,
     CMD_STEP_INTO, CMD_STEP_RETURN_MY_CODE, CMD_STEP_RETURN, CMD_SET_NEXT_STATEMENT)
@@ -20,7 +20,8 @@ from _pydevd_bundle.pydevd_json_debug_options import _extract_debug_options
 from _pydevd_bundle.pydevd_net_command import NetCommand
 from _pydevd_bundle.pydevd_utils import convert_dap_log_message_to_expression
 import pydevd_file_utils
-from _pydevd_bundle._debug_adapter.pydevd_schema import CompletionsResponseBody
+from _pydev_bundle import pydev_log
+from _pydevd_bundle.pydevd_constants import DebugInfoHolder
 
 try:
     import dis
@@ -172,8 +173,8 @@ class _PyDevJsonCommandProcessor(object):
                 return NetCommand(CMD_RETURN, 0, error_response, is_json=True)
 
         else:
-            if DEBUG:
-                print('Process %s: %s\n' % (
+            if DebugInfoHolder.DEBUG_RECORD_SOCKET_READS and DebugInfoHolder.DEBUG_TRACE_LEVEL >= 1:
+                pydev_log.info('Process %s: %s\n' % (
                     request.__class__.__name__, json.dumps(request.to_dict(), indent=4, sort_keys=True),))
 
             assert request.type == 'request'
@@ -799,7 +800,7 @@ class _PyDevJsonCommandProcessor(object):
                 # throughout the debugger which rely on always having the same file type.
                 message = ("Calls to set or change don't trace patterns (via setDebuggerProperty) are not "
                            "allowed since debugging has already started or don't trace patterns are already set.")
-                pydevd_log(0, message)
+                pydev_log.critical(message)
                 response_args = {'success':False, 'body': {}, 'message': message}
                 response = pydevd_base_schema.build_response(request, kwargs=response_args)
                 return NetCommand(CMD_RETURN, 0, response, is_json=True)

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_referrers.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_referrers.py
@@ -2,10 +2,12 @@ import sys
 from _pydevd_bundle import pydevd_xml
 from os.path import basename
 import traceback
+from _pydev_bundle import pydev_log
 try:
     from urllib import quote, quote_plus, unquote, unquote_plus
 except:
-    from urllib.parse import quote, quote_plus, unquote, unquote_plus  #@Reimport @UnresolvedImport
+    from urllib.parse import quote, quote_plus, unquote, unquote_plus  # @Reimport @UnresolvedImport
+
 
 #===================================================================================================
 # print_var_node
@@ -25,6 +27,7 @@ def print_var_node(xml_node, stream):
     if found_as:
         stream.write(', Found as: %s' % (unquote_plus(found_as),))
     stream.write('\n')
+
 
 #===================================================================================================
 # print_referrers
@@ -88,7 +91,7 @@ def get_referrer_info(searched_obj):
                 import gc
                 referrers = gc.get_referrers(searched_obj)
             except:
-                traceback.print_exc()
+                pydev_log.exception()
                 ret = ['<xml>\n']
 
                 ret.append('<for>\n')
@@ -107,14 +110,13 @@ def get_referrer_info(searched_obj):
             curr_frame = sys._getframe()
             frame_type = type(curr_frame)
 
-            #Ignore this frame and any caller frame of this frame
+            # Ignore this frame and any caller frame of this frame
 
-            ignore_frames = {}  #Should be a set, but it's not available on all python versions.
+            ignore_frames = {}  # Should be a set, but it's not available on all python versions.
             while curr_frame is not None:
                 if basename(curr_frame.f_code.co_filename).startswith('pydev'):
                     ignore_frames[curr_frame] = 1
                 curr_frame = curr_frame.f_back
-
 
             ret = ['<xml>\n']
 
@@ -133,9 +135,9 @@ def get_referrer_info(searched_obj):
             for r in referrers:
                 try:
                     if r in ignore_frames:
-                        continue  #Skip the references we may add ourselves
+                        continue  # Skip the references we may add ourselves
                 except:
-                    pass  #Ok: unhashable type checked...
+                    pass  # Ok: unhashable type checked...
 
                 if r is referrers:
                     continue
@@ -169,9 +171,9 @@ def get_referrer_info(searched_obj):
                                 sys.stderr.write('    Found as %r in dict\n' % (found_as,))
                             break
 
-                    #Ok, there's one annoying thing: many times we find it in a dict from an instance,
-                    #but with this we don't directly have the class, only the dict, so, to workaround that
-                    #we iterate over all reachable objects ad check if one of those has the given dict.
+                    # Ok, there's one annoying thing: many times we find it in a dict from an instance,
+                    # but with this we don't directly have the class, only the dict, so, to workaround that
+                    # we iterate over all reachable objects ad check if one of those has the given dict.
                     if all_objects is None:
                         all_objects = gc.get_objects()
 
@@ -184,7 +186,7 @@ def get_referrer_info(searched_obj):
                                 representation = str(r_type)
                                 break
                         except:
-                            pass  #Just ignore any error here (i.e.: ReferenceError, etc.)
+                            pass  # Just ignore any error here (i.e.: ReferenceError, etc.)
 
                 elif r_type in (tuple, list):
                     if DEBUG:
@@ -210,7 +212,7 @@ def get_referrer_info(searched_obj):
             if DEBUG:
                 sys.stderr.write('Done searching for references.\n')
 
-            #If we have any exceptions, don't keep dangling references from this frame to any of our objects.
+            # If we have any exceptions, don't keep dangling references from this frame to any of our objects.
             all_objects = None
             referrers = None
             searched_obj = None
@@ -221,7 +223,7 @@ def get_referrer_info(searched_obj):
             curr_frame = None
             ignore_frames = None
     except:
-        traceback.print_exc()
+        pydev_log.exception()
         ret = ['<xml>\n']
 
         ret.append('<for>\n')

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_reload.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_reload.py
@@ -104,12 +104,14 @@ from _pydevd_bundle import pydevd_dont_trace
 import sys
 import traceback
 import types
+from _pydev_bundle import pydev_log
 
 NO_DEBUG = 0
 LEVEL1 = 1
 LEVEL2 = 2
 
 DEBUG = NO_DEBUG
+
 
 def write(*args):
     new_lst = []
@@ -119,6 +121,7 @@ def write(*args):
     msg = ' '.join(new_lst)
     sys.stdout.write('%s\n' % (msg,))
 
+
 def write_err(*args):
     new_lst = []
     for a in args:
@@ -127,20 +130,23 @@ def write_err(*args):
     msg = ' '.join(new_lst)
     sys.stderr.write('pydev debugger: %s\n' % (msg,))
 
+
 def notify_info0(*args):
     write_err(*args)
+
 
 def notify_info(*args):
     if DEBUG >= LEVEL1:
         write(*args)
 
+
 def notify_info2(*args):
     if DEBUG >= LEVEL2:
         write(*args)
 
+
 def notify_error(*args):
     write_err(*args)
-
 
 
 #=======================================================================================================================
@@ -171,7 +177,6 @@ def xreload(mod):
     r = None
     pydevd_dont_trace.clear_trace_filter_cache()
     return found_change
-
 
 # This isn't actually used... Initially I planned to reload variables which are immutable on the
 # namespace, but this can destroy places where we're saving state, which may not be what we want,
@@ -267,8 +272,7 @@ class Reload:
                 c()
             del self._on_finish_callbacks[:]
         except:
-            traceback.print_exc()
-
+            pydev_log.exception()
 
     def _handle_namespace(self, namespace, is_class_namespace=False):
         on_finish = None
@@ -283,12 +287,9 @@ class Reload:
             self.found_change = True
             on_finish = lambda: xreload_after_update(namespace)
 
-
         if on_finish is not None:
             # If a client wants to know about it, give him a chance.
             self._on_finish_callbacks.append(on_finish)
-
-
 
     def _update(self, namespace, name, oldobj, newobj, is_class_namespace=False):
         """Update oldobj, if possible in place, with newobj.
@@ -327,7 +328,7 @@ class Reload:
                 return
 
             if hasattr(types, 'ClassType'):
-                classtype = (types.ClassType, type) #object is not instance of types.ClassType.
+                classtype = (types.ClassType, type)  # object is not instance of types.ClassType.
             else:
                 classtype = type
 
@@ -361,11 +362,9 @@ class Reload:
 
         except:
             notify_error('Exception found when updating %s. Proceeding for other items.' % (name,))
-            traceback.print_exc()
-
+            pydev_log.exception()
 
     # All of the following functions have the same signature as _update()
-
 
     def _update_function(self, oldfunc, newfunc):
         """Update a function object."""
@@ -393,7 +392,6 @@ class Reload:
 
         return oldfunc
 
-
     def _update_method(self, oldmeth, newmeth):
         """Update a method object."""
         # XXX What if im_func is not a function?
@@ -402,7 +400,6 @@ class Reload:
         elif hasattr(oldmeth, '__func__') and hasattr(newmeth, '__func__'):
             self._update(None, None, oldmeth.__func__, newmeth.__func__)
         return oldmeth
-
 
     def _update_class(self, oldclass, newclass):
         """Update a class object."""
@@ -432,7 +429,6 @@ class Reload:
 
         self._handle_namespace(oldclass, is_class_namespace=True)
 
-
     def _update_classmethod(self, oldcm, newcm):
         """Update a classmethod update."""
         # While we can't modify the classmethod object itself (it has no
@@ -441,7 +437,6 @@ class Reload:
         # it in-place.  We don't have the class available to pass to
         # __get__() but any object except None will do.
         self._update(None, None, oldcm.__get__(0), newcm.__get__(0))
-
 
     def _update_staticmethod(self, oldsm, newsm):
         """Update a staticmethod update."""

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_resolver.py
@@ -1,3 +1,4 @@
+from _pydev_bundle import pydev_log
 try:
     import StringIO
 except:
@@ -457,7 +458,7 @@ class InstanceResolver:
                 declaredFields[i].setAccessible(True)
                 ret[name] = declaredFields[i].get(obj)
             except:
-                traceback.print_exc()
+                pydev_log.exception()
 
         return ret
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_signature.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_signature.py
@@ -1,3 +1,4 @@
+from _pydev_bundle import pydev_log
 
 try:
     import trace
@@ -98,8 +99,7 @@ class SignatureFactory(object):
                 signature.set_args(frame, recursive=True)
             return signature
         except:
-            import traceback
-            traceback.print_exc()
+            pydev_log.exception()
 
     def file_module_function_of(self, frame):  # this code is take from trace module and fixed to work with new-style classes
         code = frame.f_code

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_stackless.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_stackless.py
@@ -10,6 +10,7 @@ from _pydevd_bundle.pydevd_constants import dict_items
 from _pydevd_bundle.pydevd_custom_frames import update_custom_frame, remove_custom_frame, add_custom_frame
 from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame
 import stackless  # @UnresolvedImport
+from _pydev_bundle import pydev_log
 
 
 # Used so that we don't loose the id (because we'll remove when it's not alive and would generate a new id for the
@@ -25,21 +26,20 @@ class TaskletToLastId:
         self.tasklet_ref_to_last_id = {}
         self._i = 0
 
-
     def get(self, tasklet):
         return self.tasklet_ref_to_last_id.get(weakref.ref(tasklet))
-
 
     def __setitem__(self, tasklet, last_id):
         self.tasklet_ref_to_last_id[weakref.ref(tasklet)] = last_id
         self._i += 1
-        if self._i % 100 == 0: #Collect at each 100 additions to the dict (no need to rush).
+        if self._i % 100 == 0:  # Collect at each 100 additions to the dict (no need to rush).
             for tasklet_ref in list(self.tasklet_ref_to_last_id.keys()):
                 if tasklet_ref() is None:
                     del self.tasklet_ref_to_last_id[tasklet_ref]
 
 
 _tasklet_to_last_id = TaskletToLastId()
+
 
 #=======================================================================================================================
 # _TaskletInfo
@@ -109,6 +109,7 @@ class _TaskletInfo:
         self.tasklet_name = '%s %s %s (%s)' % (state, name, thread_name, tid)
 
     if not hasattr(stackless.tasklet, "trace_function"):
+
         # bug https://bitbucket.org/stackless-dev/stackless/issue/42
         # is not fixed. Stackless releases before 2014
         def update_name(self):
@@ -143,7 +144,9 @@ class _TaskletInfo:
                 tid = '-'
             self.tasklet_name = '%s %s (%s)' % (name, thread_name, tid)
 
+
 _weak_tasklet_registered_to_info = {}
+
 
 #=======================================================================================================================
 # get_tasklet_info
@@ -165,6 +168,7 @@ def register_tasklet_info(tasklet):
 
 
 _application_set_schedule_callback = None
+
 
 #=======================================================================================================================
 # _schedule_callback
@@ -233,19 +237,20 @@ def _schedule_callback(prev, next):
                             remove_custom_frame(tasklet_info.frame_id)
                             tasklet_info.frame_id = None
 
-
         finally:
             tasklet = None
             tasklet_info = None
             frame = None
 
     except:
-        import traceback;traceback.print_exc()
+        pydev_log.exception()
 
     if _application_set_schedule_callback is not None:
         return _application_set_schedule_callback(prev, next)
 
+
 if not hasattr(stackless.tasklet, "trace_function"):
+
     # Older versions of Stackless, released before 2014
     # This code does not work reliable! It is affected by several
     # stackless bugs: Stackless issues #44, #42, #40
@@ -304,11 +309,10 @@ if not hasattr(stackless.tasklet, "trace_function"):
                 f_back = None
 
         except:
-            import traceback;traceback.print_exc()
+            pydev_log.exception()
 
         if _application_set_schedule_callback is not None:
             return _application_set_schedule_callback(prev, next)
-
 
     _original_setup = stackless.tasklet.setup
 
@@ -321,6 +325,7 @@ if not hasattr(stackless.tasklet, "trace_function"):
         '''
 
         f = self.tempval
+
         def new_f(old_f, args, kwargs):
 
             debugger = get_global_debugger()
@@ -355,9 +360,7 @@ if not hasattr(stackless.tasklet, "trace_function"):
 
         return setup(self, *args, **kwargs)
 
-
     _original_run = stackless.run
-
 
     #=======================================================================================================================
     # run
@@ -369,7 +372,6 @@ if not hasattr(stackless.tasklet, "trace_function"):
         debugger = None
 
         return _original_run(*args, **kwargs)
-
 
 
 #=======================================================================================================================
@@ -409,5 +411,6 @@ def patch_stackless():
 
         run.__doc__ = stackless.run.__doc__
         stackless.run = run
+
 
 patch_stackless = call_only_once(patch_stackless)

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_suspended_frames.py
@@ -4,11 +4,11 @@ import sys
 from _pydev_imps._pydev_saved_modules import threading
 from _pydevd_bundle.pydevd_constants import get_frame, dict_items, RETURN_VALUES_DICT, \
     dict_iter_items
-import traceback
 from _pydevd_bundle.pydevd_xml import get_variable_details, get_type
 from _pydev_bundle.pydev_override import overrides
 from _pydevd_bundle.pydevd_resolver import sorted_attributes_key
 from _pydevd_bundle.pydevd_safe_repr import SafeRepr
+from _pydev_bundle import pydev_log
 
 
 class _AbstractVariable(object):
@@ -395,5 +395,5 @@ class SuspendedFramesManager(object):
 
             return None
         except:
-            traceback.print_exc()
+            pydev_log.exception()
             return None

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch.py
@@ -2,9 +2,8 @@
 # Should give warning only here if cython is not available but supported.
 
 import os
-import sys
 from _pydevd_bundle.pydevd_constants import CYTHON_SUPPORTED
-
+from _pydev_bundle import pydev_log
 
 use_cython = os.getenv('PYDEVD_USE_CYTHON', None)
 dirname = os.path.dirname(os.path.dirname(__file__))
@@ -15,9 +14,9 @@ if not CYTHON_SUPPORTED or dirname.endswith('.egg'):
 
 
 def delete_old_compiled_extensions():
-    import _pydevd_bundle_ext
-    cython_extensions_dir = os.path.dirname(os.path.dirname(_pydevd_bundle_ext.__file__))
-    _pydevd_bundle_ext_dir = os.path.dirname(_pydevd_bundle_ext.__file__)
+    import _pydevd_bundle
+    cython_extensions_dir = os.path.dirname(os.path.dirname(_pydevd_bundle.__file__))
+    _pydevd_bundle_ext_dir = os.path.dirname(_pydevd_bundle.__file__)
     _pydevd_frame_eval_ext_dir = os.path.join(cython_extensions_dir, '_pydevd_frame_eval_ext')
     try:
         import shutil
@@ -31,8 +30,7 @@ def delete_old_compiled_extensions():
         if os.path.exists(build_dir):
             shutil.rmtree(os.path.join(cython_extensions_dir, "build"))
     except OSError:
-        from _pydev_bundle.pydev_monkey import log_error_once
-        log_error_once("warning: failed to delete old cython speedups. Please delete all *.so files from the directories "
+        pydev_log.error_once("warning: failed to delete old cython speedups. Please delete all *.so files from the directories "
                        "\"%s\" and \"%s\"" % (_pydevd_bundle_ext_dir, _pydevd_frame_eval_ext_dir))
 
 
@@ -54,18 +52,16 @@ elif use_cython is None:
         # This version number from the already compiled cython extension
         from _pydevd_bundle.pydevd_cython_wrapper import version as cython_version
         if cython_version != regular_version:
-            delete_old_compiled_extensions()
-            raise ImportError()
+            # delete_old_compiled_extensions() -- would be ok in dev mode but we don't want to erase
+            # files from other python versions on release, so, just raise import error here.
+            raise ImportError('Cython version of speedups does not match.')
 
     except ImportError:
         from _pydevd_bundle.pydevd_trace_dispatch_regular import trace_dispatch, global_cache_skips, global_cache_frame_skips, fix_top_level_trace_and_get_trace_func  # @UnusedImport
-        #from _pydev_bundle.pydev_monkey import log_error_once
 
-        #log_error_once("warning: Debugger speedups using cython not found. Run '\"%s\" \"%s\" build_ext --inplace' to build." % (
-        #    sys.executable, os.path.join(dirname, 'setup_cython.py')))
-        pass
+        # pydev_log.error_once("warning: Debugger speedups using cython not found. Run '\"%s\" \"%s\" build_ext --inplace' to build.",
+        #     sys.executable, os.path.join(dirname, 'setup_cython.py'))
 
 else:
     raise RuntimeError('Unexpected value for PYDEVD_USE_CYTHON: %s (accepted: YES, NO)' % (use_cython,))
-
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py
@@ -1,12 +1,10 @@
-import traceback
-
 from _pydev_bundle.pydev_is_thread_alive import is_thread_alive
 from _pydev_imps._pydev_saved_modules import threading
 from _pydevd_bundle.pydevd_constants import get_current_thread_id, IS_IRONPYTHON, NO_FTRACE
 from _pydevd_bundle.pydevd_kill_all_pydevd_threads import kill_all_pydev_threads
 from pydevd_file_utils import get_abs_path_real_path_and_base_from_frame, NORM_PATHS_AND_BASE_CONTAINER
-from _pydevd_bundle.pydevd_comm_constants import CMD_STEP_INTO, CMD_STEP_INTO_MY_CODE, CMD_STEP_OVER, \
-    CMD_STEP_OVER_MY_CODE, CMD_STEP_RETURN, CMD_STEP_RETURN_MY_CODE
+from _pydevd_bundle.pydevd_comm_constants import CMD_STEP_INTO, CMD_STEP_INTO_MY_CODE, CMD_STEP_RETURN, CMD_STEP_RETURN_MY_CODE
+from _pydev_bundle.pydev_log import exception as pydev_log_exception
 # IFDEF CYTHON
 # from cpython.object cimport PyObject
 # from cpython.ref cimport Py_INCREF, Py_XDECREF
@@ -371,7 +369,7 @@ class ThreadTracer(object):
                         if py_db.output_checker_thread is None:
                             kill_all_pydev_threads()
                     except:
-                        traceback.print_exc()
+                        pydev_log_exception()
                     py_db._termination_event_set = True
                 return None if event == 'call' else NO_FTRACE
 
@@ -473,9 +471,9 @@ class ThreadTracer(object):
                 return None if event == 'call' else NO_FTRACE  # Don't log errors when we're shutting down.
             # Log it
             try:
-                if traceback is not None:
+                if pydev_log_exception is not None:
                     # This can actually happen during the interpreter shutdown in Python 2.7
-                    traceback.print_exc()
+                    pydev_log_exception()
             except:
                 # Error logging? We're really in the interpreter shutdown...
                 # (https://github.com/fabioz/PyDev.Debugger/issues/8)

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_traceproperty.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_traceproperty.py
@@ -2,8 +2,8 @@
 '''
 from _pydevd_bundle.pydevd_comm import get_global_debugger
 from _pydevd_bundle.pydevd_constants import DebugInfoHolder, IS_PY2
-import pydevd_tracing
-import traceback
+from _pydev_bundle import pydev_log
+
 
 #=======================================================================================================================
 # replace_builtin_property
@@ -17,15 +17,13 @@ def replace_builtin_property(new_property=None):
             import __builtin__
             __builtin__.__dict__['property'] = new_property
         except:
-            if DebugInfoHolder.DEBUG_TRACE_LEVEL:
-                traceback.print_exc() #@Reimport
+            pydev_log.exception()  # @Reimport
     else:
         try:
-            import builtins #Python 3.0 does not have the __builtin__ module @UnresolvedImport
+            import builtins  # Python 3.0 does not have the __builtin__ module @UnresolvedImport
             builtins.__dict__['property'] = new_property
         except:
-            if DebugInfoHolder.DEBUG_TRACE_LEVEL:
-                traceback.print_exc() #@Reimport
+            pydev_log.exception()  # @Reimport
     return original
 
 
@@ -38,13 +36,11 @@ class DebugProperty(object):
     the tracing.
     """
 
-
     def __init__(self, fget=None, fset=None, fdel=None, doc=None):
         self.fget = fget
         self.fset = fset
         self.fdel = fdel
         self.__doc__ = doc
-
 
     def __get__(self, obj, objtype=None):
         if obj is None:
@@ -90,13 +86,11 @@ class DebugProperty(object):
         self.fget = fget
         return self
 
-
     def setter(self, fset):
         """Overriding setter decorator for the property
         """
         self.fset = fset
         return self
-
 
     def deleter(self, fdel):
         """Overriding deleter decorator for the property

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_vars.py
@@ -5,6 +5,7 @@ import pickle
 from _pydevd_bundle.pydevd_constants import get_frame, get_current_thread_id, xrange
 
 from _pydevd_bundle.pydevd_xml import ExceptionOnEvaluate, get_type, var_to_xml
+from _pydev_bundle import pydev_log
 
 try:
     from StringIO import StringIO
@@ -136,9 +137,8 @@ def resolve_compound_variable_fields(dbg, thread_id, frame_id, scope, attrs):
         _type, _typeName, resolver = get_type(var)
         return _typeName, resolver.get_dictionary(var)
     except:
-        sys.stderr.write('Error evaluating: thread_id: %s\nframe_id: %s\nscope: %s\nattrs: %s\n' % (
-            thread_id, frame_id, scope, attrs,))
-        traceback.print_exc()
+        pydev_log.exception('Error evaluating: thread_id: %s\nframe_id: %s\nscope: %s\nattrs: %s.',
+            thread_id, frame_id, scope, attrs)
 
 
 def resolve_var_object(var, attrs):
@@ -177,7 +177,7 @@ def resolve_compound_var_object_fields(var, attrs):
         type, _typeName, resolver = get_type(var)
         return resolver.get_dictionary(var)
     except:
-        traceback.print_exc()
+        pydev_log.exception()
 
 
 def custom_operation(dbg, thread_id, frame_id, scope, attrs, style, code_or_file, operation_fn_name):
@@ -200,7 +200,7 @@ def custom_operation(dbg, thread_id, frame_id, scope, attrs, style, code_or_file
 
         return str(namespace[operation_fn_name](expressionValue))
     except:
-        traceback.print_exc()
+        pydev_log.exception()
 
 
 def eval_in_context(expression, globals, locals):
@@ -317,7 +317,7 @@ def change_attr_expression(frame, attr, expression, dbg, value=SENTINEL_VALUE):
             return result
 
     except Exception:
-        traceback.print_exc()
+        pydev_log.exception()
 
 
 MAXIMUM_ARRAY_SIZE = 100

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_xml.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_xml.py
@@ -1,5 +1,4 @@
 from _pydev_bundle import pydev_log
-import traceback
 from _pydevd_bundle import pydevd_extension_utils
 from _pydevd_bundle import pydevd_resolver
 import sys
@@ -162,7 +161,7 @@ class TypeResolveHandler(object):
                     self._type_to_resolver_cache[type_object] = resolver
                     return (type_object, type_name, resolver)
         except:
-            traceback.print_exc()
+            pydev_log.exception()
 
         # No match return default (and cache it).
         resolver = pydevd_resolver.defaultResolver
@@ -264,8 +263,7 @@ def frame_vars_to_xml(frame_f_locals, hidden_ns=None):
                 else:
                     xml += var_to_xml(v, str(k), evaluate_full_value=eval_full_val)
         except Exception:
-            traceback.print_exc()
-            pydev_log.error("Unexpected error, recovered safely.\n")
+            pydev_log.exception("Unexpected error, recovered safely.")
 
     # Show return values as the first entry.
     return return_values_xml + xml

--- a/src/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_eval_main.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_eval_main.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from _pydevd_bundle.pydevd_constants import IS_PYCHARM
+from _pydev_bundle import pydev_log
 
 IS_PY36_OR_GREATER = sys.version_info >= (3, 6)
 
@@ -27,12 +28,10 @@ elif use_frame_eval is None:
         try:
             from _pydevd_frame_eval.pydevd_frame_eval_cython_wrapper import frame_eval_func, stop_frame_eval, dummy_trace_dispatch, clear_thread_local_info
         except ImportError:
-            from _pydev_bundle.pydev_monkey import log_error_once
-
             dirname = os.path.dirname(os.path.dirname(__file__))
             if not IS_PYCHARM:
-                #log_error_once("warning: Debugger speedups using cython not found. Run '\"%s\" \"%s\" build_ext --inplace' to build." % (
-                #    sys.executable, os.path.join(dirname, 'setup_cython.py')))
+                # pydev_log.error_once("warning: Debugger speedups using cython not found. Run '\"%s\" \"%s\" build_ext --inplace' to build.",
+                #     sys.executable, os.path.join(dirname, 'setup_cython.py'))
                 pass
             else:
                 show_frame_eval_warning = True

--- a/src/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_modify_bytecode.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_modify_bytecode.py
@@ -1,7 +1,7 @@
 import dis
-import traceback
 from opcode import opmap, EXTENDED_ARG, HAVE_ARGUMENT
 from types import CodeType
+from _pydev_bundle import pydev_log
 
 MAX_BYTE = 255
 RETURN_VALUE_SIZE = 2
@@ -267,7 +267,7 @@ def _insert_code(code_to_modify, code_to_insert, before_line):
             return False, code_to_modify
 
     except ValueError:
-        traceback.print_exc()
+        pydev_log.exception()
         return False, code_to_modify
 
     new_code = CodeType(

--- a/src/ptvsd/_vendored/pydevd/conftest.py
+++ b/src/ptvsd/_vendored/pydevd/conftest.py
@@ -5,6 +5,7 @@ from tests_python.debug_constants import TEST_CYTHON
 from tests_python.debug_constants import TEST_JYTHON
 import site
 import os
+from _pydev_bundle import pydev_log
 
 
 def pytest_report_header(config):
@@ -201,7 +202,7 @@ def before_after_each_function(request):
             from pympler import summary, muppy
             sum1 = summary.summarize(muppy.get_objects())
         except:
-            import traceback;traceback.print_exc()
+            pydev_log.exception()
 
     sys.stdout.write(
 '''
@@ -247,7 +248,7 @@ Memory before: %s
             else:
                 _global_collect_info = False
         except:
-            import traceback;traceback.print_exc()
+            pydev_log.exception()
 
     sys.stdout.write(
 '''

--- a/src/ptvsd/_vendored/pydevd/pydev_ipython/matplotlibtools.py
+++ b/src/ptvsd/_vendored/pydevd/pydev_ipython/matplotlibtools.py
@@ -1,10 +1,11 @@
 
 import sys
+from _pydev_bundle import pydev_log
 
 backends = {'tk': 'TkAgg',
             'gtk': 'GTKAgg',
             'wx': 'WXAgg',
-            'qt': 'Qt4Agg', # qt3 not supported
+            'qt': 'Qt4Agg',  # qt3 not supported
             'qt4': 'Qt4Agg',
             'qt5': 'Qt5Agg',
             'osx': 'MacOSX'}
@@ -31,8 +32,7 @@ def do_enable_gui(guiname):
             enable_gui(guiname)
         except:
             sys.stderr.write("Failed to enable GUI event loop integration for '%s'\n" % guiname)
-            import traceback
-            traceback.print_exc()
+            pydev_log.exception()
     elif guiname not in ['none', '', None]:
         # Only print a warning if the guiname was going to do something
         sys.stderr.write("Debug console: Python version does not support GUI event loop integration for '%s'\n" % guiname)
@@ -66,6 +66,7 @@ def is_interactive_backend(backend):
 def patch_use(enable_gui_function):
     """ Patch matplotlib function 'use' """
     matplotlib = sys.modules['matplotlib']
+
     def patched_use(*args, **kwargs):
         matplotlib.real_use(*args, **kwargs)
         gui, backend = find_gui_and_backend()
@@ -78,6 +79,7 @@ def patch_use(enable_gui_function):
 def patch_is_interactive():
     """ Patch matplotlib function 'use' """
     matplotlib = sys.modules['matplotlib']
+
     def patched_is_interactive():
         return matplotlib.rcParams['interactive']
 
@@ -122,9 +124,9 @@ def flag_calls(func):
     if hasattr(func, 'called'):
         return func
 
-    def wrapper(*args,**kw):
+    def wrapper(*args, **kw):
         wrapper.called = False
-        out = func(*args,**kw)
+        out = func(*args, **kw)
         wrapper.called = True
         return out
 

--- a/src/ptvsd/_vendored/pydevd/pydevd.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd.py
@@ -427,7 +427,7 @@ class PyDB(object):
         # was killed.
         self._running_thread_ids = {}
         # Note: also access '_enable_thread_notifications' with '_lock_running_thread_ids'
-        self._enable_thread_notifications = True
+        self._enable_thread_notifications = False
 
         self._set_breakpoints_with_id = False
 

--- a/src/ptvsd/_vendored/pydevd/pydevd_concurrency_analyser/pydevd_concurrency_logger.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd_concurrency_analyser/pydevd_concurrency_logger.py
@@ -1,5 +1,4 @@
 import time
-import traceback
 
 from _pydev_bundle._pydev_filesystem_encoding import getfilesystemencoding
 from _pydev_imps._pydev_saved_modules import threading
@@ -9,6 +8,7 @@ from _pydevd_bundle.pydevd_constants import get_thread_id, IS_PY3K
 from _pydevd_bundle.pydevd_net_command import NetCommand
 from pydevd_concurrency_analyser.pydevd_thread_wrappers import ObjectWrapper, wrap_attr
 import pydevd_file_utils
+from _pydev_bundle import pydev_log
 
 file_system_encoding = getfilesystemencoding()
 
@@ -74,7 +74,7 @@ def get_text_list_for_frame(frame):
             cmdTextList.append("</frame>")
             curFrame = curFrame.f_back
     except :
-        traceback.print_exc()
+        pydev_log.exception()
 
     return cmdTextList
 
@@ -230,7 +230,7 @@ class ThreadingLogger:
                         #       real_method, back.f_code.co_filename, back.f_lineno)
 
         except Exception:
-            traceback.print_exc()
+            pydev_log.exception()
 
 
 class NameManager:

--- a/src/ptvsd/_vendored/pydevd/pydevd_file_utils.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd_file_utils.py
@@ -41,6 +41,7 @@ r'''
         machine for the paths that'll actually have breakpoints).
 '''
 
+from _pydev_bundle import pydev_log
 from _pydevd_bundle.pydevd_constants import IS_PY2, IS_PY3K, DebugInfoHolder, IS_WINDOWS, IS_JYTHON
 from _pydev_bundle._pydev_filesystem_encoding import getfilesystemencoding
 from _pydevd_bundle.pydevd_comm_constants import file_system_encoding, filesystem_encoding_is_utf8
@@ -78,7 +79,7 @@ try:
     PATHS_FROM_ECLIPSE_TO_PYTHON = json.loads(os.environ.get('PATHS_FROM_ECLIPSE_TO_PYTHON', '[]'))
 except Exception:
     sys.stderr.write('Error loading PATHS_FROM_ECLIPSE_TO_PYTHON from environment variable.\n')
-    traceback.print_exc()
+    pydev_log.exception()
     PATHS_FROM_ECLIPSE_TO_PYTHON = []
 else:
     if not isinstance(PATHS_FROM_ECLIPSE_TO_PYTHON, list):
@@ -206,7 +207,7 @@ if sys.platform == 'win32':
                                          'filename: %s\ndrive: %s\nparts: %s\n'
                                          '(please create a ticket in the tracker to address this).\n\n' % (
                                              filename, drive, parts))
-                        traceback.print_exc()
+                        pydev_log.exception()
                     # Don't fail, just return the original file passed.
                     return filename
 
@@ -215,7 +216,7 @@ if sys.platform == 'win32':
     except:
         # Something didn't quite work out, leave no-op conversions in place.
         if DebugInfoHolder.DEBUG_TRACE_LEVEL > 2:
-            traceback.print_exc()
+            pydev_log.exception()
     else:
         convert_to_long_pathname = _convert_to_long_pathname
         convert_to_short_pathname = _convert_to_short_pathname
@@ -454,7 +455,7 @@ try:
 
 except:
     # Don't fail if there's something not correct here -- but at least print it to the user so that we can correct that
-    traceback.print_exc()
+    pydev_log.exception()
 
 # Note: as these functions may be rebound, users should always import
 # pydevd_file_utils and then use:

--- a/src/ptvsd/_vendored/pydevd/pydevd_plugins/django_debug.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd_plugins/django_debug.py
@@ -117,7 +117,7 @@ def _is_django_render_call(frame, debug=False):
 
         return clsname != 'TextNode' and clsname != 'NodeList'
     except:
-        traceback.print_exc()
+        pydev_log.exception()
         return False
 
 
@@ -130,7 +130,7 @@ def _is_django_context_get_call(frame):
 
         return _inherits(cls, 'BaseContext')
     except:
-        traceback.print_exc()
+        pydev_log.exception()
         return False
 
 
@@ -148,7 +148,7 @@ def _is_django_resolve_call(frame):
         clsname = cls.__name__
         return clsname == 'Variable'
     except:
-        traceback.print_exc()
+        pydev_log.exception()
         return False
 
 
@@ -225,7 +225,7 @@ def _get_source_django_18_or_lower(frame):
             return None
 
     except:
-        pydev_log.debug(traceback.format_exc())
+        pydev_log.exception()
         return None
 
 

--- a/src/ptvsd/_vendored/pydevd/pydevd_plugins/jinja2_debug.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd_plugins/jinja2_debug.py
@@ -1,10 +1,10 @@
-import traceback
 from _pydevd_bundle.pydevd_breakpoints import LineBreakpoint
 from _pydevd_bundle.pydevd_constants import STATE_SUSPEND, dict_iter_items, dict_keys, JINJA2_SUSPEND, \
     IS_PY2
 from _pydevd_bundle.pydevd_comm import CMD_SET_BREAK, CMD_ADD_EXCEPTION_BREAK
 from pydevd_file_utils import get_abs_path_real_path_and_base_from_file
 from _pydevd_bundle.pydevd_frame_utils import add_exception_to_frame, FCode
+from _pydev_bundle import pydev_log
 
 
 class Jinja2LineBreakpoint(LineBreakpoint):
@@ -75,7 +75,7 @@ def _is_jinja2_render_call(frame):
             return True
         return False
     except:
-        traceback.print_exc()
+        pydev_log.exception()
         return False
 
 

--- a/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_thread_started_exited.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_thread_started_exited.py
@@ -1,0 +1,18 @@
+import threading
+
+
+class MyThread(threading.Thread):
+
+    def run(self):
+        pass
+
+
+threads = [MyThread() for i in range(3)]
+
+for t in threads:
+    t.start()
+
+for t in threads:
+    t.join()
+
+print('TEST SUCEEDED!')  # Break here

--- a/src/ptvsd/_vendored/pydevd/tests_python/test_debugger_json.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/test_debugger_json.py
@@ -1401,7 +1401,18 @@ def test_goto(case_setup):
 
 @pytest.mark.parametrize('dbg_property', ['dont_trace', 'trace', 'change_pattern', 'dont_trace_after_start'])
 def test_set_debugger_property(case_setup, dbg_property):
-    with case_setup.test_file('_debugger_case_dont_trace_test.py') as writer:
+
+    kwargs = {}
+    if dbg_property == 'dont_trace_after_start':
+
+        def additional_output_checks(writer, stdout, stderr):
+            if "Calls to set or change don't trace patterns (via setDebuggerProperty) are not allowed since debugging has already started or don't trace patterns are already set." not in stderr:
+                raise AssertionError('Expected test to have error message.\nstdout:\n%s\n\nstderr:\n%s' % (
+                    stdout, stderr))
+
+        kwargs['additional_output_checks'] = additional_output_checks
+
+    with case_setup.test_file('_debugger_case_dont_trace_test.py', **kwargs) as writer:
         json_facade = JsonFacade(writer)
 
         json_facade.write_set_breakpoints(writer.get_line_index_with_content('Break here'))

--- a/src/ptvsd/wrapper.py
+++ b/src/ptvsd/wrapper.py
@@ -1158,10 +1158,14 @@ class VSCodeMessageProcessor(VSCLifecycleMsgProcessor):
     def on_pydevd_event(self, cmd_id, seq, args):
         if not self._detached:
             try:
-                f = self.pydevd_events[cmd_id]
-            except KeyError:
-                raise UnsupportedPyDevdCommandError(cmd_id)
-            return f(self, seq, args)
+                try:
+                    f = self.pydevd_events[cmd_id]
+                except KeyError:
+                    raise UnsupportedPyDevdCommandError(cmd_id)
+                return f(self, seq, args)
+            except:
+                ptvsd.log.exception('Error handling pydevd event: {0}', args)
+                raise
         else:
             return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,17 +22,16 @@ _original_dump_stacks = pytest_timeout.dump_stacks
 
 
 def _print_pydevd_log(reason):
-    print('******************************************************************')
-    print('pydevd log on %s' % (reason,))
-    print('******************************************************************')
+    sys.stderr.write('\n******************************************************************\n')
+    sys.stderr.write('pydevd log on %s\n' % (reason,))
+    sys.stderr.write('******************************************************************\n')
     current_pydevd_debug_file = os.environ.get('PYDEVD_DEBUG_FILE')
     if current_pydevd_debug_file:
         if os.path.exists(current_pydevd_debug_file):
             with open(current_pydevd_debug_file, 'r') as stream:
-                print(stream.read())
-    print('******************************************************************')
-    print('******************************************************************')
-    print('******************************************************************')
+                sys.stderr.write(stream.read())
+    sys.stderr.write('\n******************************************************************\n')
+    sys.stderr.write('******************************************************************\n')
 
 
 def _on_dump_stack_print_pydevd_log():

--- a/tests/func/test_output.py
+++ b/tests/func/test_output.py
@@ -11,6 +11,7 @@ from tests.helpers.pattern import ANY
 
 
 def test_with_no_output(pyfile, run_as, start_method):
+
     @pyfile
     def code_to_debug():
         from dbgimporter import import_and_enable_debugger
@@ -26,6 +27,7 @@ def test_with_no_output(pyfile, run_as, start_method):
 
 
 def test_with_tab_in_output(pyfile, run_as, start_method):
+
     @pyfile
     def code_to_debug():
         from dbgimporter import import_and_enable_debugger
@@ -33,7 +35,7 @@ def test_with_tab_in_output(pyfile, run_as, start_method):
         a = '\t'.join(('Hello', 'World'))
         print(a)
         # Break here so we are sure to get the output event.
-        a = 1 # @bp1
+        a = 1  # @bp1
 
     line_numbers = get_marked_line_numbers(code_to_debug)
     with DebugSession() as session:

--- a/tests/helpers/session.py
+++ b/tests/helpers/session.py
@@ -522,9 +522,10 @@ class DebugSession(object):
         if not self.no_debug:
             # Issue 'threads' so that we get the 'thread' event for the main thread now,
             # rather than at some random time later during the test.
-            (self.send_request('threads')
-                .causing(Event('thread'))
-                .wait_for_response())
+            # Note: it's actually possible that the 'thread' event was sent before the 'threads'
+            # request (although the 'threads' will force 'thread' to be sent if it still wasn't).
+            self.send_request('threads').wait_for_response()
+            self.expect_realized(Event('thread'))
 
     def start_debugging(self, freeze=True):
         """Finalizes the configuration stage, and issues a 'configurationDone' request


### PR DESCRIPTION
With this change, all the thread notifications come from pydevd through the DAP.

I think this is a big change in how things work internally, so, maybe it'd be nice to do some manual testing especially in disconnect/reconnect scenarios with threads/django/flask/multiprocessing (I haven't actually checked -- do we support disconnect/reconnect in multiprocessing scenarios?)