### PR TITLE
Fix #1552: attach_socket_import tests hang waiting for "process" event

### DIFF
--- a/src/ptvsd/__init__.py
+++ b/src/ptvsd/__init__.py
@@ -24,6 +24,14 @@ from os import path
 __file__ = path.abspath(__file__)
 del path
 
+# Preload encodings that we're going to use to avoid import deadlocks on Python 2.
+import codecs
+codecs.lookup('ascii')
+codecs.lookup('utf8')
+codecs.lookup('utf-8')
+codecs.lookup('latin1')
+codecs.lookup('latin-1')
+
 from ptvsd import _version
 __version__ = _version.get_versions()["version"]
 del _version


### PR DESCRIPTION
Preload codecs used by ptvsd and pydevd to avoid deadlocks when calling wait_for_attach()  while importing a module on Python 2.