### PR TITLE
Add option to connect to adapter via port from IDE

### DIFF
--- a/src/ptvsd/adapter/__main__.py
+++ b/src/ptvsd/adapter/__main__.py
@@ -5,9 +5,16 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 import sys
+import argparse
 
 # WARNING: ptvsd and submodules must not be imported on top level in this module,
 # and should be imported locally inside main() instead.
+
+
+def _get_parsed_args():
+    parser = argparse.ArgumentParser(prog="ptvsd.adapter")
+    parser.add_argument("--debug-port", nargs="?", default=None, const=6789)
+    return parser.parse_args(sys.argv[1:])
 
 
 def main():
@@ -15,10 +22,11 @@ def main():
     from ptvsd.common import log
     from ptvsd.adapter import channels
 
+    args = _get_parsed_args()
     log.to_file()
 
     chan = channels.Channels()
-    chan.connect_to_ide()
+    chan.connect_to_ide(address=("localhost", int(args.debug_port)))
 
     chan.ide.send_event(
         "output",

--- a/src/ptvsd/adapter/__main__.py
+++ b/src/ptvsd/adapter/__main__.py
@@ -12,7 +12,7 @@ import argparse
 
 
 def _get_parsed_args():
-    parser = argparse.ArgumentParser(prog="ptvsd.adapter")
+    parser = argparse.ArgumentParser()
     parser.add_argument("--debug-port", nargs="?", default=None, const=6789)
     return parser.parse_args(sys.argv[1:])
 

--- a/src/ptvsd/adapter/channels.py
+++ b/src/ptvsd/adapter/channels.py
@@ -29,17 +29,17 @@ class Channels(singleton.ThreadSafeSingleton):
     """
 
     @singleton.autolocked_method
-    def connect_to_ide(self, address=("localhost", None)):
+    def connect_to_ide(self, address=None):
         assert self.ide is None
 
         # Import message handlers lazily to avoid circular imports.
         from ptvsd.adapter import messages
 
-        host, port = address
-        if port is None:
+        if address is None:
             ide_channel = messaging.JsonIOStream.from_stdio("IDE")
         else:
-            sock = create_server("localhost", port).accept()
+            host, port = address
+            sock = create_server(host, port).accept()
             ide_channel = messaging.JsonIOStream.from_socket(sock, "IDE")
 
         self.ide = messaging.JsonMessageChannel(

--- a/src/ptvsd/adapter/channels.py
+++ b/src/ptvsd/adapter/channels.py
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
 from ptvsd.common import messaging, singleton
+from ptvsd.common.socket import create_server
 
 
 class Channels(singleton.ThreadSafeSingleton):
@@ -28,13 +29,19 @@ class Channels(singleton.ThreadSafeSingleton):
     """
 
     @singleton.autolocked_method
-    def connect_to_ide(self):
+    def connect_to_ide(self, address=("localhost", None)):
         assert self.ide is None
 
         # Import message handlers lazily to avoid circular imports.
         from ptvsd.adapter import messages
 
-        ide_channel = messaging.JsonIOStream.from_stdio("IDE")
+        host, port = address
+        if port is None:
+            ide_channel = messaging.JsonIOStream.from_stdio("IDE")
+        else:
+            sock = create_server("localhost", port).accept()
+            ide_channel = messaging.JsonIOStream.from_socket(sock, "IDE")
+
         self.ide = messaging.JsonMessageChannel(
             ide_channel, messages.IDEMessages(), ide_channel.name
         )

--- a/src/ptvsd/adapter/messages.py
+++ b/src/ptvsd/adapter/messages.py
@@ -105,8 +105,8 @@ class IDEMessages(Messages):
     # and that must be replayed to the server once it is established.
     def _replay_to_server(handler):
         def store_and_handle(self, message):
-            if self.initial_messages is not None:
-                self.initial_messages.append(message)
+            if self._initial_messages is not None:
+                self._initial_messages.append(message)
             return handler(self, message)
 
         return store_and_handle


### PR DESCRIPTION
Fixes #1556

You should be able to connect tot the adapter using this CLI:
```
-m ptvsd.adapter --debug-port 6789
```
This launch json config:
```js
        {
            "name": "Attach port",
            "type": "python",
            "request": "attach",
            "debugServer": 6789,
        },
```
