### PR TITLE
Make it possible to use debugger in IronPython again.

### DIFF
--- a/src/ptvsd/_vendored/pydevd/pydevd.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd.py
@@ -37,7 +37,7 @@ from _pydevd_bundle.pydevd_comm_constants import (CMD_THREAD_SUSPEND, CMD_STEP_I
 from _pydevd_bundle.pydevd_constants import (IS_JYTH_LESS25, IS_PYCHARM, get_thread_id, get_current_thread_id,
     dict_keys, dict_iter_items, DebugInfoHolder, PYTHON_SUSPEND, STATE_SUSPEND, STATE_RUN, get_frame,
     clear_cached_thread_id, INTERACTIVE_MODE_AVAILABLE, SHOW_DEBUG_INFO_ENV, IS_PY34_OR_GREATER, IS_PY2, NULL,
-    NO_FTRACE, GOTO_HAS_RESPONSE)
+    NO_FTRACE, GOTO_HAS_RESPONSE, IS_IRONPYTHON)
 from _pydevd_bundle.pydevd_custom_frames import CustomFramesContainer, custom_frames_container_init
 from _pydevd_bundle.pydevd_dont_trace_files import DONT_TRACE, PYDEV_FILE
 from _pydevd_bundle.pydevd_extension_api import DebuggerEventHandler
@@ -464,7 +464,15 @@ class PyDB(object):
         # Bind many locals to the debugger because upon teardown those names may become None
         # in the namespace (and thus can't be relied upon unless the reference was previously
         # saved).
-        self.trace_dispatch = partial(_trace_dispatch, self)
+        if IS_IRONPYTHON:
+
+            # A partial() cannot be used in IronPython for sys.settrace.
+            def new_trace_dispatch(frame, event, arg):
+                return _trace_dispatch(self, frame, event, arg)
+
+            self.trace_dispatch = new_trace_dispatch
+        else:
+            self.trace_dispatch = partial(_trace_dispatch, self)
         self.fix_top_level_trace_and_get_trace_func = fix_top_level_trace_and_get_trace_func
         self.frame_eval_func = frame_eval_func
         self.dummy_trace_dispatch = dummy_trace_dispatch

--- a/src/ptvsd/_vendored/pydevd/pydevd_tracing.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd_tracing.py
@@ -3,63 +3,66 @@ from _pydevd_bundle.pydevd_constants import get_frame
 from _pydev_imps._pydev_saved_modules import thread
 
 try:
-    import cStringIO as StringIO #may not always be available @UnusedImport
+    import cStringIO as StringIO  # may not always be available @UnusedImport
 except:
     try:
-        import StringIO #@Reimport
+        import StringIO  # @Reimport
     except:
         import io as StringIO
 
-
-import sys #@Reimport
+import sys  # @Reimport
 import traceback
 
 _original_settrace = sys.settrace
 
+
 class TracingFunctionHolder:
-    '''This class exists just to keep some variables (so that we don't keep them in the global namespace). 
+    '''This class exists just to keep some variables (so that we don't keep them in the global namespace).
     '''
     _original_tracing = None
     _warn = True
     _lock = thread.allocate_lock()
     _traceback_limit = 1
     _warnings_shown = {}
- 
- 
+
+
 def get_exception_traceback_str():
     exc_info = sys.exc_info()
     s = StringIO.StringIO()
     traceback.print_exception(exc_info[0], exc_info[1], exc_info[2], file=s)
     return s.getvalue()
 
+
 def _get_stack_str(frame):
-    
+
     msg = '\nIf this is needed, please check: ' + \
           '\nhttp://pydev.blogspot.com/2007/06/why-cant-pydev-debugger-work-with.html' + \
-          '\nto see how to restore the debug tracing back correctly.\n' 
-          
+          '\nto see how to restore the debug tracing back correctly.\n'
+
     if TracingFunctionHolder._traceback_limit:
         s = StringIO.StringIO()
         s.write('Call Location:\n')
         traceback.print_stack(f=frame, limit=TracingFunctionHolder._traceback_limit, file=s)
         msg = msg + s.getvalue()
-    
+
     return msg
+
 
 def _internal_set_trace(tracing_func):
     if TracingFunctionHolder._warn:
         frame = get_frame()
         if frame is not None and frame.f_back is not None:
-            if not frame.f_back.f_code.co_filename.lower().endswith('threading.py'):
-            
+            filename = frame.f_back.f_code.co_filename.lower()
+            if not filename.endswith('threading.py') and not filename.endswith('pydevd_tracing.py'):
+
                 message = \
                 '\nPYDEV DEBUGGER WARNING:' + \
                 '\nsys.settrace() should not be used when the debugger is being used.' + \
                 '\nThis may cause the debugger to stop working correctly.' + \
                 '%s' % _get_stack_str(frame.f_back)
-                
+
                 if message not in TracingFunctionHolder._warnings_shown:
-                    #only warn about each message once...
+                    # only warn about each message once...
                     TracingFunctionHolder._warnings_shown[message] = 1
                     sys.stderr.write('%s\n' % (message,))
                     sys.stderr.flush()
@@ -70,7 +73,7 @@ def _internal_set_trace(tracing_func):
 
 def SetTrace(tracing_func):
     if TracingFunctionHolder._original_tracing is None:
-        #This may happen before replace_sys_set_trace_func is called.
+        # This may happen before replace_sys_set_trace_func is called.
         sys.settrace(tracing_func)
         return
 
@@ -87,6 +90,7 @@ def replace_sys_set_trace_func():
     if TracingFunctionHolder._original_tracing is None:
         TracingFunctionHolder._original_tracing = sys.settrace
         sys.settrace = _internal_set_trace
+
 
 def restore_sys_set_trace_func():
     if TracingFunctionHolder._original_tracing is not None:


### PR DESCRIPTION
I know ptvsd doesn't officially support IronPython, and I don't really know whether the DAP works with it as it's not currently in the ci -- not even in the `pydevd` ci, where currently I only take a look when someone complains, but with this change (using the `pydevd` protocol) it's working for a simple scenario (i.e.: hit breakpoints/step in/over), so, it's at least a step in the right direction.