### PR TITLE
Provide disconnect/reconnect and a non-blocking way of setting up the debugger. Fixes #1382, Fixes #1248.

### DIFF
--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_api.py
@@ -25,6 +25,12 @@ class PyDevdAPI(object):
     def run(self, py_db):
         py_db.ready_to_run = True
 
+    def notify_configuration_done(self, py_db):
+        py_db.on_configuration_done()
+
+    def notify_disconnect(self, py_db):
+        py_db.on_disconnect()
+
     def set_protocol(self, py_db, seq, protocol):
         set_protocol(protocol.strip())
         if get_protocol() in (HTTP_JSON_PROTOCOL, JSON_PROTOCOL):
@@ -104,6 +110,14 @@ class PyDevdAPI(object):
         be used on disconnect/reconnect).
         '''
         py_db.set_enable_thread_notifications(enable)
+
+    def request_disconnect(self, py_db, resume_threads):
+        self.set_enable_thread_notifications(py_db, False)
+        self.remove_all_breakpoints(py_db, filename='*')
+        self.remove_all_exception_breakpoints(py_db)
+        self.notify_disconnect(py_db)
+        if resume_threads:
+            self.request_resume_thread(thread_id='*')
 
     def request_resume_thread(self, thread_id):
         threads = []

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_comm.py
@@ -187,10 +187,12 @@ def run_as_pydevd_daemon_thread(func, *args, **kwargs):
 class ReaderThread(PyDBDaemonThread):
     ''' reader thread reads and dispatches commands in an infinite loop '''
 
-    def __init__(self, sock):
+    def __init__(self, sock, terminate_on_socket_close=True):
+        assert sock is not None
         from _pydevd_bundle.pydevd_process_net_command_json import process_net_command_json
         from _pydevd_bundle.pydevd_process_net_command import process_net_command
         PyDBDaemonThread.__init__(self)
+        self._terminate_on_socket_close = terminate_on_socket_close
 
         self.sock = sock
         self._buffer = b''
@@ -199,13 +201,17 @@ class ReaderThread(PyDBDaemonThread):
         self.process_net_command_json = process_net_command_json
         self.global_debugger_holder = GlobalDebuggerHolder
 
+    @overrides(PyDBDaemonThread.do_kill_pydev_thread)
     def do_kill_pydev_thread(self):
+        PyDBDaemonThread.do_kill_pydev_thread(self)
         # We must close the socket so that it doesn't stay halted there.
-        self.killReceived = True
         try:
             self.sock.shutdown(SHUT_RD)  # shutdown the socket for read
         except:
-            # just ignore that
+            pass
+        try:
+            self.sock.close()
+        except:
             pass
 
     def _read(self, size):
@@ -313,7 +319,8 @@ class ReaderThread(PyDBDaemonThread):
             self.handle_except()
 
     def handle_except(self):
-        self.global_debugger_holder.global_dbg.finish_debugging_session()
+        if self._terminate_on_socket_close:
+            self.global_debugger_holder.global_dbg.finish_debugging_session()
 
     def process_command(self, cmd_id, seq, text):
         self.process_net_command(self.global_debugger_holder.global_dbg, cmd_id, seq, text)
@@ -322,9 +329,10 @@ class ReaderThread(PyDBDaemonThread):
 class WriterThread(PyDBDaemonThread):
     ''' writer thread writes out the commands in an infinite loop '''
 
-    def __init__(self, sock):
+    def __init__(self, sock, terminate_on_socket_close=True):
         PyDBDaemonThread.__init__(self)
         self.sock = sock
+        self._terminate_on_socket_close = terminate_on_socket_close
         self.setName("pydevd.Writer")
         self.cmdQueue = _queue.Queue()
         if pydevd_vm_type.get_vm_type() == 'python':
@@ -350,6 +358,9 @@ class WriterThread(PyDBDaemonThread):
                         if self.killReceived:
                             try:
                                 self.sock.shutdown(SHUT_WR)
+                            except:
+                                pass
+                            try:
                                 self.sock.close()
                             except:
                                 pass
@@ -370,16 +381,29 @@ class WriterThread(PyDBDaemonThread):
                     break  # interpreter shutdown
                 time.sleep(self.timeout)
         except Exception:
-            GlobalDebuggerHolder.global_dbg.finish_debugging_session()
-            if DebugInfoHolder.DEBUG_TRACE_LEVEL >= 0:
-                pydev_log_exception()
+            if self._terminate_on_socket_close:
+                GlobalDebuggerHolder.global_dbg.finish_debugging_session()
+                if DebugInfoHolder.DEBUG_TRACE_LEVEL > 0:
+                    pydev_log_exception()
 
     def empty(self):
         return self.cmdQueue.empty()
 
+    @overrides(PyDBDaemonThread.do_kill_pydev_thread)
+    def do_kill_pydev_thread(self):
+        PyDBDaemonThread.do_kill_pydev_thread(self)
+        # We must close the socket so that it doesn't stay halted there.
+        try:
+            self.sock.shutdown(SHUT_WR)  # shutdown the socket for write
+        except:
+            pass
+        try:
+            self.sock.close()
+        except:
+            pass
 
-def start_server(port):
-    ''' binds to a port, waits for the debugger to connect '''
+
+def create_server_socket(host, port):
     s = socket(AF_INET, SOCK_STREAM)
     s.settimeout(None)
 
@@ -389,20 +413,26 @@ def start_server(port):
     except ImportError:
         s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
 
-    s.bind(('', port))
+    s.bind((host, port))
     pydev_log.info("Bound to port :%s", port)
+    return s
+
+
+def start_server(port):
+    ''' binds to a port, waits for the debugger to connect '''
+    s = create_server_socket(host='', port=port)
 
     try:
         s.listen(1)
-        newSock, _addr = s.accept()
+        new_socket, _addr = s.accept()
         pydev_log.info("Connection accepted")
         # closing server socket is not necessary but we don't need it
         s.shutdown(SHUT_RDWR)
         s.close()
-        return newSock
-
+        return new_socket
     except:
         pydev_log.exception("Could not bind to port: %s\n", port)
+        raise
 
 
 def start_client(host, port):

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_process_net_command_json.py
@@ -201,6 +201,8 @@ class _PyDevJsonCommandProcessor(object):
         :param ConfigurationDoneRequest request:
         '''
         self.api.run(py_db)
