### PR TITLE
Fix object_repr slicing in Python2

### DIFF
--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
@@ -306,7 +306,7 @@ class SafeRepr(object):
 
         if isinstance(obj_repr, bytes):
             # convert to unicode before slicing strings
-            obj_repr = obj_repr.decode(sys.stdout.encoding or 'utf-8', errors='replace')
+            obj_repr = obj_repr.decode(getattr(sys.stdout, 'encoding', None) or 'utf-8', errors='replace')
             yield obj_repr[:left_count].encode('utf-8')
             yield '...'
             yield obj_repr[-right_count:].encode('utf-8')

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
@@ -304,6 +304,7 @@ class SafeRepr(object):
         # you are using the wrong class.
         left_count, right_count = max(1, int(2 * limit / 3)), max(1, int(limit / 3))  # noqa
 
-        yield obj_repr[:left_count]
+        obj_repr = obj_repr.decode('utf-8')
+        yield obj_repr[:left_count].encode('utf-8')
         yield '...'
-        yield obj_repr[-right_count:]
+        yield obj_repr[-right_count:].encode('utf-8')

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
@@ -304,7 +304,7 @@ class SafeRepr(object):
         # you are using the wrong class.
         left_count, right_count = max(1, int(2 * limit / 3)), max(1, int(limit / 3))  # noqa
 
-        if isintance(obj_repr, bytes):
+        if isinstance(obj_repr, bytes):
             # convert to unicode before slicing strings
             obj_repr = unicode(obj_repr, 'utf-8', errors='replace')
             yield obj_repr[:left_count].encode('utf-8')

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
@@ -304,7 +304,13 @@ class SafeRepr(object):
         # you are using the wrong class.
         left_count, right_count = max(1, int(2 * limit / 3)), max(1, int(limit / 3))  # noqa
 
-        obj_repr = obj_repr.decode('utf-8')
-        yield obj_repr[:left_count].encode('utf-8')
-        yield '...'
-        yield obj_repr[-right_count:].encode('utf-8')
+        if isintance(obj_repr, bytes):
+            # convert to unicode before slicing strings
+            obj_repr = unicode(obj_repr, 'utf-8', errors='replace')
+            yield obj_repr[:left_count].encode('utf-8')
+            yield '...'
+            yield obj_repr[-right_count:].encode('utf-8')
+        else:
+            yield obj_repr[:left_count]
+            yield '...'
+            yield obj_repr[-right_count:]

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
@@ -306,7 +306,7 @@ class SafeRepr(object):
 
         if isinstance(obj_repr, bytes):
             # convert to unicode before slicing strings
-            obj_repr = obj_repr.decode(errors='replace')
+            obj_repr = obj_repr.decode(sys.stdout.encoding or 'utf-8', errors='replace')
             yield obj_repr[:left_count].encode('utf-8')
             yield '...'
             yield obj_repr[-right_count:].encode('utf-8')

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_safe_repr.py
@@ -306,7 +306,7 @@ class SafeRepr(object):
 
         if isinstance(obj_repr, bytes):
             # convert to unicode before slicing strings
-            obj_repr = unicode(obj_repr, 'utf-8', errors='replace')
+            obj_repr = obj_repr.decode(errors='replace')
             yield obj_repr[:left_count].encode('utf-8')
             yield '...'
             yield obj_repr[-right_count:].encode('utf-8')


### PR DESCRIPTION
Sorry, this is a bit of necromancy (python 2 is eol soon).
In case of utf-8 non ascii characters we can not just slice python2 strings, because characters can be two-byte. This change converts it to unicode and back for slicing.