### PR TITLE
Fix #2008 and other error reporting issues

### DIFF
--- a/src/ptvsd/adapter/launchers.py
+++ b/src/ptvsd/adapter/launchers.py
@@ -66,7 +66,7 @@ def spawn_debuggee(session, start_request, sudo, args, console, console_title):
             if log.log_dir is not None:
                 env[str("PTVSD_LOG_DIR")] = compat.filename_str(log.log_dir)
             if log.stderr.levels != {"warning", "error"}:
-                env[str("PTVSD_LOG_STDERR")] = " ".join(log.log_stderr)
+                env[str("PTVSD_LOG_STDERR")] = " ".join(log.stderr.levels)
 
             if console == "internalConsole":
                 log.info("{0} spawning launcher: {1!r}", session, cmdline)

--- a/src/ptvsd/adapter/launchers.py
+++ b/src/ptvsd/adapter/launchers.py
@@ -66,7 +66,7 @@ def spawn_debuggee(session, start_request, sudo, args, console, console_title):
             if log.log_dir is not None:
                 env[str("PTVSD_LOG_DIR")] = compat.filename_str(log.log_dir)
             if log.stderr.levels != {"warning", "error"}:
-                env[str("PTVSD_LOG_STDERR")] = " ".join(log.stderr.levels)
+                env[str("PTVSD_LOG_STDERR")] = str(" ".join(log.stderr.levels))
 
             if console == "internalConsole":
                 log.info("{0} spawning launcher: {1!r}", session, cmdline)

--- a/src/ptvsd/adapter/servers.py
+++ b/src/ptvsd/adapter/servers.py
@@ -443,7 +443,9 @@ def inject(pid, ptvsd_args):
     except Exception as exc:
         log.exception("Failed to inject debug server into process with PID={0}", pid)
         raise messaging.MessageHandlingError(
-            "Failed to inject debug server into process with PID={0}: {1}", pid, exc
+            fmt(
+                "Failed to inject debug server into process with PID={0}: {1}", pid, exc
+            )
         )
 
     # We need to capture the output of the injector - otherwise it can get blocked

--- a/src/ptvsd/launcher/debuggee.py
+++ b/src/ptvsd/launcher/debuggee.py
@@ -58,8 +58,8 @@ def spawn(process_name, cmdline, cwd, env, redirect_output):
             global process
             process = subprocess.Popen(cmdline, cwd=cwd, env=env, bufsize=0, **kwargs)
         except Exception as exc:
-            raise messaging.Message.cant_handle(
-                "Couldn't spawn debuggee: {0}\n\nCommand line:{1!r}", exc, cmdline
+            raise messaging.MessageHandlingError(
+                fmt("Couldn't spawn debuggee: {0}\n\nCommand line:{1!r}", exc, cmdline)
             )
 
         log.info("Spawned {0}.", describe())


### PR DESCRIPTION
This also fixes the error "unbound method ...", as seen in e.g. #1978, that could occur while reporting errors during launch, and another one when reporting error to inject debugger for attach-by-PID.