### PR TITLE
Custom pydevd event to support InputRequested

### DIFF
--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/debugProtocolCustom.json
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/debugProtocolCustom.json
@@ -20,7 +20,7 @@
 						"$ref": "#/definitions/SetDebuggerPropertyArguments"
 					}
 				},
-				"required": [ "command", "arguments"  ]
+				"required": [ "command", "arguments" ]
 			}]
 		},
 		"SetDebuggerPropertyArguments": {
@@ -58,7 +58,21 @@
 				"type": "object",
 				"description": "Response to 'setDebuggerProperty' request. This is just an acknowledgement, so no body field is required."
 			}]
+		},
+
+		"PydevdInputRequestedEvent": {
+			"allOf": [ { "$ref": "#/definitions/Event" }, {
+				"type": "object",
+				"description": "The event indicates input was requested by debuggee.",
+				"properties": {
+					"event": {
+						"type": "string",
+						"enum": [ "pydevdInputRequested" ]
+					}
+				},
+				"required": [ "event" ]
+			}]
 		}
 
-    }
+	}
 }

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/pydevd_schema.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/_debug_adapter/pydevd_schema.py
@@ -12490,6 +12490,79 @@ class SetDebuggerPropertyResponse(BaseSchema):
         return dct
 
 
+@register_event('pydevdInputRequested')
+@register
+class PydevdInputRequestedEvent(BaseSchema):
+    """
+    The event indicates input was requested by debuggee.
+
+    Note: automatically generated code. Do not edit manually.
+    """
+
+    __props__ = {
+        "seq": {
+            "type": "integer",
+            "description": "Sequence number."
+        },
+        "type": {
+            "type": "string",
+            "enum": [
+                "event"
+            ]
+        },
+        "event": {
+            "type": "string",
+            "enum": [
+                "pydevdInputRequested"
+            ]
+        },
+        "body": {
+            "type": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ],
+            "description": "Event-specific information."
+        }
+    }
+    __refs__ = set()
+
+    __slots__ = list(__props__.keys()) + ['kwargs']
+
+    def __init__(self, seq=-1, body=None, update_ids_from_dap=False, **kwargs):  # noqa (update_ids_from_dap may be unused)
+        """
+        :param string type: 
+        :param string event: 
+        :param integer seq: Sequence number.
+        :param ['array', 'boolean', 'integer', 'null', 'number', 'object', 'string'] body: Event-specific information.
+        """
+        self.type = 'event'
+        self.event = 'pydevdInputRequested'
+        self.seq = seq
+        self.body = body
+        self.kwargs = kwargs
+
+
+    def to_dict(self, update_ids_to_dap=False):  # noqa (update_ids_to_dap may be unused)
+        type = self.type  # noqa (assign to builtin)
+        event = self.event
+        seq = self.seq
+        body = self.body
+        dct = {
+            'type': type,
+            'event': event,
+            'seq': seq,
+        }
+        if body is not None:
+            dct['body'] = body
+        dct.update(self.kwargs)
+        return dct
+
+
 @register
 class ErrorResponseBody(BaseSchema):
     """

--- a/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
+++ b/src/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_net_command_factory_json.py
@@ -14,7 +14,7 @@ from _pydevd_bundle.pydevd_comm_constants import CMD_THREAD_CREATE, CMD_RETURN, 
     CMD_WRITE_TO_CONSOLE, CMD_STEP_INTO, CMD_STEP_INTO_MY_CODE, CMD_STEP_OVER, CMD_STEP_OVER_MY_CODE, \
     CMD_STEP_RETURN, CMD_STEP_CAUGHT_EXCEPTION, CMD_ADD_EXCEPTION_BREAK, CMD_SET_BREAK, \
     CMD_SET_NEXT_STATEMENT, CMD_THREAD_SUSPEND_SINGLE_NOTIFICATION, \
-    CMD_THREAD_RESUME_SINGLE_NOTIFICATION, CMD_THREAD_KILL
+    CMD_THREAD_RESUME_SINGLE_NOTIFICATION, CMD_THREAD_KILL, CMD_INPUT_REQUESTED
 from _pydevd_bundle.pydevd_constants import get_thread_id, dict_values
 from _pydevd_bundle.pydevd_net_command import NetCommand, NULL_NET_COMMAND
 from _pydevd_bundle.pydevd_net_command_factory_xml import NetCommandFactory
@@ -344,3 +344,7 @@ class NetCommandFactoryJson(NetCommandFactory):
     def make_thread_run_message(self, *args, **kwargs):
         return NULL_NET_COMMAND  # Not a part of the debug adapter protocol
 
+    @overrides(NetCommandFactory.make_input_requested_message)
+    def make_input_requested_message(self, started):
+        event = pydevd_schema.PydevdInputEvent(body={})
+        return NetCommand(CMD_INPUT_REQUESTED, 0, event, is_json=True)


### PR DESCRIPTION
This Fixes #1523 in a way that it adds a custom event so that there is always a name for the event.

This also addresses Fixes #1497, Fixes #1496. Those events don't need additional work, and they can be forwarded in their current state.