### PR TITLE
Fix #1551: Backchannel failures in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
+tests/_logs/*.log
 .tox/
 .coverage
 .coverage.*

--- a/src/ptvsd/common/fmt.py
+++ b/src/ptvsd/common/fmt.py
@@ -19,6 +19,51 @@ import sys
 import types
 
 
+class JsonObject(object):
+    """A wrapped Python object that formats itself as JSON when asked for a string
+    representation via str() or format().
+    """
+
+    json_encoder_type = json.JSONEncoder
+    """Used by __format__ when format_spec is not empty."""
+
+    json_encoder = json_encoder_type(indent=4)
+    """The default encoder used by __format__ when format_spec is empty."""
+
+    def __init__(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return repr(self.value)
+
+    def __str__(self):
+        return format(self)
+
+    def __format__(self, format_spec):
+        """If format_spec is empty, uses self.json_encoder to serialize self.value
+        as a string. Otherwise, format_spec is treated as an argument list to be
+        passed to self.json_encoder_type - which defaults to JSONEncoder - and then
+        the resulting formatter is used to serialize self.value as a string.
+
+        Example::
+
+            fmt("{0!j} {0!j:indent=4,sort_keys=True}", x)
+        """
+        if format_spec:
+            # At this point, format_spec is a string that looks something like
+            # "indent=4,sort_keys=True". What we want is to build a function call
+            # from that which looks like:
+            #
+            #   json_encoder_type(indent=4,sort_keys=True)
+            #
+            # which we can then eval() to create our encoder instance.
+            make_encoder = "json_encoder_type(" + format_spec + ")"
+            encoder = eval(make_encoder, {"json_encoder_type": self.json_encoder_type})
+        else:
+            encoder = self.json_encoder
+        return encoder.encode(self.value)
+
+
 class Formatter(string.Formatter, types.ModuleType):
     """A custom string.Formatter with support for JSON pretty-printing.
 
@@ -29,13 +74,6 @@ class Formatter(string.Formatter, types.ModuleType):
     they must always be numbered explicitly - "{0} {1}" rather than "{} {}". Named
     placeholders are supported.
     """
-
-    # Because globals() go away after the module object substitution, all modules
-    # that were imported globally, but that are referenced by method bodies that
-    # can run after substitition occurred, must be re-imported here, so that they
-    # can be accessed via self.
-
-    json_encoder = json.JSONEncoder(indent=4)
 
     # Because globals() go away after the module object substitution, all method bodies
     # below must access globals via self instead, or re-import modules locally.
@@ -54,7 +92,7 @@ class Formatter(string.Formatter, types.ModuleType):
 
     def convert_field(self, value, conversion):
         if conversion == "j":
-            return self.json_encoder.encode(value)
+            return self.JsonObject(value)
         return super(self.Formatter, self).convert_field(value, conversion)
 
 

--- a/src/ptvsd/common/stacks.py
+++ b/src/ptvsd/common/stacks.py
@@ -12,13 +12,12 @@ import sys
 import time
 import threading
 import traceback
-import pytest_timeout
 
 from ptvsd.common import log
 
 
 def dump():
-    """Dump the stacks of all threads except the current thread.
+    """Dump stacks of all threads in this process, except for the current thread.
     """
 
     tid = threading.current_thread().ident
@@ -53,14 +52,14 @@ def dump():
 
 def dump_after(secs):
     """Invokes dump() on a background thread after waiting for the specified time.
-
-    Can be called from debugged code before the point after which it hangs,
-    to determine the cause of the hang when debugging a test.
     """
 
     def dumper():
         time.sleep(secs)
-        pytest_timeout.dump_stacks()
+        try:
+            dump()
+        except:
+            log.exception()
 
     thread = threading.Thread(target=dumper)
     thread.daemon = True

--- a/tests/_logs/README
+++ b/tests/_logs/README
@@ -1,0 +1,13 @@
+Pass --ptvsd-logs and/or --pydevd-logs to pytest to create log files here for a run.
+For example:
+
+    tox -e py37 -- --ptvsd-logs "tests/ptvsd/server/test_run.py::test_run[launch-file]"
+
+A separate ptvsd-{pid}.log file will be created for every ptvsd process spawned by
+the tests. However, because process IDs are reused by OS, logs may end up overwriting
+earlier logs.
+
+All pydevd logs go into the same file named pydevd.log - and subsequent tests will
+overwrite earlier logs.
+
+Thus, it is best to use this when running a single test, or a small number of tests.

--- a/tests/pydevd_log.py
+++ b/tests/pydevd_log.py
@@ -7,16 +7,19 @@ from __future__ import absolute_import, print_function, unicode_literals
 import contextlib
 import os
 
+from ptvsd.common import log
+
 
 @contextlib.contextmanager
 def enabled(filename):
     os.environ['PYDEVD_DEBUG'] = 'True'
     os.environ['PYDEVD_DEBUG_FILE'] = filename
-
-    yield
-
-    del os.environ['PYDEVD_DEBUG']
-    del os.environ['PYDEVD_DEBUG_FILE']
+    log.debug("pydevd log will be at {0}", filename)
+    try:
+        yield
+    finally:
+        del os.environ['PYDEVD_DEBUG']
+        del os.environ['PYDEVD_DEBUG_FILE']
 
 
 def dump(why):
@@ -28,10 +31,10 @@ def dump(why):
 
     try:
         f = open(pydevd_debug_file)
+        with f:
+            pydevd_log = f.read()
     except Exception:
-        print('Test {0}, but no ptvsd log found'.format(why))
+        log.exception("Test {0}, but pydevd log {1} could not be retrieved.", why, pydevd_debug_file)
         return
 
-    with f:
-        print('Test {0}; dumping pydevd log:'.format(why))
-        print(f.read())
+    log.info("Test {0}; pydevd log:\n\n{1}", why, pydevd_log)

--- a/tests/pytest_fixtures.py
+++ b/tests/pytest_fixtures.py
@@ -12,6 +12,7 @@ import tempfile
 import threading
 import types
 
+from ptvsd.common import timestamp
 from tests import code, pydevd_log
 
 __all__ = ['run_as', 'start_method', 'with_pydevd_log', 'daemon', 'pyfile']
@@ -39,6 +40,13 @@ def run_as(request):
 @pytest.fixture(params=START_METHODS)
 def start_method(request):
     return request.param
+
+
+@pytest.fixture(autouse=True)
+def reset_timestamp(request):
+    timestamp.reset()
+    print("\n")  # make sure logs start on a new line
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_data/_PYTHONPATH/backchannel.py
+++ b/tests/test_data/_PYTHONPATH/backchannel.py
@@ -18,12 +18,14 @@ import sys
 assert "debug_me" in sys.modules
 import debug_me
 
-from ptvsd.common import fmt, messaging
+from ptvsd.common import fmt, log, messaging
 
 
+name = fmt("backchannel-{0}", debug_me.session_id)
 port = int(os.getenv('PTVSD_BACKCHANNEL_PORT', 0))
+
 if port:
-    print(fmt('Connecting backchannel-{0} to port {1}...', debug_me.session_id, port))
+    log.info('Connecting {0} to port {1}...', name, port)
 
     _socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     _socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
@@ -35,8 +37,13 @@ if port:
 
     @atexit.register
     def _atexit_handler():
-        print(fmt('Shutting down backchannel-{0}...', debug_me.session_id))
+        log.info('Shutting down {0}...', name)
         try:
             _socket.shutdown(socket.SHUT_RDWR)
         except Exception:
             pass
+        finally:
+            try:
+                _socket.close()
+            except Exception:
+                pass

--- a/tests/test_data/_PYTHONPATH/debug_me.py
+++ b/tests/test_data/_PYTHONPATH/debug_me.py
@@ -24,6 +24,7 @@ import os
 
 # Needs to be set before backchannel can set things up.
 session_id = int(os.getenv('PTVSD_SESSION_ID'))
+name = "ptvsd-" + str(session_id)
 
 # For `from debug_me import ...`.
 import backchannel  # noqa


### PR DESCRIPTION
Fix various bugs around handling of disconnect in JsonIOStream and JsonMessageChannel.

Fix handling of DAP "terminated" event in debug.Session.

Add --ptvsd-logs and --pydevd-logs switches to pytest.

Improve message logging to fully capture the raw message data in the logs if deserialization fails.

Log all debuggee environment variables in debug.Session, and improve log readability.