### PR TITLE
Reduce running time for CI test runs

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 testpaths=tests
-timeout=20
+timeout=30
 timeout_method=thread
 addopts=-n8

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 testpaths=tests
-timeout=30
+timeout=20
 timeout_method=thread
 addopts=-n8

--- a/src/ptvsd/adapter/ide.py
+++ b/src/ptvsd/adapter/ide.py
@@ -5,7 +5,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
-import platform
 import sys
 
 import ptvsd
@@ -206,7 +205,7 @@ class IDE(components.Component, sockets.ClientConnection):
             elif {"UnixClient", "UNIX"} & debug_options:
                 client_os_type = "UNIX"
             else:
-                client_os_type = "WINDOWS" if platform.system() == "Windows" else "UNIX"
+                client_os_type = "WINDOWS" if sys.platform == "win32" else "UNIX"
             self.server.channel.request(
                 "setDebuggerProperty",
                 {
@@ -231,7 +230,7 @@ class IDE(components.Component, sockets.ClientConnection):
 
         sudo = request("sudo", json.default("Sudo" in self.session.debug_options))
         if sudo:
-            if platform.system() == "Windows":
+            if sys.platform == "win32":
                 raise request.cant_handle('"sudo":true is not supported on Windows.')
         else:
             if "Sudo" in self.session.debug_options:

--- a/src/ptvsd/common/log.py
+++ b/src/ptvsd/common/log.py
@@ -8,8 +8,8 @@ import contextlib
 import functools
 import inspect
 import io
-import platform
 import os
+import platform
 import sys
 import threading
 import traceback

--- a/src/ptvsd/common/sockets.py
+++ b/src/ptvsd/common/sockets.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import platform
 import socket
+import sys
 import threading
 
 from ptvsd.common import log
@@ -37,7 +37,7 @@ def create_client():
 
 def _new_sock():
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
-    if platform.system() == "Windows":
+    if sys.platform == "win32":
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_EXCLUSIVEADDRUSE, 1)
     else:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/src/ptvsd/launcher/adapter.py
+++ b/src/ptvsd/launcher/adapter.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import functools
 import os
-import platform
 import sys
 
 import ptvsd
@@ -51,7 +50,7 @@ class Handlers(object):
 
         cmdline = []
         if property_or_debug_option("sudo", "Sudo"):
-            if platform.system() == "Windows":
+            if sys.platform == "win32":
                 raise request.cant_handle('"sudo":true is not supported on Windows.')
             else:
                 cmdline += ["sudo"]

--- a/src/ptvsd/launcher/debuggee.py
+++ b/src/ptvsd/launcher/debuggee.py
@@ -7,7 +7,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import atexit
 import locale
 import os
-import platform
 import struct
 import subprocess
 import sys
@@ -114,7 +113,7 @@ def wait_for_exit():
 
     try:
         code = process.wait()
-        if platform.system() != "Windows" and code < 0:
+        if sys.platform != "win32" and code < 0:
             # On POSIX, if the process was terminated by a signal, Popen will use
             # a negative returncode to indicate that - but the actual exit code of
             # the process is always an unsigned number, and can be determined by

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -53,7 +53,6 @@ If there is no configuration phase, the runner returns directly::
 """
 
 import os
-import platform
 import pytest
 import sys
 
@@ -159,7 +158,7 @@ def _attach_common_config(session, target, cwd):
 
 @_runner
 def attach_by_pid(session, target, cwd=None, wait=True):
-    if sys.version_info < (3,) and platform.system() == "Windows":
+    if sys.version_info < (3,) and sys.platform == "win32":
         pytest.skip("https://github.com/microsoft/ptvsd/issues/1811")
 
     log.info("Attaching {0} to {1} by PID.", session, target)

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -162,6 +162,8 @@ def _attach_common_config(session, target, cwd):
 def attach_by_pid(session, target, cwd=None, wait=True):
     if sys.version_info < (3,) and sys.platform == "win32":
         pytest.skip("https://github.com/microsoft/ptvsd/issues/1811")
+    if wait and not sys.platform.startswith("linux"):
+        pytest.skip("https://github.com/microsoft/ptvsd/issues/1926")
 
     log.info("Attaching {0} to {1} by PID.", session, target)
 

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -162,6 +162,8 @@ def _attach_common_config(session, target, cwd):
 def attach_by_pid(session, target, cwd=None, wait=True):
     if sys.version_info < (3,) and sys.platform == "win32":
         pytest.skip("https://github.com/microsoft/ptvsd/issues/1811")
+    if sys.version_info < (3,) and sys.platform == "darwin":
+        pytest.skip("https://github.com/microsoft/ptvsd/issues/1916")
     if wait and not sys.platform.startswith("linux"):
         pytest.skip("https://github.com/microsoft/ptvsd/issues/1926")
 

--- a/tests/debug/runners.py
+++ b/tests/debug/runners.py
@@ -82,6 +82,13 @@ def _runner(f):
                 return self.with_options(*args, **kwargs)(session, target)
             return f(session, target, *self._args, **self._kwargs)
 
+        def __iter__(self):
+            # Since we implement __getitem__, iter() will assume that runners are
+            # iterable, and will iterate over them by calling __getitem__ until it
+            # raises IndexError - i.e. indefinitely. To prevent that, explicitly
+            # implement __iter__ as unsupported.
+            raise NotImplementedError
+
         def __getitem__(self, arg):
             return self.with_options(arg)
 
@@ -240,13 +247,14 @@ if {wait!r}:
 attach_by_socket.host = "127.0.0.1"
 attach_by_socket.port = net.get_test_server_port(5678, 5800)
 
-
 all_launch = [
     launch["internalConsole"],
     launch["integratedTerminal"],
     launch["externalTerminal"],
 ]
 
-all_attach = [attach_by_socket["api"], attach_by_socket["cli"], attach_by_pid]
+all_attach_by_socket = [attach_by_socket["api"], attach_by_socket["cli"]]
+
+all_attach = all_attach_by_socket + [attach_by_pid]
 
 all = all_launch + all_attach

--- a/tests/patterns/some.py
+++ b/tests/patterns/some.py
@@ -48,7 +48,7 @@ Usage::
     assert "abbc" != some.str.matching(r"ab")
     assert "abbc" != some.str.matching(r"bc")
 
-    if platform.system() == "Windows":
+    if sys.platform == "win32":
         assert "\\Foo\\Bar" == some.path("/foo/bar")
     else:
         assert "/Foo/Bar" != some.path("/foo/bar")

--- a/tests/ptvsd/common/test_socket.py
+++ b/tests/ptvsd/common/test_socket.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import platform
 import pytest
+import sys
 
 from ptvsd.common import sockets
 
@@ -15,7 +15,7 @@ class TestSocketServerReuse(object):
     # NOTE: Windows allows loopback range 127/8. Some flavors of Linux support
     # 127/8 range. Mac by default supports only 127/0. Configuring /etc/network/interface
     # for this one test is overkill so use '0.0.0.0' on Mac instead.
-    HOST2 = "127.0.0.2" if platform.system() in ["Windows", "Linux"] else "0.0.0.0"
+    HOST2 = "127.0.0.2" if sys.platform != "darwin" else "0.0.0.0"
 
     def test_reuse_same_address_port(self):
         # NOTE: This test should ensure that same address port can be used by two

--- a/tests/ptvsd/server/test_args.py
+++ b/tests/ptvsd/server/test_args.py
@@ -7,11 +7,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from tests import debug
-from tests.debug import targets
+from tests.debug import runners, targets
 from tests.patterns import some
 
 
 @pytest.mark.parametrize("target", targets.all)
+@pytest.mark.parametrize("run", runners.all)
 def test_args(pyfile, target, run):
     @pyfile
     def code_to_debug():

--- a/tests/ptvsd/server/test_breakpoints.py
+++ b/tests/ptvsd/server/test_breakpoints.py
@@ -18,6 +18,12 @@ from tests.patterns import some
 bp_root = test_data / "bp"
 
 
+@pytest.fixture(params=[runners.launch, runners.attach_by_socket["api"]])
+def run(request):
+    return request.param
+
+
+@pytest.mark.parametrize("target", targets.all_named)
 def test_path_with_ampersand(target, run):
     test_py = bp_root / "a&b" / "test.py"
 
@@ -38,6 +44,7 @@ def test_path_with_ampersand(target, run):
     platform.system() == "Windows" and sys.version_info < (3, 6),
     reason="https://github.com/Microsoft/ptvsd/issues/1124#issuecomment-459506802",
 )
+@pytest.mark.parametrize("target", targets.all_named)
 def test_path_with_unicode(target, run):
     test_py = bp_root / "ನನ್ನ_ಸ್ಕ್ರಿಪ್ಟ್.py"
 
@@ -65,6 +72,7 @@ conditions = {
 
 
 @pytest.mark.parametrize("condition_kind, condition", list(conditions.keys()))
+@pytest.mark.parametrize("target", targets.all_named)
 def test_conditional_breakpoint(pyfile, target, run, condition_kind, condition):
     hit = conditions[condition_kind, condition]
 
@@ -169,6 +177,7 @@ def test_error_in_condition(pyfile, target, run, error_name):
 
 
 @pytest.mark.parametrize("condition", ["condition", ""])
+@pytest.mark.parametrize("target", targets.all_named)
 def test_log_point(pyfile, target, run, condition):
     @pyfile
     def code_to_debug():
@@ -226,8 +235,8 @@ def test_log_point(pyfile, target, run, condition):
     assert session.output("stderr") == some.str.matching(expected_stderr)
 
 
-@pytest.mark.parametrize("run", runners.all_launch)
-def test_package_launch(run):
+@pytest.mark.parametrize("run", [runners.launch])
+def test_breakpoint_in_package_main(run):
     testpkgs = test_data / "testpkgs"
     main_py = testpkgs / "pkg1" / "__main__.py"
 

--- a/tests/ptvsd/server/test_breakpoints.py
+++ b/tests/ptvsd/server/test_breakpoints.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import platform
 import pytest
 import re
 import sys
@@ -41,7 +40,7 @@ def test_path_with_ampersand(target, run):
     sys.version_info < (3, 0), reason="Paths are not Unicode in Python 2.7"
 )
 @pytest.mark.skipif(
-    platform.system() == "Windows" and sys.version_info < (3, 6),
+    sys.platform == "win32" and sys.version_info < (3, 6),
     reason="https://github.com/Microsoft/ptvsd/issues/1124#issuecomment-459506802",
 )
 @pytest.mark.parametrize("target", targets.all_named)

--- a/tests/ptvsd/server/test_disconnect.py
+++ b/tests/ptvsd/server/test_disconnect.py
@@ -12,9 +12,7 @@ from tests.debug import runners
 from tests.patterns import some
 
 
-@pytest.mark.parametrize(
-    "run", [runners.attach_by_socket["api"], runners.attach_by_socket["cli"]]
-)
+@pytest.mark.parametrize("run", runners.all_attach_by_socket)
 def test_continue_on_disconnect_for_attach(pyfile, target, run):
     @pyfile
     def code_to_debug():

--- a/tests/ptvsd/server/test_exception.py
+++ b/tests/ptvsd/server/test_exception.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from tests import debug
+from tests.debug import runners, targets
 from tests.patterns import some
 from tests.timeline import Event
 
@@ -142,6 +143,8 @@ def test_vsc_exception_options_raise_without_except(
             session.request_continue()
 
 
+@pytest.mark.parametrize("target", targets.all_named)
+@pytest.mark.parametrize("run", runners.all)
 @pytest.mark.parametrize("raised", ["raised", ""])
 @pytest.mark.parametrize("uncaught", ["uncaught", ""])
 @pytest.mark.parametrize("zero", ["zero", ""])
@@ -281,6 +284,8 @@ def test_raise_exception_options(pyfile, target, run, exceptions, break_mode):
             session.request_continue()
 
 
+@pytest.mark.parametrize("target", targets.all_named)
+@pytest.mark.parametrize("run", runners.all)
 @pytest.mark.parametrize("exit_code", [0, 3])
 @pytest.mark.parametrize("break_on_system_exit_zero", ["break_on_system_exit_zero", ""])
 @pytest.mark.parametrize("django", ["django", ""])

--- a/tests/ptvsd/server/test_exclude_rules.py
+++ b/tests/ptvsd/server/test_exclude_rules.py
@@ -7,7 +7,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from tests import code, debug, log, test_data
+from tests.debug import targets
 from tests.patterns import some
+
+
+@pytest.fixture(params=targets.all_named)
+def target(request):
+    return request.param
 
 
 @pytest.mark.parametrize("scenario", ["exclude_by_name", "exclude_by_dir"])

--- a/tests/ptvsd/server/test_flask.py
+++ b/tests/ptvsd/server/test_flask.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import platform
 import pytest
+import sys
 
 from ptvsd.common import compat
 from tests import code, debug, log, net, test_data
@@ -43,8 +43,8 @@ def start_flask(run):
                 "FLASK_DEBUG": "1" if multiprocess else "0",
             }
         )
-        if platform.system() != "Windows":
-            locale = "en_US.utf8" if platform.system() == "Linux" else "en_US.UTF-8"
+        if sys.platform != "win32":
+            locale = "en_US.utf8" if sys.platform.startswith("linux") else "en_US.UTF-8"
             session.config.env.update({"LC_ALL": locale, "LANG": locale})
 
         session.config.update({"jinja": True, "subProcess": multiprocess})

--- a/tests/ptvsd/server/test_flask.py
+++ b/tests/ptvsd/server/test_flask.py
@@ -29,18 +29,8 @@ class lines:
     app_py = code.get_marked_line_numbers(paths.app_py)
 
 
-@pytest.fixture(
-    params=[
-        runners.launch["internalConsole"],
-        runners.launch["integratedTerminal"],
-        runners.attach_by_socket["cli"],
-    ]
-)
-def run(request):
-    return request.param
-
-
 @pytest.fixture
+@pytest.mark.parametrize("run", [runners.launch, runners.attach_by_socket["cli"]])
 def start_flask(run):
     def start(session, multiprocess=False):
         # No clean way to kill Flask server, expect non-zero exit code

--- a/tests/ptvsd/server/test_justmycode.py
+++ b/tests/ptvsd/server/test_justmycode.py
@@ -7,10 +7,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from tests import debug
+from tests.debug import targets
 from tests.patterns import some
 
 
 @pytest.mark.parametrize("jmc", ["jmc", ""])
+@pytest.mark.parametrize("target", targets.all_named)
 def test_justmycode_frames(pyfile, target, run, jmc):
     @pyfile
     def code_to_debug():

--- a/tests/ptvsd/server/test_multiproc.py
+++ b/tests/ptvsd/server/test_multiproc.py
@@ -4,7 +4,6 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import platform
 import pytest
 import sys
 
@@ -13,6 +12,8 @@ from ptvsd.common import messaging
 from tests import debug
 from tests.debug import runners
 from tests.patterns import some
+
+pytestmark = pytest.mark.timeout(30)
 
 
 @pytest.fixture(params=[runners.launch, runners.attach_by_socket["api"]])
@@ -25,11 +26,11 @@ def run(request):
     [""]
     if sys.version_info < (3,)
     else ["spawn"]
-    if platform.system() == "Windows"
+    if sys.platform == "win32"
     else ["spawn", "fork"],
 )
 def test_multiprocessing(pyfile, target, run, start_method):
-    if start_method == "spawn" and platform.system() != "Windows":
+    if start_method == "spawn" and sys.platform != "win32":
         pytest.skip("https://github.com/microsoft/ptvsd/issues/1887")
 
     @pyfile
@@ -204,7 +205,6 @@ def test_subprocess(pyfile, target, run):
             assert child_argv == [child, "--arg1", "--arg2", "--arg3"]
 
 
-@pytest.mark.timeout(30)
 @pytest.mark.skip("Needs refactoring to use the new debug.Session API")
 @pytest.mark.parametrize(
     "start_method", [runners.launch, runners.attach_by_socket["cli"]]

--- a/tests/ptvsd/server/test_multiproc.py
+++ b/tests/ptvsd/server/test_multiproc.py
@@ -15,6 +15,11 @@ from tests.debug import runners
 from tests.patterns import some
 
 
+@pytest.fixture(params=[runners.launch, runners.attach_by_socket["api"]])
+def run(request):
+    return request.param
+
+
 @pytest.mark.parametrize(
     "start_method",
     [""]

--- a/tests/ptvsd/server/test_output.py
+++ b/tests/ptvsd/server/test_output.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from tests import debug
+from tests.debug import runners
 
 # When debuggee exits, there's no guarantee currently that all "output" events have
 # already been sent. To ensure that they are, all tests below must set a breakpoint
@@ -14,6 +15,7 @@ from tests import debug
 # sequentially, by the time we get to "stopped", we also have all the output events.
 
 
+@pytest.mark.parametrize("run", runners.all)
 def test_with_no_output(pyfile, target, run):
     @pyfile
     def code_to_debug():
@@ -30,8 +32,9 @@ def test_with_no_output(pyfile, target, run):
 
     assert not session.output("stdout")
     assert not session.output("stderr")
-    assert not session.captured_stdout()
-    assert not session.captured_stderr()
+    if session.debuggee is not None:
+        assert not session.captured_stdout()
+        assert not session.captured_stderr()
 
 
 def test_with_tab_in_output(pyfile, target, run):
@@ -53,6 +56,7 @@ def test_with_tab_in_output(pyfile, target, run):
     assert session.output("stdout").startswith("Hello\tWorld")
 
 
+@pytest.mark.parametrize("run", runners.all)
 @pytest.mark.parametrize("redirect", ["enabled", "disabled"])
 def test_redirect_output(pyfile, target, run, redirect):
     @pyfile

--- a/tests/ptvsd/server/test_path_mapping.py
+++ b/tests/ptvsd/server/test_path_mapping.py
@@ -7,7 +7,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from tests import debug, test_data
+from tests.debug import targets
 from tests.patterns import some
+
+
+@pytest.fixture(params=targets.all_named)
+def target(request):
+    return request.param
 
 
 def test_with_dot_remote_root(pyfile, long_tmpdir, target, run):

--- a/tests/ptvsd/server/test_source_mapping.py
+++ b/tests/ptvsd/server/test_source_mapping.py
@@ -4,9 +4,17 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import pytest
 import sys
+
 from tests import debug
+from tests.debug import runners
 from tests.patterns import some
+
+
+@pytest.fixture(params=[runners.launch, runners.attach_by_socket["api"]])
+def run(request):
+    return request.param
 
 
 def test_with_path_mappings(pyfile, tmpdir, target, run):

--- a/tests/ptvsd/server/test_start_stop.py
+++ b/tests/ptvsd/server/test_start_stop.py
@@ -14,6 +14,12 @@ from tests.debug import runners
 from tests.patterns import some
 
 
+# Can't test "internalConsole", because we don't have debuggee stdin.
+@pytest.fixture(params=[runners.launch["integratedTerminal"], runners.launch["externalTerminal"]])
+def run(request):
+    return request.param
+
+
 def has_waited(session):
     lines = session.captured_output.stdout_lines()
     return any(
@@ -34,9 +40,6 @@ def wait_and_press_key(session):
     session.debuggee.stdin.write(b"\n")
 
 
-@pytest.mark.parametrize(
-    "run", [runners.launch["integratedTerminal"], runners.launch["externalTerminal"]]
-)
 def test_wait_on_normal_exit_enabled(pyfile, target, run):
     @pyfile
     def code_to_debug():
@@ -59,9 +62,6 @@ def test_wait_on_normal_exit_enabled(pyfile, target, run):
 
 @pytest.mark.skipif(
     sys.version_info < (3, 0), reason="https://github.com/microsoft/ptvsd/issues/1819"
-)
-@pytest.mark.parametrize(
-    "run", [runners.launch["integratedTerminal"], runners.launch["externalTerminal"]]
 )
 def test_wait_on_abnormal_exit_enabled(pyfile, target, run):
     @pyfile
@@ -86,9 +86,6 @@ def test_wait_on_abnormal_exit_enabled(pyfile, target, run):
         wait_and_press_key(session)
 
 
-@pytest.mark.parametrize(
-    "run", [runners.launch["integratedTerminal"], runners.launch["externalTerminal"]]
-)
 def test_exit_normally_with_wait_on_abnormal_exit_enabled(pyfile, target, run):
     @pyfile
     def code_to_debug():

--- a/tests/ptvsd/server/test_stop_on_entry.py
+++ b/tests/ptvsd/server/test_stop_on_entry.py
@@ -7,12 +7,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import pytest
 
 from tests import debug
-from tests.debug import runners
+from tests.debug import runners, targets
 from tests.patterns import some
 
 
 @pytest.mark.parametrize("breakpoint", ["breakpoint", ""])
 @pytest.mark.parametrize("run", runners.all_launch)
+@pytest.mark.parametrize("target", targets.all_named)
 def test_stop_on_entry(pyfile, run, target, breakpoint):
     @pyfile
     def code_to_debug():

--- a/tests/ptvsd/server/test_threads.py
+++ b/tests/ptvsd/server/test_threads.py
@@ -4,8 +4,8 @@
 
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import platform
 import pytest
+import sys
 import time
 
 from tests import debug
@@ -129,14 +129,14 @@ def test_step_multi_threads(pyfile, target, run, resume):
 
 
 @pytest.mark.skipif(
-    platform.system() not in ["Windows", "Linux", "Darwin"],
-    reason="Test not implemented on " + platform.system(),
+    sys.platform not in ["win32", "darwin"] and not sys.platform.startswith("linux"),
+    reason="Test not implemented for sys.platform=" + repr(sys.platform),
 )
 def test_debug_this_thread(pyfile, target, run):
     @pyfile
     def code_to_debug():
         from debug_me import ptvsd
-        import platform
+        import sys
         import threading
 
         def foo(x):
@@ -146,7 +146,7 @@ def test_debug_this_thread(pyfile, target, run):
 
         event = threading.Event()
 
-        if platform.system() == "Windows":
+        if sys.platform == "win32":
             from ctypes import CFUNCTYPE, c_void_p, c_size_t, c_uint32, windll
 
             thread_func_p = CFUNCTYPE(c_uint32, c_void_p)
@@ -161,7 +161,7 @@ def test_debug_this_thread(pyfile, target, run):
                 c_uint32(0),
                 c_void_p(0),
             )
-        elif platform.system() == "Linux" or platform.system() == "Darwin":
+        elif sys.platform == "darwin" or sys.platform.startswith("linux"):
             from ctypes import CDLL, CFUNCTYPE, byref, c_void_p, c_ulong
             from ctypes.util import find_library
 
@@ -174,7 +174,7 @@ def test_debug_this_thread(pyfile, target, run):
                 byref(c_ulong(0)), c_void_p(0), thread_func, c_void_p(0)
             )
         else:
-            assert False
+            pytest.fail(sys.platform)
 
         event.wait()
 

--- a/tests/pytest_fixtures.py
+++ b/tests/pytest_fixtures.py
@@ -6,9 +6,9 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import inspect
 import os
-import platform
 import py
 import pytest
+import sys
 import threading
 import types
 
@@ -125,7 +125,7 @@ def daemon(request):
                 assert not thread.is_alive()
 
 
-if platform.system() != "Windows":
+if sys.platform != "win32":
 
     @pytest.fixture
     def long_tmpdir(request, tmpdir):

--- a/tests/pytest_fixtures.py
+++ b/tests/pytest_fixtures.py
@@ -16,19 +16,14 @@ from ptvsd.common import compat, fmt, log, options, timestamp
 from tests import code, logs
 from tests.debug import runners, session, targets
 
-# Set up the test matrix for various code types and attach methods. Most tests will
-# use both run_as and start_method, so the matrix is a cross product of them.
+# Set up the test matrix for various code types and attach methods
 
-if int(os.environ.get("PTVSD_SIMPLE_TESTS", "0")):
-    TARGETS = [targets.Program]
-    RUNNERS = [runners.launch, runners.attach_by_socket["cli"]]
-else:
+if int(os.environ.get("PTVSD_TESTS_FULL", "0")):
     TARGETS = targets.all_named
-    RUNNERS = [
-        runners.launch,
-        runners.attach_by_socket["api"],
-        runners.attach_by_socket["cli"],
-    ]
+    RUNNERS = runners.all_launch + runners.all_attach_by_socket,
+else:
+    TARGETS = [targets.Program]
+    RUNNERS = [runners.launch]
 
 
 @pytest.fixture(params=TARGETS)

--- a/tests/watchdog/worker.py
+++ b/tests/watchdog/worker.py
@@ -151,16 +151,6 @@ def main(tests_pid):
                 proc.pid,
             )
 
-            # if platform.system() == "Linux":
-            #     try:
-            #         # gcore will automatically add pid to the filename
-            #         core_file = os.path.join(tempfile.gettempdir(), "ptvsd_core")
-            #         gcore_cmd = fmt("gcore -o {0} {1}", core_file, proc.pid)
-            #         log.warning("WatchDog-{0}: {1}", tests_pid, gcore_cmd)
-            #         os.system(gcore_cmd)
-            #     except Exception:
-            #         log.exception()
-
             try:
                 proc.kill()
             except psutil.NoSuchProcess:


### PR DESCRIPTION
- reduce test matrix where not necessary
- switch to `sys.platform` 