### PR TITLE
tox.ini: Add Python 3.8 and remove 3.4 and 3.5

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37}{,-cov}
+envlist = py{27,36,37,38}{,-cov}
 
 [testenv]
 deps = -rtests/requirements.txt


### PR DESCRIPTION
https://devguide.python.org/#status-of-python-branches
https://devguide.python.org/devcycle/#end-of-life-branches  # Python 3.5 EOLs in one month.