### PR TITLE
Ensure port is set on enable_attach

### DIFF
--- a/src/ptvsd/_remote.py
+++ b/src/ptvsd/_remote.py
@@ -21,6 +21,7 @@ global_next_session = lambda: None
 def enable_attach(address, on_attach=lambda: None, **kwargs):
 
     host, port = address
+    print(port)
 
     def wait_for_connection(daemon, host, port, next_session=None):
         ptvsd.log.debug('Waiting for pydevd ...')
@@ -50,6 +51,8 @@ def enable_attach(address, on_attach=lambda: None, **kwargs):
         _, next_session = daemon.start_server(addr=(host, port))
         global global_next_session
         global_next_session = next_session
+        if port == 0:
+            _, ptvsd.options.port = daemon._server.getsockname()
         return daemon._sock
 
     daemon = install(pydevd,

--- a/src/ptvsd/_remote.py
+++ b/src/ptvsd/_remote.py
@@ -52,6 +52,8 @@ def enable_attach(address, on_attach=lambda: None, **kwargs):
         global_next_session = next_session
         if port == 0:
             _, ptvsd.options.port = daemon._server.getsockname()
+        else:
+            ptvsd.options.port = port
         return daemon._sock
 
     daemon = install(pydevd,

--- a/src/ptvsd/_remote.py
+++ b/src/ptvsd/_remote.py
@@ -21,7 +21,6 @@ global_next_session = lambda: None
 def enable_attach(address, on_attach=lambda: None, **kwargs):
 
     host, port = address
-    print(port)
 
     def wait_for_connection(daemon, host, port, next_session=None):
         ptvsd.log.debug('Waiting for pydevd ...')

--- a/src/ptvsd/attach_server.py
+++ b/src/ptvsd/attach_server.py
@@ -61,6 +61,11 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=None, lo
         Name of the directory that debugger will create its log files in.
         If not specified, logging is disabled.
 
+    Return
+    ------
+    Returns tuple (host, port) as used to by the debugging server. If `enable_attach` was
+    called with port '0'. The return value will contain the actual ephemeral port number.
+
     Notes
     -----
     This function returns immediately after setting up the debugging server,

--- a/src/ptvsd/attach_server.py
+++ b/src/ptvsd/attach_server.py
@@ -94,6 +94,7 @@ def enable_attach(address=(DEFAULT_HOST, DEFAULT_PORT), redirect_output=None, lo
     address = (address[0], port if type(port) is int else int(port))
 
     ptvsd_enable_attach(address)
+    return (address[0], ptvsd.options.port)
 
 
 def attach(address, redirect_output=None, log_dir=None):


### PR DESCRIPTION
Users should be able to call enable attach with port `0` and have a way to get the port address.
```console
> import ptvsd
> ptvsd.enable_attach(('localhost', 0))
('loclahost', 58940)
```