+        self.api.notify_configuration_done(py_db)
+
         configuration_done_response = pydevd_base_schema.build_response(request)
         return NetCommand(CMD_RETURN, 0, configuration_done_response, is_json=True)
 
@@ -421,10 +423,7 @@ class _PyDevJsonCommandProcessor(object):
         '''
         :param DisconnectRequest request:
         '''
-        self.api.set_enable_thread_notifications(py_db, False)
-        self.api.remove_all_breakpoints(py_db, filename='*')
-        self.api.remove_all_exception_breakpoints(py_db)
-        self.api.request_resume_thread(thread_id='*')
+        self.api.request_disconnect(py_db, resume_threads=True)
 
         response = pydevd_base_schema.build_response(request)
         return NetCommand(CMD_RETURN, 0, response, is_json=True)

--- a/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_wait_for_attach.py
+++ b/src/ptvsd/_vendored/pydevd/tests_python/resources/_debugger_case_wait_for_attach.py
@@ -1,0 +1,50 @@
+if __name__ == '__main__':
+    import os
+    import sys
+    import time
+    port = int(sys.argv[1])
+    root_dirname = os.path.dirname(os.path.dirname(__file__))
+
+    if root_dirname not in sys.path:
+        sys.path.append(root_dirname)
+
+    import pydevd
+    try:
+        pydevd._wait_for_attach()  # Cannot be called before _enable_attach.
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError('Expected _wait_for_attach to raise exception.')
+
+    assert sys.gettrace() is None
+    print('enable attach to port: %s' % (port,))
+    pydevd._enable_attach(('127.0.0.1', port))
+    pydevd._enable_attach(('127.0.0.1', port))  # no-op in practice
+
+    try:
+        pydevd._enable_attach(('127.0.0.1', port + 15))  # different port: raise error.
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError('Expected _enable_attach to raise exception (because it is already hearing in another port).')
+
+    assert pydevd.get_global_debugger() is not None
+    assert sys.gettrace() is not None
+
+    a = 10  # Break 1
+    print('wait for attach')
+    pydevd._wait_for_attach()
+    print('finished wait for attach')
+    pydevd._wait_for_attach()  # Should promptly return (already connected).
+
+    a = 20  # Break 2
+
+    pydevd._wait_for_attach()  # As we disconnected on the 2nd break, this one should wait until a new configurationDone.
+
+    a = 20  # Break 3
+
+    while a == 20:  # Pause 1
+        # The debugger should disconnect/reconnect, pause and then change 'a' to another value.
+        time.sleep(1 / 20.)  # Pause 2
+
+    print('TEST SUCEEDED!')


### PR DESCRIPTION
Some notes:

- I still haven't done changes in `ptvsd` (not sure if it's worth doing the needed monkeypatching vs going toward the final solution splitting `ptvsd` and `pydevd`).

- I created `_enable_attach` and `_wait_for_attach` as protected because they should only be public on `ptvsd`, not on `pydevd`. 