### PR TITLE
Fix #1944: Debugging fails with timeout when using conda run

### DIFF
--- a/src/ptvsd/adapter/ide.py
+++ b/src/ptvsd/adapter/ide.py
@@ -228,6 +228,9 @@ class IDE(components.Component, sockets.ClientConnection):
     def launch_request(self, request):
         from ptvsd.adapter import launchers
 
+        if self.session.id != 1 or len(servers.connections()):
+            raise request.cant_handle('"attach" expected')
+
         sudo = request("sudo", json.default("Sudo" in self.session.debug_options))
         if sudo:
             if sys.platform == "win32":

--- a/src/ptvsd/adapter/launchers.py
+++ b/src/ptvsd/adapter/launchers.py
@@ -123,14 +123,9 @@ def spawn_debuggee(session, start_request, sudo, args, console, console_title):
                 session.launcher,
             )
 
-        # Python can be started via a stub - e.g. py.exe on Windows, which doubles
-        # as python.exe in virtual environments. In this case, the PID of the process
-        # that connects to us won't match the PID of the process that we spawned, but
-        # will have the latter as its parent.
-        pid = session.launcher.pid
-        conn = servers.wait_for_connection(
-            session, (lambda conn: pid in (conn.pid, conn.ppid)), timeout=10
-        )
+        # Wait for the first incoming connection regardless of the PID - it won't
+        # necessarily match due to the use of stubs like py.exe or "conda run".
+        conn = servers.wait_for_connection(session, lambda conn: True, timeout=10)
         if conn is None:
             raise start_request.cant_handle(
                 "{0} timed out waiting for debuggee to spawn", session


### PR DESCRIPTION
Do not validate PID of the debuggee when debug server connects while handling "launch".

Restrict "launch" to the first session with no server connections.