### PR TITLE
Fix #1930: "launch" doesn't work with venv on Windows and Python 3.7+

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
             "consoleTitle": "ptvsd.adapter",
             "program": "${workspaceFolder}/src/ptvsd/adapter",
             "args": ["--port", "8765", "--log-stderr"],
-            "customDebugger": true,
+            "noDebug": true,
         },
 
         // For these, ptvsd.adapter must be started first via the above configuration.
@@ -27,24 +27,13 @@
             "consoleTitle": "ptvsd.server",
             //"program": "${file}",
             "program": "${workspaceFolder}/tests/test_data/testpkgs/pkg1/__main__.py",
-            //"ptvsdArgs": ["--log-stderr"],
         },
         {
-            //"debugServer": 8765,
             "name": "Attach [debugServer]",
             "type": "python",
             "request": "attach",
             "host": "localhost",
             "port": 5678,
-        },
-        {
-            //"debugServer": 8765,
-            "name": "Attach Child Process [debugServer]",
-            "type": "python",
-            "request": "attach",
-            "host": "localhost",
-            "port": 5678,
-            "subProcessId": 00000,
         },
     ]
 }

--- a/src/ptvsd/common/sockets.py
+++ b/src/ptvsd/common/sockets.py
@@ -64,17 +64,20 @@ class ClientConnection(object):
     """
 
     @classmethod
-    def listen(cls, host=None, port=0, timeout=None):
+    def listen(cls, host=None, port=0, timeout=None, name=None):
         """Accepts TCP connections on the specified host and port, and creates a new
         instance of this class wrapping every accepted socket.
         """
+
+        if name is None:
+            name = cls.__name__
 
         assert cls.listener is None
         cls.listener = create_server(host, port, timeout)
         host, port = cls.listener.getsockname()
         log.info(
             "Waiting for incoming {0} connections on {1}:{2}...",
-            cls.__name__,
+            name,
             host,
             port,
         )
@@ -89,7 +92,7 @@ class ClientConnection(object):
 
                 log.info(
                     "Accepted incoming {0} connection from {1}:{2}.",
-                    cls.__name__,
+                    name,
                     other_host,
                     other_port,
                 )


### PR DESCRIPTION
For "launch", match processes on parent PID as a fallback for PID, to accommodate launcher stubs like py.exe.