### PR TITLE
Fix #1706: Multiprocessing via debug adapter

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,10 +17,10 @@
 
         // For these, ptvsd.adapter must be started first via the above configuration.
         {
+            //"debugServer": 8765,
             "name": "Launch Python file [debugServer]",
             "type": "python",
             "request": "launch",
-            "debugServer": 8765,
             //"console": "internalConsole",
             "console": "integratedTerminal",
             //"console": "externalTerminal",
@@ -30,12 +30,21 @@
             //"ptvsdArgs": ["--log-stderr"],
         },
         {
+            //"debugServer": 8765,
             "name": "Attach [debugServer]",
             "type": "python",
             "request": "attach",
-            "debugServer": 8765,
             "host": "localhost",
             "port": 5678,
+        },
+        {
+            //"debugServer": 8765,
+            "name": "Attach Child Process [debugServer]",
+            "type": "python",
+            "request": "attach",
+            "host": "localhost",
+            "port": 5678,
+            "subProcessId": 00000,
         },
     ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "setuptools.build_meta"
 # The only exclusions that should remain in the end are _vendored and versioneer.
 exclude = '''
 ( __pycache__
+| ^/.tox
 | ^/versioneer.py
 | ^/src/ptvsd/_vendored
 | ^/src/ptvsd/_version.py

--- a/src/ptvsd/__init__.py
+++ b/src/ptvsd/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """An implementation of the Debug Adapter Protocol (DAP) for Python.
 

--- a/src/ptvsd/__main__.py
+++ b/src/ptvsd/__main__.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os.path
+import os
 import sys
 
 # Force absolute path on Python 2.

--- a/src/ptvsd/_vendored/__init__.py
+++ b/src/ptvsd/_vendored/__init__.py
@@ -2,12 +2,11 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import contextlib
 from importlib import import_module
 import os
-import os.path
 import sys
 
 from . import _util

--- a/src/ptvsd/_vendored/_pydevd_packaging.py
+++ b/src/ptvsd/_vendored/_pydevd_packaging.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from . import VENDORED_ROOT
 from ._util import cwd, iter_all_files

--- a/src/ptvsd/_vendored/_util.py
+++ b/src/ptvsd/_vendored/_util.py
@@ -2,11 +2,10 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import contextlib
 import os
-import os.path
 
 
 @contextlib.contextmanager

--- a/src/ptvsd/_vendored/force_pydevd.py
+++ b/src/ptvsd/_vendored/force_pydevd.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from importlib import import_module
 import warnings

--- a/src/ptvsd/adapter/__init__.py
+++ b/src/ptvsd/adapter/__init__.py
@@ -2,11 +2,11 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __all__ = []
 
-import os.path
+import os
 
 # Force absolute path on Python 2.
 __file__ = os.path.abspath(__file__)

--- a/src/ptvsd/adapter/__main__.py
+++ b/src/ptvsd/adapter/__main__.py
@@ -40,7 +40,7 @@ def main(args):
     if args.for_enable_attach:
         endpoints = {
             "ide": {"host": ide_host, "port": ide_port},
-            "server": {"host": server_host, "port": server_port}
+            "server": {"host": server_host, "port": server_port},
         }
         log.info("Sending endpoints to stdout: {0!r}", endpoints)
         print(json.dumps(endpoints))
@@ -76,9 +76,7 @@ def _parse_argv(argv):
     )
 
     parser.add_argument(
-        "--for-enable-attach",
-        action="store_true",
-        help=argparse.SUPPRESS,
+        "--for-enable-attach", action="store_true", help=argparse.SUPPRESS
     )
 
     parser.add_argument(

--- a/src/ptvsd/adapter/__main__.py
+++ b/src/ptvsd/adapter/__main__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 import json
@@ -19,7 +19,7 @@ __file__ = os.path.abspath(__file__)
 
 def main(args):
     from ptvsd.common import log, options as common_options
-    from ptvsd.adapter import ide, server, session, options as adapter_options
+    from ptvsd.adapter import ide, servers, sessions, options as adapter_options
 
     if args.log_stderr:
         log.stderr.levels |= set(log.LEVELS)
@@ -34,7 +34,7 @@ def main(args):
         log.error("--for-enable-attach requires --port")
         sys.exit(64)
 
-    server_host, server_port = server.listen()
+    server_host, server_port = servers.listen()
     ide_host, ide_port = ide.listen(port=args.port)
 
     if args.for_enable_attach:
@@ -49,10 +49,10 @@ def main(args):
     if args.port is None:
         ide.IDE("stdio")
 
-    server.wait_until_disconnected()
+    servers.wait_until_disconnected()
     log.info("All debug servers disconnected; waiting for remaining sessions...")
 
-    session.wait_until_ended()
+    sessions.wait_until_ended()
     log.info("All debug sessions have ended; exiting.")
 
 

--- a/src/ptvsd/adapter/components.py
+++ b/src/ptvsd/adapter/components.py
@@ -2,11 +2,12 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
 
 from ptvsd.common import fmt, json, log, messaging, util
+
 
 ACCEPT_CONNECTIONS_TIMEOUT = 10
 

--- a/src/ptvsd/adapter/launcher.py
+++ b/src/ptvsd/adapter/launcher.py
@@ -4,7 +4,13 @@
 
 from __future__ import absolute_import, print_function, unicode_literals
 
-from ptvsd.adapter import components
+import os
+import subprocess
+import sys
+
+import ptvsd.launcher
+from ptvsd.common import compat, log, messaging, options as common_options
+from ptvsd.adapter import components, options as adapter_options, server
 
 
 class Launcher(components.Component):
@@ -13,16 +19,17 @@ class Launcher(components.Component):
     message_handler = components.Component.message_handler
 
     def __init__(self, session, stream):
-        super(Launcher, self).__init__(session, stream)
+        with session:
+            assert not session.launcher
+            super(Launcher, self).__init__(session, stream)
 
-        self.pid = None
-        """Process ID of the debuggee process, as reported by the launcher."""
+            self.pid = None
+            """Process ID of the debuggee process, as reported by the launcher."""
 
-        self.exit_code = None
-        """Exit code of the debuggee process."""
+            self.exit_code = None
+            """Exit code of the debuggee process."""
 
-        assert not session.launcher
-        session.launcher = self
+            session.launcher = self
 
     @message_handler
     def process_event(self, event):
@@ -47,3 +54,77 @@ class Launcher(components.Component):
     def terminated_event(self, event):
         self.ide.channel.send_event("exited", {"exitCode": self.exit_code})
         self.channel.close()
+
+
+def spawn_debuggee(session, start_request, sudo, args, console, console_title):
+    cmdline = ["sudo"] if sudo else []
+    cmdline += [sys.executable, os.path.dirname(ptvsd.launcher.__file__)]
+    cmdline += args
+    env = {str("PTVSD_SESSION_ID"): str(session.id)}
+
+    def spawn_launcher():
+        with session.accept_connection_from_launcher() as (_, launcher_port):
+            env[str("PTVSD_LAUNCHER_PORT")] = str(launcher_port)
+            if common_options.log_dir is not None:
+                env[str("PTVSD_LOG_DIR")] = compat.filename_str(common_options.log_dir)
+            if adapter_options.log_stderr:
+                env[str("PTVSD_LOG_STDERR")] = str("debug info warning error")
+
+            if console == "internalConsole":
+                log.info("{0} spawning launcher: {1!r}", session, cmdline)
+
+                # If we are talking to the IDE over stdio, sys.stdin and sys.stdout are
+                # redirected to avoid mangling the DAP message stream. Make sure the
+                # launcher also respects that.
+                subprocess.Popen(
+                    cmdline,
+                    env=dict(list(os.environ.items()) + list(env.items())),
+                    stdin=sys.stdin,
+                    stdout=sys.stdout,
+                    stderr=sys.stderr,
+                )
+
+            else:
+                log.info('{0} spawning launcher via "runInTerminal" request.', session)
+                session.ide.capabilities.require("supportsRunInTerminalRequest")
+                kinds = {
+                    "integratedTerminal": "integrated",
+                    "externalTerminal": "external",
+                }
+                session.ide.channel.request(
+                    "runInTerminal",
+                    {
+                        "kind": kinds[console],
+                        "title": console_title,
+                        "args": cmdline,
+                        "env": env,
+                    },
+                )
+
+        try:
+            session.launcher.channel.request(start_request.command, arguments)
+        except messaging.MessageHandlingError as exc:
+            exc.propagate(start_request)
+
+    if session.no_debug:
+        arguments = start_request.arguments
+        spawn_launcher()
+    else:
+        _, port = server.Connection.listener.getsockname()
+        arguments = dict(start_request.arguments)
+        arguments["port"] = port
+        spawn_launcher()
+
+        if not session.wait_for(lambda: session.pid is not None, timeout=5):
+            raise start_request.cant_handle(
+                '{0} timed out waiting for "process" event from {1}',
+                session,
+                session.launcher,
+            )
+
+        conn = server.wait_for_connection(session.pid, timeout=10)
+        if conn is None:
+            raise start_request.cant_handle(
+                "{0} timed out waiting for debuggee to spawn", session
+            )
+        conn.attach_to_session(session)

--- a/src/ptvsd/adapter/launchers.py
+++ b/src/ptvsd/adapter/launchers.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import subprocess
@@ -10,7 +10,7 @@ import sys
 
 import ptvsd.launcher
 from ptvsd.common import compat, log, messaging, options as common_options
-from ptvsd.adapter import components, options as adapter_options, server
+from ptvsd.adapter import components, servers, options as adapter_options
 
 
 class Launcher(components.Component):
@@ -110,7 +110,7 @@ def spawn_debuggee(session, start_request, sudo, args, console, console_title):
         arguments = start_request.arguments
         spawn_launcher()
     else:
-        _, port = server.Connection.listener.getsockname()
+        _, port = servers.Connection.listener.getsockname()
         arguments = dict(start_request.arguments)
         arguments["port"] = port
         spawn_launcher()
@@ -122,7 +122,7 @@ def spawn_debuggee(session, start_request, sudo, args, console, console_title):
                 session.launcher,
             )
 
-        conn = server.wait_for_connection(session.pid, timeout=10)
+        conn = servers.wait_for_connection(session.pid, timeout=10)
         if conn is None:
             raise start_request.cant_handle(
                 "{0} timed out waiting for debuggee to spawn", session

--- a/src/ptvsd/adapter/options.py
+++ b/src/ptvsd/adapter/options.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Global adapter options that are set via command line, environment variables,
 or configuartion files.

--- a/src/ptvsd/adapter/server.py
+++ b/src/ptvsd/adapter/server.py
@@ -2,9 +2,126 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
+import os
+import subprocess
+import sys
+import threading
+import time
+
+import ptvsd
+from ptvsd.common import compat, fmt, json, log, messaging, sockets
 from ptvsd.adapter import components
+
+
+_lock = threading.RLock()
+
+_connections = []
+"""All servers that are connected to this adapter, in order in which they connected.
+"""
+
+_connections_changed = threading.Event()
+
+
+class Connection(sockets.ClientConnection):
+    """A debug server that is connected to the adapter.
+
+    Servers that are not participating in a debug session are managed directly by the
+    corresponding Connection instance.
+
+    Servers that are participating in a debug session are managed by that sessions's
+    Server component instance, but Connection object remains, and takes over again
+    once the session ends.
+    """
+
+    def __init__(self, sock):
+        from ptvsd.adapter import session
+
+        self.server = None
+        """The Server component, if this debug server belongs to Session.
+        """
+
+        self.pid = None
+
+        stream = messaging.JsonIOStream.from_socket(sock, str(self))
+        self.channel = messaging.JsonMessageChannel(stream, self)
+        self.channel.start()
+
+        try:
+            info = self.channel.request("pydevdSystemInfo")
+            process_info = info("process", json.object())
+            self.pid = process_info("pid", int)
+            self.ppid = process_info("ppid", int, optional=True)
+            if self.ppid == ():
+                self.ppid = None
+
+            self.channel.name = stream.name = str(self)
+            with _lock:
+                if any(conn.pid == self.pid for conn in _connections):
+                    raise KeyError(
+                        fmt("{0} is already connected to this adapter", self)
+                    )
+                _connections.append(self)
+                _connections_changed.set()
+
+        except Exception:
+            log.exception("Failed to accept incoming server connection:")
+            # If we couldn't retrieve all the necessary info from the debug server,
+            # or there's a PID clash, we don't want to track this debuggee anymore,
+            # but we want to continue accepting connections.
+            self.channel.close()
+            return
+
+        parent_session = session.get(self.ppid)
+        if parent_session is None:
+            log.info("No active debug session for parent process of {0}.", self)
+        else:
+            try:
+                parent_session.ide.notify_of_subprocess(self)
+            except Exception:
+                # This might fail if the IDE concurrently disconnects from the parent
+                # session. We still want to keep the connection around, in case the
+                # IDE reconnects later. If the parent session was "launch", it'll take
+                # care of closing the remaining server connections.
+                log.exception("Failed to notify parent session about {0}:", self)
+
+    def __str__(self):
+        return "Server" + fmt("[?]" if self.pid is None else "[pid={0}]", self.pid)
+
+    def request(self, request):
+        raise request.isnt_valid(
+            "Requests from the debug server to the IDE are not allowed."
+        )
+
+    def event(self, event):
+        pass
+
+    def terminated_event(self, event):
+        self.channel.close()
+
+    def disconnect(self):
+        with _lock:
+            # If the disconnect happened while Server was being instantiated, we need
+            # to tell it, so that it can clean up properly via Session.finalize(). It
+            # will also take care of deregistering the connection in that case.
+            if self.server is not None:
+                self.server.disconnect()
+            elif self in _connections:
+                _connections.remove(self)
+                _connections_changed.set()
+
+    def attach_to_session(self, session):
+        """Attaches this server to the specified Session as a Server component.
+
+        Raises ValueError if the server already belongs to some session.
+        """
+
+        with _lock:
+            if self.server is not None:
+                raise ValueError
+            log.info("Attaching {0} to {1}", self, session)
+            self.server = Server(session, self)
 
 
 class Server(components.Component):
@@ -45,24 +162,44 @@ class Server(components.Component):
             "supportedChecksumAlgorithms": [],
         }
 
-    def __init__(self, session, stream):
-        super(Server, self).__init__(session, stream)
+    def __init__(self, session, connection):
+        assert connection.server is None
+        with session:
+            assert not session.server
+            super(Server, self).__init__(session, channel=connection.channel)
 
-        self.pid = None
+            self.connection = connection
+
+            if self.launcher:
+                assert self.session.pid is not None
+            else:
+                assert self.session.pid is None
+            if self.session.pid is not None and self.session.pid != self.pid:
+                log.warning(
+                    "Launcher reported PID={0}, but server reported PID={1}",
+                    self.session.pid,
+                    self.pid,
+                )
+            else:
+                self.session.pid = self.pid
+
+            session.server = self
+
+    @property
+    def pid(self):
         """Process ID of the debuggee process, as reported by the server."""
+        return self.connection.pid
 
-        assert not session.server
-        session.server = self
+    @property
+    def ppid(self):
+        """Parent process ID of the debuggee process, as reported by the server."""
+        return self.connection.ppid
 
     def initialize(self, request):
         assert request.is_request("initialize")
         request = self.channel.propagate(request)
         request.wait_for_response()
         self.capabilities = self.Capabilities(self, request.response)
-
-    def set_debugger_property(self, arguments):
-        assert isinstance(arguments, dict)
-        self.channel.request("setDebuggerProperty", arguments=arguments)
 
     # Generic request handler, used if there's no specific handler below.
     @message_handler
@@ -88,22 +225,6 @@ class Server(components.Component):
 
     @message_handler
     def process_event(self, event):
-        self.pid = event("systemProcessId", int)
-
-        if self.launcher:
-            assert self.session.pid is not None
-        else:
-            assert self.session.pid is None
-        if self.session.pid is not None and self.session.pid != self.pid:
-            event.cant_handle(
-                '"process" event mismatch: launcher reported "systemProcessId":{0}, '
-                'but server reported "systemProcessId":{1}',
-                self.session.pid,
-                self.pid,
-            )
-        else:
-            self.session.pid = self.pid
-
         # If there is a launcher, it's handling the process event.
         if not self.launcher:
             self.ide.propagate_after_start(event)
@@ -141,4 +262,117 @@ class Server(components.Component):
     @message_handler
     def terminated_event(self, event):
         # Do not propagate this, since we'll report our own.
-        pass
+        self.channel.close()
+
+    def detach_from_session(self):
+        with _lock:
+            self.is_connected = False
+            self.channel.handlers = self.connection
+            self.channel.name = self.channel.stream.name = str(self.connection)
+            self.connection.server = None
+
+    def disconnect(self):
+        with _lock:
+            _connections.remove(self.connection)
+            _connections_changed.set()
+        super(Server, self).disconnect()
+
+
+listen = Connection.listen
+
+
+def connections():
+    with _lock:
+        return list(_connections)
+
+
+def wait_for_connection(pid=any, timeout=None):
+    """Waits until there is a server with the specified PID connected to this adapter,
+    and returns the corresponding Connection.
+
+    If there is more than one server connection already available, returns the oldest
+    one.
+    """
+
+    def wait_for_timeout():
+        time.sleep(timeout)
+        wait_for_timeout.timed_out = True
+        with _lock:
+            _connections_changed.set()
+
+    wait_for_timeout.timed_out = timeout == 0
+    if timeout:
+        thread = threading.Thread(
+            target=wait_for_timeout, name="server.wait_for_connection() timeout"
+        )
+        thread.daemon = True
+        thread.start()
+
+    if timeout != 0:
+        log.info(
+            "Waiting for connection from debug server..."
+            if pid is any
+            else "Waiting for connection from debug server with PID={0}...",
+            pid,
+        )
+    while True:
+        with _lock:
+            _connections_changed.clear()
+            conns = (conn for conn in _connections if pid is any or conn.pid == pid)
+            conn = next(conns, None)
+            if conn is not None or wait_for_timeout.timed_out:
+                return conn
+        _connections_changed.wait()
+
+
+def wait_until_disconnected():
+    """Blocks until all debug servers disconnect from the adapter.
+
+    If there are no server connections, waits until at least one is established first,
+    before waiting for it to disconnect.
+    """
+    while True:
+        _connections_changed.wait()
+        with _lock:
+            _connections_changed.clear()
+            if not len(_connections):
+                return
+
+
+def dont_expect_connections():
+    """Unblocks any pending wait_until_disconnected() call that is waiting on the
+    first server to connect.
+    """
+    with _lock:
+        _connections_changed.set()
+
+
+def inject(pid, ptvsd_args):
+    host, port = Connection.listener.getsockname()
+
+    cmdline = [
+        sys.executable,
+        compat.filename(os.path.dirname(ptvsd.__file__)),
+        "--client",
+        "--host",
+        host,
+        "--port",
+        str(port),
+    ]
+    cmdline += ptvsd_args
+    cmdline += ["--pid", str(pid)]
+
+    log.info("Spawning attach-to-PID debugger injector: {0!r}", cmdline)
+    try:
+        subprocess.Popen(
+            cmdline,
+            bufsize=0,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    except Exception as exc:
+        log.exception("Failed to inject debug server into process with PID={0}", pid)
+        raise messaging.MessageHandlingError(
+            "Failed to inject debug server into process with PID={0}: {1}", pid, exc
+        )

--- a/src/ptvsd/adapter/servers.py
+++ b/src/ptvsd/adapter/servers.py
@@ -36,7 +36,7 @@ class Connection(sockets.ClientConnection):
     """
 
     def __init__(self, sock):
-        from ptvsd.adapter import session
+        from ptvsd.adapter import sessions
 
         self.server = None
         """The Server component, if this debug server belongs to Session.
@@ -73,7 +73,7 @@ class Connection(sockets.ClientConnection):
             self.channel.close()
             return
 
-        parent_session = session.get(self.ppid)
+        parent_session = sessions.get(self.ppid)
         if parent_session is None:
             log.info("No active debug session for parent process of {0}.", self)
         else:

--- a/src/ptvsd/adapter/sessions.py
+++ b/src/ptvsd/adapter/sessions.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import contextlib
 import itertools
@@ -11,7 +11,7 @@ import threading
 import time
 
 from ptvsd.common import fmt, log, messaging, sockets, util
-from ptvsd.adapter import components, launcher, server
+from ptvsd.adapter import components, launchers, servers
 
 
 _lock = threading.RLock()
@@ -40,12 +40,12 @@ class Session(util.Observable):
         self.ide = components.missing(self, ide.IDE)
         """The IDE component. Always present."""
 
-        self.launcher = components.missing(self, launcher.Launcher)
+        self.launcher = components.missing(self, launchers.Launcher)
         """The launcher componet. Always present in "launch" sessions, and never
         present in "attach" sessions.
         """
 
-        self.server = components.missing(self, server.Server)
+        self.server = components.missing(self, servers.Server)
         """The debug server component. Always present, unless this is a "launch"
         session with "noDebug".
         """
@@ -174,7 +174,7 @@ class Session(util.Observable):
         what(self, stream)
 
     def accept_connection_from_launcher(self, address=("127.0.0.1", 0)):
-        return self._accept_connection_from(launcher.Launcher, address, timeout=10)
+        return self._accept_connection_from(launchers.Launcher, address, timeout=10)
 
     def finalize(self, why, terminate_debuggee=None):
         """Finalizes the debug session.

--- a/src/ptvsd/common/__init__.py
+++ b/src/ptvsd/common/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 __all__ = []

--- a/src/ptvsd/common/compat.py
+++ b/src/ptvsd/common/compat.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Python 2/3 compatibility helpers.
 """

--- a/src/ptvsd/common/fmt.py
+++ b/src/ptvsd/common/fmt.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Provides a custom string.Formatter with JSON support.
 

--- a/src/ptvsd/common/json.py
+++ b/src/ptvsd/common/json.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Improved JSON serialization.
 """

--- a/src/ptvsd/common/log.py
+++ b/src/ptvsd/common/log.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import contextlib
 import functools

--- a/src/ptvsd/common/messaging.py
+++ b/src/ptvsd/common/messaging.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """An implementation of the session and presentation layers as used in the Debug
 Adapter Protocol (DAP): channels and their lifetime, JSON messages, requests,

--- a/src/ptvsd/common/options.py
+++ b/src/ptvsd/common/options.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 

--- a/src/ptvsd/common/singleton.py
+++ b/src/ptvsd/common/singleton.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
 import threading

--- a/src/ptvsd/common/sockets.py
+++ b/src/ptvsd/common/sockets.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import platform
 import socket

--- a/src/ptvsd/common/stacks.py
+++ b/src/ptvsd/common/stacks.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Provides facilities to dump all stacks of all threads in the process.
 """

--- a/src/ptvsd/common/timestamp.py
+++ b/src/ptvsd/common/timestamp.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Provides monotonic timestamps with a resetable zero.
 """

--- a/src/ptvsd/common/util.py
+++ b/src/ptvsd/common/util.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import sys

--- a/src/ptvsd/common/util.py
+++ b/src/ptvsd/common/util.py
@@ -22,6 +22,8 @@ def evaluate(code, path=__file__, mode="eval"):
 class Observable(object):
     """An object with change notifications."""
 
+    observers = ()  # used when attributes are set before __init__ is invoked
+
     def __init__(self):
         self.observers = []
 

--- a/src/ptvsd/launcher/__init__.py
+++ b/src/ptvsd/launcher/__init__.py
@@ -2,11 +2,11 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __all__ = []
 
-import os.path
+import os
 
 # Force absolute path on Python 2.
 __file__ = os.path.abspath(__file__)

--- a/src/ptvsd/server/__init__.py
+++ b/src/ptvsd/server/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 # "force_pydevd" must be imported first to ensure (via side effects)
 # that the ptvsd-vendored copy of pydevd gets used.

--- a/src/ptvsd/server/api.py
+++ b/src/ptvsd/server/api.py
@@ -117,6 +117,7 @@ def enable_attach(dont_trace_start_patterns, dont_trace_end_patterns):
         host=host,
         port=port,
         suspend=False,
+        patch_multiprocessing=server_opts.multiprocess,
         wait_for_ready_to_run=False,
         block_until_connected=True,
         dont_trace_start_patterns=dont_trace_start_patterns,
@@ -127,7 +128,7 @@ def enable_attach(dont_trace_start_patterns, dont_trace_end_patterns):
 
     # Ensure that we ignore the adapter process when terminating the debugger.
     pydevd.add_dont_terminate_child_pid(process.pid)
-    server_opts.port =  connection_details["adapter"]["port"]
+    server_opts.port =  connection_details["ide"]["port"]
 
     listener_file = os.getenv("PTVSD_LISTENER_FILE")
     if listener_file is not None:

--- a/src/ptvsd/server/api.py
+++ b/src/ptvsd/server/api.py
@@ -81,6 +81,7 @@ def enable_attach(dont_trace_start_patterns, dont_trace_end_patterns):
         raise RuntimeError("enable_attach() can only be called once per process.")
 
     import subprocess
+
     adapter_args = [
         sys.executable,
         _ADAPTER_PATH,
@@ -98,11 +99,7 @@ def enable_attach(dont_trace_start_patterns, dont_trace_end_patterns):
 
     # Adapter life time is expected to be longer than this process,
     # so never wait on the adapter process
-    process = subprocess.Popen(
-        adapter_args,
-        bufsize=0,
-        stdout=subprocess.PIPE,
-    )
+    process = subprocess.Popen(adapter_args, bufsize=0, stdout=subprocess.PIPE)
 
     line = process.stdout.readline()
     if isinstance(line, bytes):
@@ -110,7 +107,7 @@ def enable_attach(dont_trace_start_patterns, dont_trace_end_patterns):
     connection_details = json.JSONDecoder().decode(line)
     log.info("Connection details received from adapter: {0!r}", connection_details)
 
-    host = "127.0.0.1" # This should always be loopback address.
+    host = "127.0.0.1"  # This should always be loopback address.
     port = connection_details["server"]["port"]
 
     pydevd.settrace(
@@ -128,7 +125,7 @@ def enable_attach(dont_trace_start_patterns, dont_trace_end_patterns):
 
     # Ensure that we ignore the adapter process when terminating the debugger.
     pydevd.add_dont_terminate_child_pid(process.pid)
-    server_opts.port =  connection_details["ide"]["port"]
+    server_opts.port = connection_details["ide"]["port"]
 
     listener_file = os.getenv("PTVSD_LISTENER_FILE")
     if listener_file is not None:

--- a/src/ptvsd/server/api.py
+++ b/src/ptvsd/server/api.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import contextlib
 import json

--- a/src/ptvsd/server/attach_pid_injected.py
+++ b/src/ptvsd/server/attach_pid_injected.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 

--- a/src/ptvsd/server/cli.py
+++ b/src/ptvsd/server/cli.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os.path
+import os
 import runpy
 import sys
 

--- a/src/ptvsd/server/options.py
+++ b/src/ptvsd/server/options.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 """ptvsd command-line options that need to be globally available.

--- a/tests/DEBUGGEE_PYTHONPATH/debug_me/__init__.py
+++ b/tests/DEBUGGEE_PYTHONPATH/debug_me/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Makes sure that the code is run under debugger, using the appropriate method
 to establish connection back to DebugSession in the test process, depending on

--- a/tests/DEBUGGEE_PYTHONPATH/debug_me/backchannel.py
+++ b/tests/DEBUGGEE_PYTHONPATH/debug_me/backchannel.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Imported from test code that runs under ptvsd, and allows that code
 to communcate back to the test. Works in conjunction with debug_session

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """ptvsd tests
 """

--- a/tests/code.py
+++ b/tests/code.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Helpers to work with Python code.
 """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """pytest configuration.
 """

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -207,8 +207,6 @@ def attach_by_socket(
         if wait:
             args += ["--wait"]
         args += ["--host", compat.filename_str(host), "--port", str(port)]
-        if not config["subProcess"]:
-            args += ["--no-subprocesses"]
         if log_dir is not None:
             args += ["--log-dir", log_dir]
         debug_me = None

--- a/tests/logs.py
+++ b/tests/logs.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import io
 import os

--- a/tests/net.py
+++ b/tests/net.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Test helpers for networking.
 """

--- a/tests/patterns/__init__.py
+++ b/tests/patterns/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Do not import this package directly - import tests.patterns.some instead.
 """

--- a/tests/patterns/_impl.py
+++ b/tests/patterns/_impl.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 # The actual patterns are defined here, so that tests.patterns.some can redefine
 # builtin names like str, int etc without affecting the implementations in this

--- a/tests/patterns/dap.py
+++ b/tests/patterns/dap.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Patterns that are specific to the Debug Adapter Protocol.
 """

--- a/tests/patterns/some.py
+++ b/tests/patterns/some.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Pattern matching for recursive Python data structures.
 

--- a/tests/ptvsd/__init__.py
+++ b/tests/ptvsd/__init__.py
@@ -2,6 +2,6 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Product tests."""

--- a/tests/ptvsd/adapter/__init__.py
+++ b/tests/ptvsd/adapter/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Tests for the debug adapter.
 """

--- a/tests/ptvsd/common/__init__.py
+++ b/tests/ptvsd/common/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Tests for product code that is shared between the adapter and the server.
 """

--- a/tests/ptvsd/common/test_messaging.py
+++ b/tests/ptvsd/common/test_messaging.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Tests for JSON message streams and channels.
 """

--- a/tests/ptvsd/common/test_socket.py
+++ b/tests/ptvsd/common/test_socket.py
@@ -2,8 +2,11 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import platform
 import pytest
+
 from ptvsd.common import sockets
 
 

--- a/tests/ptvsd/server/__init__.py
+++ b/tests/ptvsd/server/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Tests for the debug server.
 """

--- a/tests/ptvsd/server/test_args.py
+++ b/tests/ptvsd/server/test_args.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_attach.py
+++ b/tests/ptvsd/server/test_attach.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_breakpoints.py
+++ b/tests/ptvsd/server/test_breakpoints.py
@@ -101,7 +101,6 @@ def test_conditional_breakpoint(pyfile, target, run, condition_kind, condition):
 
 
 def test_crossfile_breakpoint(pyfile, target, run):
-
     @pyfile
     def script1():
         import debug_me  # noqa
@@ -171,7 +170,6 @@ def test_error_in_condition(pyfile, target, run, error_name):
 
 @pytest.mark.parametrize("condition", ["condition", ""])
 def test_log_point(pyfile, target, run, condition):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
@@ -247,7 +245,6 @@ def test_package_launch(run):
 
 
 def test_add_and_remove_breakpoint(pyfile, target, run):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
@@ -279,7 +276,6 @@ def test_add_and_remove_breakpoint(pyfile, target, run):
 
 
 def test_breakpoint_in_nonexistent_file(pyfile, target, run):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
@@ -300,7 +296,6 @@ def test_breakpoint_in_nonexistent_file(pyfile, target, run):
 
 
 def test_invalid_breakpoints(pyfile, target, run):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
@@ -368,7 +363,6 @@ def test_invalid_breakpoints(pyfile, target, run):
 
 
 def test_deep_stacks(pyfile, target, run):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa

--- a/tests/ptvsd/server/test_breakpoints.py
+++ b/tests/ptvsd/server/test_breakpoints.py
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import platform
 import pytest

--- a/tests/ptvsd/server/test_completions.py
+++ b/tests/ptvsd/server/test_completions.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_disconnect.py
+++ b/tests/ptvsd/server/test_disconnect.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import os.path
+import os
 import pytest
 
 from tests import debug

--- a/tests/ptvsd/server/test_django.py
+++ b/tests/ptvsd/server/test_django.py
@@ -2,9 +2,10 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
+
 from ptvsd.common import compat
 from tests import code, debug, log, net, test_data
 from tests.debug import runners, targets

--- a/tests/ptvsd/server/test_evaluate.py
+++ b/tests/ptvsd/server/test_evaluate.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 import sys

--- a/tests/ptvsd/server/test_exception.py
+++ b/tests/ptvsd/server/test_exception.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_exclude_rules.py
+++ b/tests/ptvsd/server/test_exclude_rules.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_flask.py
+++ b/tests/ptvsd/server/test_flask.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import platform
 import pytest

--- a/tests/ptvsd/server/test_justmycode.py
+++ b/tests/ptvsd/server/test_justmycode.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_log.py
+++ b/tests/ptvsd/server/test_log.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import contextlib
 import pytest

--- a/tests/ptvsd/server/test_multiproc.py
+++ b/tests/ptvsd/server/test_multiproc.py
@@ -135,9 +135,7 @@ def test_multiprocessing(pyfile, target, run, start_method):
 
 
 @pytest.mark.timeout(30)
-@pytest.mark.skipif(
-    sys.version_info < (3, 0) and (platform.system() != "Windows"), reason="Bug #935"
-)
+@pytest.mark.skip("Needs refactoring to use the new debug.Session API")
 @pytest.mark.parametrize(
     "start_method", [runners.launch, runners.attach_by_socket["cli"]]
 )
@@ -204,9 +202,7 @@ def test_subprocess(pyfile, start_method, run_as):
 
 
 @pytest.mark.timeout(30)
-@pytest.mark.skipif(
-    sys.version_info < (3, 0) and (platform.system() != "Windows"), reason="Bug #935"
-)
+@pytest.mark.skip("Needs refactoring to use the new debug.Session API")
 @pytest.mark.parametrize(
     "start_method", [runners.launch, runners.attach_by_socket["cli"]]
 )
@@ -261,9 +257,7 @@ def test_autokill(pyfile, start_method, run_as):
                 parent_backchannel.send(None)
 
 
-@pytest.mark.skipif(
-    sys.version_info < (3, 0) and (platform.system() != "Windows"), reason="Bug #935"
-)
+@pytest.mark.skip("Needs refactoring to use the new debug.Session API")
 def test_argv_quoting(pyfile, start_method, run_as):
     @pyfile
     def args():
@@ -316,6 +310,7 @@ def test_argv_quoting(pyfile, start_method, run_as):
         assert expected_args == actual_args
 
 
+@pytest.mark.skip("Needs refactoring to use the new debug.Session API")
 def test_echo_and_shell(pyfile, run_as, start_method):
     """
     Checks https://github.com/microsoft/ptvsd/issues/1548

--- a/tests/ptvsd/server/test_multiproc.py
+++ b/tests/ptvsd/server/test_multiproc.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import platform
 import pytest

--- a/tests/ptvsd/server/test_output.py
+++ b/tests/ptvsd/server/test_output.py
@@ -15,7 +15,6 @@ from tests import debug
 
 
 def test_with_no_output(pyfile, target, run):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
@@ -36,7 +35,6 @@ def test_with_no_output(pyfile, target, run):
 
 
 def test_with_tab_in_output(pyfile, target, run):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
@@ -57,7 +55,6 @@ def test_with_tab_in_output(pyfile, target, run):
 
 @pytest.mark.parametrize("redirect", ["enabled", "disabled"])
 def test_redirect_output(pyfile, target, run, redirect):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
@@ -83,12 +80,12 @@ def test_redirect_output(pyfile, target, run, redirect):
 
 
 def test_non_ascii_output(pyfile, target, run):
-
     @pyfile
     def code_to_debug():
         import debug_me  # noqa
         import sys
-        a = b'\xc3\xa9 \xc3\xa0 \xc3\xb6 \xc3\xb9\n'
+
+        a = b"\xc3\xa9 \xc3\xa0 \xc3\xb6 \xc3\xb9\n"
         if sys.version_info[0] >= 3:
             sys.stdout.buffer.write(a)
         else:
@@ -104,10 +101,9 @@ def test_non_ascii_output(pyfile, target, run):
         session.wait_for_stop()
         session.request_continue()
 
-    output = session.output("stdout").encode('utf-8', 'replace')
+    output = session.output("stdout").encode("utf-8", "replace")
 
     assert output in (
-        b'\xc3\xa9 \xc3\xa0 \xc3\xb6 \xc3\xb9\n',
-        b'\xc3\x83\xc2\xa9 \xc3\x83\xc2\xa0 \xc3\x83\xc2\xb6 \xc3\x83\xc2\xb9\n'
+        b"\xc3\xa9 \xc3\xa0 \xc3\xb6 \xc3\xb9\n",
+        b"\xc3\x83\xc2\xa9 \xc3\x83\xc2\xa0 \xc3\x83\xc2\xb6 \xc3\x83\xc2\xb9\n",
     )
-

--- a/tests/ptvsd/server/test_output.py
+++ b/tests/ptvsd/server/test_output.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_parse_args.py
+++ b/tests/ptvsd/server/test_parse_args.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_path_mapping.py
+++ b/tests/ptvsd/server/test_path_mapping.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_run.py
+++ b/tests/ptvsd/server/test_run.py
@@ -2,9 +2,9 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-from os import path
+import os
 import pytest
 import re
 
@@ -21,11 +21,11 @@ def test_run(pyfile, target, run):
     @pyfile
     def code_to_debug():
         from debug_me import backchannel
-        from os import path
+        import os
         import sys
 
         print("begin")
-        backchannel.send(path.abspath(sys.modules["ptvsd"].__file__))
+        backchannel.send(os.path.abspath(sys.modules["ptvsd"].__file__))
         assert backchannel.receive() == "continue"
         print("end")
 
@@ -34,7 +34,7 @@ def test_run(pyfile, target, run):
         with run(session, target(code_to_debug)):
             pass
 
-        expected_ptvsd_path = path.abspath(ptvsd.__file__)
+        expected_ptvsd_path = os.path.abspath(ptvsd.__file__)
         assert backchannel.receive() == some.str.matching(
             re.escape(expected_ptvsd_path) + r"(c|o)?"
         )

--- a/tests/ptvsd/server/test_source_mapping.py
+++ b/tests/ptvsd/server/test_source_mapping.py
@@ -2,8 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 from tests import debug

--- a/tests/ptvsd/server/test_start_stop.py
+++ b/tests/ptvsd/server/test_start_stop.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 import sys

--- a/tests/ptvsd/server/test_step.py
+++ b/tests/ptvsd/server/test_step.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_stop_on_entry.py
+++ b/tests/ptvsd/server/test_stop_on_entry.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/server/test_system_info.py
+++ b/tests/ptvsd/server/test_system_info.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 import sys

--- a/tests/ptvsd/server/test_threads.py
+++ b/tests/ptvsd/server/test_threads.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import platform
 import pytest

--- a/tests/ptvsd/server/test_tracing.py
+++ b/tests/ptvsd/server/test_tracing.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from tests import debug
 from tests.patterns import some

--- a/tests/ptvsd/server/test_vs_specific.py
+++ b/tests/ptvsd/server/test_vs_specific.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/tests/ptvsd/test_docstrings.py
+++ b/tests/ptvsd/test_docstrings.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import inspect
 

--- a/tests/pytest_fixtures.py
+++ b/tests/pytest_fixtures.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import inspect
 import os

--- a/tests/pytest_hooks.py
+++ b/tests/pytest_hooks.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import pytest

--- a/tests/test_data/flask1/app.py
+++ b/tests/test_data/flask1/app.py
@@ -1,3 +1,4 @@
+import debug_me  # noqa
 from flask import Flask
 from flask import render_template
 

--- a/tests/test_data/flask1/main.py
+++ b/tests/test_data/flask1/main.py
@@ -1,0 +1,8 @@
+# For multiproc attach, we need to use a helper stub to import debug_me before running
+# Flask; otherwise, we will get the connection only from the subprocess, not from the
+# Flask server process.
+
+import debug_me  # noqa
+import runpy
+
+runpy.run_module("flask", run_name="__main__")

--- a/tests/tests/__init__.py
+++ b/tests/tests/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """Tests for the testing infrastructure.
 """

--- a/tests/tests/test_patterns.py
+++ b/tests/tests/test_patterns.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 import sys

--- a/tests/tests/test_timeline.py
+++ b/tests/tests/test_timeline.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 import functools

--- a/tests/timeline.py
+++ b/tests/timeline.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 import contextlib

--- a/tests/watchdog/__init__.py
+++ b/tests/watchdog/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """A watchdog process for debuggee processes spawned by tests.
 

--- a/tests/watchdog/worker.py
+++ b/tests/watchdog/worker.py
@@ -12,11 +12,8 @@ from __future__ import absolute_import, print_function, unicode_literals
 # this is done in main().
 
 import collections
-import os
-import platform
 import psutil
 import sys
-import tempfile
 import time
 
 
@@ -154,15 +151,15 @@ def main(tests_pid):
                 proc.pid,
             )
 
-            if platform.system() == "Linux":
-                try:
-                    # gcore will automatically add pid to the filename
-                    core_file = os.path.join(tempfile.gettempdir(), "ptvsd_core")
-                    gcore_cmd = fmt("gcore -o {0} {1}", core_file, proc.pid)
-                    log.warning("WatchDog-{0}: {1}", tests_pid, gcore_cmd)
-                    os.system(gcore_cmd)
-                except Exception:
-                    log.exception()
+            # if platform.system() == "Linux":
+            #     try:
+            #         # gcore will automatically add pid to the filename
+            #         core_file = os.path.join(tempfile.gettempdir(), "ptvsd_core")
+            #         gcore_cmd = fmt("gcore -o {0} {1}", core_file, proc.pid)
+            #         log.warning("WatchDog-{0}: {1}", tests_pid, gcore_cmd)
+            #         os.system(gcore_cmd)
+            #     except Exception:
+            #         log.exception()
 
             try:
                 proc.kill()

--- a/tests/watchdog/worker.py
+++ b/tests/watchdog/worker.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License. See LICENSE in the project root
 # for license information.
 
-from __future__ import absolute_import, print_function, unicode_literals
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 """The main script for the watchdog worker process.
 """


### PR DESCRIPTION
There are a few test failures, but we can track these separately.

The change in pydevd_defaults.py is a workaround for #1874. 

#1877 is preventing this from functioning on Windows; however, test_multiprocessing passes on Python 2.7 on Linux (which also means that fork is working!).

#1875, #1876 are still TBD.