### PR TITLE
Set don't trace patterns from the debug server

### DIFF
--- a/src/ptvsd/adapter/messages.py
+++ b/src/ptvsd/adapter/messages.py
@@ -199,8 +199,6 @@ class IDEMessages(Messages):
 
         try:
             self._server.request("setDebuggerProperty", arguments={
-                "dontTraceStartPatterns": ["\\ptvsd\\", "/ptvsd/"],
-                "dontTraceEndPatterns": ["ptvsd_launcher.py"],
                 "skipSuspendOnBreakpointException": ("BaseException",),
                 "skipPrintBreakpointException": ("NameError",),
                 "multiThreadsSingleNotification": True,


### PR DESCRIPTION
Testing to see if this is a better solution. If this works out better i think we should remove the `dontTrace*Patterns` from setDebuggerProperty