### PR TITLE
Fix #1967: attach_by_socket tests fail sporadically on MacOS

### DIFF
--- a/src/ptvsd/adapter/sessions.py
+++ b/src/ptvsd/adapter/sessions.py
@@ -161,6 +161,7 @@ class Session(util.Observable):
 
         try:
             sock, (other_host, other_port) = listener.accept()
+            sock.setblocking(True)  # override any inherited timeout
         finally:
             listener.close()
         log.info(

--- a/src/ptvsd/common/sockets.py
+++ b/src/ptvsd/common/sockets.py
@@ -86,6 +86,7 @@ class ClientConnection(object):
             while True:
                 try:
                     sock, (other_host, other_port) = cls.listener.accept()
+                    sock.setblocking(True)  # override any inherited timeout
                 except OSError:
                     # Listener socket has been closed.
                     break

--- a/tests/debug/comms.py
+++ b/tests/debug/comms.py
@@ -43,6 +43,7 @@ class BackChannel(object):
 
             try:
                 sock, _ = server_socket.accept()
+                sock.setblocking(True)  # override any inherited timeout
             except socket.timeout:
                 if self._server_socket is None:
                     return


### PR DESCRIPTION
Override inherited timeouts for sockets returned by accept() to ensure that they're blocking.