### PR TITLE
Fix #1950: Nonsensical error message for type errors in launch.json

### DIFF
--- a/src/ptvsd/common/json.py
+++ b/src/ptvsd/common/json.py
@@ -225,7 +225,7 @@ def array(validate_item=False, vectorize=False, size=None):
             try:
                 value[i] = validate_item(item)
             except (TypeError, ValueError) as exc:
-                raise type(exc)("[{0!j}] {1}".format(i, exc))
+                raise type(exc)(fmt("[{0!j}] {1}", i, exc))
         return value
 
     return validate
@@ -259,7 +259,15 @@ def object(validate_value=False):
                 try:
                     value[k] = validate_value(v)
                 except (TypeError, ValueError) as exc:
-                    raise type(exc)("[{0!j}] {1}".format(k, exc))
+                    raise type(exc)(fmt("[{0!j}] {1}", k, exc))
         return value
 
     return validate
+
+
+# A helper to resolve the circular dependency between common.fmt and common.json
+# on Python 2.
+def fmt(*args, **kwargs):
+    from ptvsd.common import fmt
+
+    return fmt(*args, **kwargs)

--- a/src/ptvsd/common/messaging.py
+++ b/src/ptvsd/common/messaging.py
@@ -413,7 +413,10 @@ class MessageDict(collections.OrderedDict):
             value = validate(value)
         except (TypeError, ValueError) as exc:
             message = Message if self.message is None else self.message
-            raise message.isnt_valid("{0!r} {1}", key, exc)
+            err = fmt("{0}", exc)
+            if not err.startswith("["):
+                err = " " + err
+            raise message.isnt_valid("{0!j}{1}", key, err)
         return value
 
     def _invalid_if_no_key(func):


### PR DESCRIPTION
Use fmt() instead of format() for validation error text.

Include description of message that was deemed invalid due to validation in the error text.