### PR TITLE
Always send goto response

### DIFF
--- a/src/ptvsd/_vendored/force_pydevd.py
+++ b/src/ptvsd/_vendored/force_pydevd.py
@@ -3,16 +3,14 @@ import warnings
 
 from . import check_modules, prefix_matcher, preimport, vendored
 
-
 # Ensure that pydevd is our vendored copy.
 _unvendored, _ = check_modules('pydevd',
                                prefix_matcher('pydev', '_pydev'))
 if _unvendored:
     _unvendored = sorted(_unvendored.values())
     msg = 'incompatible copy of pydevd already imported'
-    #raise ImportError(msg)
+    # raise ImportError(msg)
     warnings.warn(msg + ':\n {}'.format('\n  '.join(_unvendored)))
-
 
 # Constants must be set before importing any other pydevd module
 # # due to heavy use of "from" in them.
@@ -21,10 +19,7 @@ with vendored('pydevd'):
 # TODO: figure out what the appropriate setting is to work for both wheels and sdist.
 pydevd_constants.CYTHON_SUPPORTED = False
 # We limit representation size in our representation provider when needed.
-pydevd_constants.MAXIMUM_VARIABLE_REPRESENTATION_SIZE = 2**32
-# We want CMD_SET_NEXT_STATEMENT to have a response indicating success or failure.
-pydevd_constants.GOTO_HAS_RESPONSE = True
-
+pydevd_constants.MAXIMUM_VARIABLE_REPRESENTATION_SIZE = 2 ** 32
 
 # Now make sure all the top-level modules and packages in pydevd are
 # loaded.  Any pydevd modules that aren't loaded at this point, will

--- a/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_log.py
+++ b/src/ptvsd/_vendored/pydevd/_pydev_bundle/pydev_log.py
@@ -1,7 +1,9 @@
-from _pydevd_bundle.pydevd_constants import DebugInfoHolder
+from _pydevd_bundle.pydevd_constants import DebugInfoHolder, SHOW_COMPILE_CYTHON_COMMAND_LINE
 from _pydev_imps._pydev_saved_modules import threading
 from contextlib import contextmanager
 import traceback
+import os
+import sys
 currentThread = threading.currentThread
 
 WARN_ONCE_MAP = {}
@@ -95,4 +97,11 @@ def error_once(msg, *args):
     if message not in WARN_ONCE_MAP:
         WARN_ONCE_MAP[message] = True
         critical(message)
