### PR TITLE
Fix #1769: Logpoint messages aren't printed for "launch"

### DIFF
--- a/src/ptvsd/adapter/ide.py
+++ b/src/ptvsd/adapter/ide.py
@@ -223,6 +223,10 @@ class IDE(components.Component):
 
         self.session.spawn_debuggee(request, sudo, args, console, console_title)
 
+        if "RedirectOutput" in self.session.debug_options:
+            # The launcher is doing output redirection, so we don't need the server.
+            request.arguments["debugOptions"].remove("RedirectOutput")
+
     @_start_message_handler
     def attach_request(self, request):
         if self.session.no_debug:

--- a/src/ptvsd/adapter/server.py
+++ b/src/ptvsd/adapter/server.py
@@ -129,13 +129,6 @@ class Server(components.Component):
             self.ide.propagate_after_start(event)
 
     @message_handler
-    def output_event(self, event):
-        category = event("category", "console")
-        # If there is a launcher, it's handling stdout and stderr.
-        if not self.launcher or category not in ("stdout", "stderr"):
-            self.ide.propagate_after_start(event)
-
-    @message_handler
     def exited_event(self, event):
         # If there is a launcher, it's handling the exit code.
         if not self.launcher:


### PR DESCRIPTION
When using launcher to redirect output, tell pydevd to not perform redirection.

Always propagate "output" events from the server to the IDE.

Fix test_log_point to not assume that logpoint output is strictly ordered wrt regular output.