### PR TITLE
Fix #1614: Test run times out on Python 2.7

### DIFF
--- a/tests/watchdog/__init__.py
+++ b/tests/watchdog/__init__.py
@@ -107,10 +107,16 @@ def _invoke(command, *args):
     else:
         assert not timeout.occurred, str(timeout.occurred)
 
+
 def stop():
     if _stream is None:
         return
-    _invoke("stop")
+
+    try:
+        _invoke("stop")
+        _stream.close()
+    except Exception:
+        log.exception()
 
 
 def register_spawn(pid, name):


### PR DESCRIPTION
Close the watchdog message channel from the test process side after "stop" command is sent and acknowledged.