+
+
+def show_compile_cython_command_line():
+    if SHOW_COMPILE_CYTHON_COMMAND_LINE:
+        dirname = os.path.dirname(os.path.dirname(__file__))
+        error_once("warning: Debugger speedups using cython not found. Run '\"%s\" \"%s\" build_ext --inplace' to build.",
+            sys.executable, os.path.join(dirname, 'setup_cython.py'))
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_constants.py
@@ -2,8 +2,6 @@
 This module holds the constants used for specifying the states of the debugger.
 '''
 from __future__ import nested_scopes
-import traceback
-from contextlib import contextmanager
 
 STATE_RUN = 1
 STATE_SUSPEND = 2
@@ -126,10 +124,8 @@ USE_LIB_COPY = SUPPORT_GEVENT and \
                 (IS_PY3K and sys.version_info[1] >= 3))
 
 INTERACTIVE_MODE_AVAILABLE = sys.platform in ('darwin', 'win32') or os.getenv('DISPLAY') is not None
-IS_PYCHARM = False
 
-# If True, CMD_SET_NEXT_STATEMENT and CMD_RUN_TO_LINE commands have responses indicating success or failure.
-GOTO_HAS_RESPONSE = IS_PYCHARM
+SHOW_COMPILE_CYTHON_COMMAND_LINE = os.getenv('PYDEVD_SHOW_COMPILE_CYTHON_COMMAND_LINE', 'False') == 'True'
 
 LOAD_VALUES_ASYNC = os.getenv('PYDEVD_LOAD_VALUES_ASYNC', 'False') == 'True'
 DEFAULT_VALUE = "__pydevd_value_async"

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
@@ -20,7 +20,7 @@ from _pydevd_bundle.pydevd_net_command import NetCommand
 from _pydevd_bundle.pydevd_net_command_factory_xml import NetCommandFactory
 from _pydevd_bundle.pydevd_utils import get_non_pydevd_threads
 import pydevd_file_utils
-from _pydevd_bundle.pydevd_comm import pydevd_find_thread_by_id, build_exception_info_response
+from _pydevd_bundle.pydevd_comm import build_exception_info_response
 from _pydevd_bundle.pydevd_additional_thread_info_regular import set_additional_thread_info
 
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch.py
@@ -58,10 +58,7 @@ elif use_cython is None:
 
     except ImportError:
         from _pydevd_bundle.pydevd_trace_dispatch_regular import trace_dispatch, global_cache_skips, global_cache_frame_skips, fix_top_level_trace_and_get_trace_func  # @UnusedImport
-
-        # pydev_log.error_once("warning: Debugger speedups using cython not found. Run '\"%s\" \"%s\" build_ext --inplace' to build.",
-        #     sys.executable, os.path.join(dirname, 'setup_cython.py'))
-
+        pydev_log.show_compile_cython_command_line()
 else:
     raise RuntimeError('Unexpected value for PYDEVD_USE_CYTHON: %s (accepted: YES, NO)' % (use_cython,))
 

--- a/src/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_eval_main.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_frame_eval/pydevd_frame_eval_main.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-from _pydevd_bundle.pydevd_constants import IS_PYCHARM
 from _pydev_bundle import pydev_log
 
 IS_PY36_OR_GREATER = sys.version_info >= (3, 6)
@@ -9,7 +8,6 @@ IS_PY36_OR_GREATER = sys.version_info >= (3, 6)
 frame_eval_func = None
 stop_frame_eval = None
 dummy_trace_dispatch = None
-show_frame_eval_warning = False
 clear_thread_local_info = None
 
 # "NO" means we should not use frame evaluation, 'YES' we should use it (and fail if not there) and unspecified uses if possible.
@@ -28,13 +26,7 @@ elif use_frame_eval is None:
         try:
             from _pydevd_frame_eval.pydevd_frame_eval_cython_wrapper import frame_eval_func, stop_frame_eval, dummy_trace_dispatch, clear_thread_local_info
         except ImportError:
-            dirname = os.path.dirname(os.path.dirname(__file__))
-            if not IS_PYCHARM:
-                # pydev_log.error_once("warning: Debugger speedups using cython not found. Run '\"%s\" \"%s\" build_ext --inplace' to build.",
-                #     sys.executable, os.path.join(dirname, 'setup_cython.py'))
-                pass
-            else:
-                show_frame_eval_warning = True
+            pydev_log.show_compile_cython_command_line()
 
 else:
     raise RuntimeError('Unexpected value for PYDEVD_USE_FRAME_EVAL: %s (accepted: YES, NO)' % (use_frame_eval,))

--- a/src/ptvsd/_vendored/pydevd/pydevd.py
+++ b/src/ptvsd/_vendored/pydevd/pydevd.py
@@ -34,10 +34,10 @@ from _pydevd_bundle.pydevd_comm_constants import (CMD_THREAD_SUSPEND, CMD_STEP_I
     CMD_STEP_INTO_MY_CODE, CMD_STEP_OVER, CMD_SMART_STEP_INTO, CMD_RUN_TO_LINE,
     CMD_SET_NEXT_STATEMENT, CMD_STEP_RETURN, CMD_ADD_EXCEPTION_BREAK, CMD_STEP_RETURN_MY_CODE,
     CMD_STEP_OVER_MY_CODE)
-from _pydevd_bundle.pydevd_constants import (IS_JYTH_LESS25, IS_PYCHARM, get_thread_id, get_current_thread_id,
+from _pydevd_bundle.pydevd_constants import (IS_JYTH_LESS25, get_thread_id, get_current_thread_id,
     dict_keys, dict_iter_items, DebugInfoHolder, PYTHON_SUSPEND, STATE_SUSPEND, STATE_RUN, get_frame,
     clear_cached_thread_id, INTERACTIVE_MODE_AVAILABLE, SHOW_DEBUG_INFO_ENV, IS_PY34_OR_GREATER, IS_PY2, NULL,
-    NO_FTRACE, GOTO_HAS_RESPONSE, IS_IRONPYTHON)
+    NO_FTRACE, IS_IRONPYTHON)
 from _pydevd_bundle.pydevd_custom_frames import CustomFramesContainer, custom_frames_container_init
 from _pydevd_bundle.pydevd_dont_trace_files import DONT_TRACE, PYDEV_FILE
 from _pydevd_bundle.pydevd_extension_api import DebuggerEventHandler
@@ -1406,11 +1406,10 @@ class PyDB(object):
             except ValueError as e:
                 response_msg = "%s" % e
             finally:
-                if GOTO_HAS_RESPONSE:
-                    seq = info.pydev_message
-                    cmd = self.cmd_factory.make_set_next_stmnt_status_message(seq, stop, response_msg)
-                    self.writer.add_command(cmd)
-                    info.pydev_message = ''
+                seq = info.pydev_message
+                cmd = self.cmd_factory.make_set_next_stmnt_status_message(seq, stop, response_msg)
+                self.writer.add_command(cmd)
+                info.pydev_message = ''
 
             if stop:
                 # Uninstall the current frames tracker before running it.


### PR DESCRIPTION
With this change I'm also using an env variable to determine whether the cython compile command line should be shown so that the code on `pydevd` and `ptvsd` is the same.